### PR TITLE
melpomene: make `tracing` feature flags additive

### DIFF
--- a/source/melpomene/src/sim_tracing.rs
+++ b/source/melpomene/src/sim_tracing.rs
@@ -1,9 +1,21 @@
-#[cfg(feature = "trace-fmt")]
-pub fn setup_tracing() {
-    tracing_subscriber::fmt::init();
-}
+const ENV_FILTER: &str = "MELPOMENE_TRACE";
 
-#[cfg(feature = "trace-modality")]
 pub fn setup_tracing() {
-    tracing_modality::TracingModality::init().expect("init");
+    use tracing_subscriber::prelude::*;
+
+    let subscriber = tracing_subscriber::registry();
+
+    // if `trace-fmt` is enabled, add a `tracing-subscriber::fmt` layer along
+    // with an `EnvFilter`
+    #[cfg(feature = "trace-fmt")]
+    let subscriber = {
+        let filter = tracing_subscriber::EnvFilter::from_env(ENV_FILTER);
+        subscriber.with(tracing_subscriber::fmt::layer().with_filter(filter))
+    };
+
+    // if `trace-modality` is enabled, add the Modality layer as well.
+    #[cfg(feature = "trace-modality")]
+    let subscriber = subscriber.with(tracing_modality::ModalityLayer::new());
+
+    subscriber.init();
 }


### PR DESCRIPTION
Currently, the `tracing` behavior in Melpomene is controlled by a pair
of feature flags, "trace-modality" and "trace-fmt". These select between
emitting traces to stdout using `tracing_subscriber::fmt`, and emitting
to Modality using the `tracing-modality` crate. However, these feature
flags are not additive. If they are both enabled, the code will not
compile, since there are two implementations of the `setup_tracing`
function, which are conditionally compiled based on whether those
feature flags are enabled. If both are enabled, both functions will be
present, resulting in a compiler error.

This commit changes this code so that there is a single implementation
of the `setup_tracing` function, which will construct a `tracing`
subscriber that includes either `fmt`, Modality, or _both_, depending on
the feature combination. Now, Melpomene should build even with
`--all-features` or similar.

Now that the `fmt` layer is built manually rather than using
`fmt::init()` "easy mode" helper, I've also changed the filter
environment variable from "RUST_LOG" to "MELPOMENE_TRACE". I thought
this was nicer, but we can continue using the default env var if that's
preferable.