### PR TITLE
melpomene: tracing improvements

### DIFF
--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -36,6 +36,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +444,7 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 name = "melpomene"
 version = "0.1.0"
 dependencies = [
+ "atty",
  "mnemos",
  "mnemos-abi",
  "mnemos-std",

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -78,11 +78,9 @@ impl Kernel {
     const INIT_IDLE: usize = 2;
     const INIT_LOCK: usize = 3;
 
-    pub unsafe fn new(
-        settings: KernelSettings,
-    ) -> Result<HeapBox<Self>, ()> {
+    pub unsafe fn new(settings: KernelSettings) -> Result<HeapBox<Self>, ()> {
         info!(
-            start = settings.heap_start as usize,
+            start = ?settings.heap_start,
             size = settings.heap_size,
             "Initializing heap"
         );

--- a/source/melpomene/Cargo.toml
+++ b/source/melpomene/Cargo.toml
@@ -30,8 +30,12 @@ path = "../mstd"
 version = "0.7.3"
 default-features = false
 
+[dependencies.atty]
+version = "0.2"
+optional = true
+
 [features]
-trace-fmt = ["tracing-subscriber"]
+trace-fmt = ["tracing-subscriber", "atty"]
 # Note, the "trace-modality" feature requires the use of the Auxon modality tool.
 # More information: https://auxon.io/products/modality
 trace-modality = ["tracing-modality"]

--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -1,31 +1,34 @@
 use std::{
-    sync::atomic::{Ordering, AtomicBool},
-    thread::{spawn, yield_now, sleep},
-    time::{Duration, Instant},
     future::Future,
+    sync::atomic::{AtomicBool, Ordering},
     task::Poll,
+    thread::{sleep, spawn, yield_now},
+    time::{Duration, Instant},
 };
 
 use abi::{bbqueue_ipc::BBBuffer, syscall::DriverKind};
-use mnemos_kernel::{Kernel, KernelSettings, DriverHandle, KChannel};
 use melpomene::sim_tracing::setup_tracing;
+use mnemos_kernel::{DriverHandle, KChannel, Kernel, KernelSettings};
 
 const HEAP_SIZE: usize = 192 * 1024;
 static KERNEL_LOCK: AtomicBool = AtomicBool::new(true);
 
 fn main() {
     setup_tracing();
+    let _span = tracing::info_span!("Melpo").entered();
 
     println!("========================================");
     let kernel = spawn(move || {
         kernel_entry();
     });
-    println!("[Melpo]: Kernel started.");
+    tracing::info!("Kernel started.");
 
     // Wait for the kernel to complete initialization...
     while KERNEL_LOCK.load(Ordering::Acquire) {
         yield_now();
     }
+
+    tracing::debug!("Kernel initialized.");
 
     // let userspace = spawn(move || {
     //     userspace_entry();
@@ -40,14 +43,14 @@ fn main() {
 
     let kj = kernel.join();
     sleep(Duration::from_millis(50));
-    println!("[Melpo]: Kernel ended:    {:?}", kj);
-
+    tracing::info!("Kernel ended:    {:?}", kj);
 
     println!("========================================");
 
-    println!("[Melpo]: You've met with a terrible fate, haven't you?");
+    tracing::error!("You've met with a terrible fate, haven't you?");
 }
 
+#[tracing::instrument(name = "Kernel", level = "info")]
 fn kernel_entry() {
     // First, we'll do some stuff that later the linker script will do...
     let kernel_heap = Box::into_raw(Box::new([0u8; HEAP_SIZE]));
@@ -72,7 +75,9 @@ fn kernel_entry() {
         k.register_driver(DriverHandle {
             kind: DriverKind::Todo,
             queue: dummy_chan.clone(),
-        }).map_err(drop).unwrap();
+        })
+        .map_err(drop)
+        .unwrap();
 
         let dummy_fut = async move {
             let _ = dummy_chan;
@@ -86,7 +91,6 @@ fn kernel_entry() {
         let boxed_dummy = guard.alloc_box(dummy_task).map_err(drop).unwrap();
         k.spawn_allocated(boxed_dummy);
     }
-
 
     //////////////////////////////////////////////////////////////////////////////
     // TODO: Userspace doesn't really do anything yet! Simulate initialization of
@@ -104,6 +108,7 @@ fn kernel_entry() {
     }
 
     let _userspace = spawn(|| {
+        let _span = tracing::info_span!("userspace").entered();
         loop {
             while KERNEL_LOCK.load(Ordering::Acquire) {
                 sleep(Duration::from_millis(10));
@@ -113,7 +118,6 @@ fn kernel_entry() {
             KERNEL_LOCK.store(true, Ordering::Release);
         }
     });
-
 
     loop {
         while !KERNEL_LOCK.load(Ordering::Acquire) {
@@ -157,8 +161,6 @@ fn kernel_entry() {
 //         k2u,
 //     };
 //     mstd::executor::mailbox::MAILBOX.set_rings(rings);
-
-
 
 //     let start = Instant::now();
 //     loop {
@@ -215,7 +217,10 @@ impl Sleepy {
 impl Future for Sleepy {
     type Output = ();
 
-    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
         cx.waker().wake_by_ref();
         if self.start.elapsed() < self.dur {
             Poll::Pending

--- a/source/melpomene/src/sim_tracing.rs
+++ b/source/melpomene/src/sim_tracing.rs
@@ -1,9 +1,21 @@
-#[cfg(feature = "trace-fmt")]
-pub fn setup_tracing() {
-    tracing_subscriber::fmt::init();
-}
+const ENV_FILTER: &str = "MELPOMENE_TRACE";
 
-#[cfg(feature = "trace-modality")]
 pub fn setup_tracing() {
-    tracing_modality::TracingModality::init().expect("init");
+    use tracing_subscriber::prelude::*;
+
+    let subscriber = tracing_subscriber::registry();
+
+    // if `trace-fmt` is enabled, add a `tracing-subscriber::fmt` layer along
+    // with an `EnvFilter`
+    #[cfg(feature = "trace-fmt")]
+    let subscriber = {
+        let filter = tracing_subscriber::EnvFilter::from_env(ENV_FILTER);
+        subscriber.with(tracing_subscriber::fmt::layer().with_filter(filter))
+    };
+
+    // if `trace-modality` is enabled, add the Modality layer as well.
+    #[cfg(feature = "trace-modality")]
+    let subscriber = subscriber.with(tracing_modality::ModalityLayer::new());
+
+    subscriber.init();
 }

--- a/source/melpomene/src/sim_tracing.rs
+++ b/source/melpomene/src/sim_tracing.rs
@@ -9,8 +9,18 @@ pub fn setup_tracing() {
     // with an `EnvFilter`
     #[cfg(feature = "trace-fmt")]
     let subscriber = {
-        let filter = tracing_subscriber::EnvFilter::from_env(ENV_FILTER);
-        subscriber.with(tracing_subscriber::fmt::layer().with_filter(filter))
+        use tracing_subscriber::{filter, fmt};
+
+        let filter = filter::EnvFilter::builder()
+            .with_default_directive(filter::LevelFilter::INFO.into())
+            .with_env_var(ENV_FILTER)
+            .from_env_lossy();
+
+        let fmt = fmt::layer()
+            .with_timer(fmt::time::uptime())
+            .with_ansi(atty::is(atty::Stream::Stdout))
+            .with_filter(filter);
+        subscriber.with(fmt)
     };
 
     // if `trace-modality` is enabled, add the Modality layer as well.


### PR DESCRIPTION
(This includes changes from #1 because that PR was opened from a fork
and I can't nicely stack PRs when one branch is on a fork)

This branch makes several small improvements to `tracing` in Melpomene:

 * melpomene: make `tracing` feature flags additive
 
   Currently, the `tracing` behavior in Melpomene is controlled by a
   pair of feature flags, "trace-modality" and "trace-fmt". These select
   between emitting traces to stdout using `tracing_subscriber::fmt`,
   and emitting to Modality using the `tracing-modality` crate. However,
   these feature flags are not additive. If they are both enabled, the
   code will not compile, since there are two implementations of the
   `setup_tracing` function, which are conditionally compiled based on
   whether those feature flags are enabled. If both are enabled, both
   functions will be present, resulting in a compiler error.
   
   This commit changes this code so that there is a single
   implementation of the `setup_tracing` function, which will construct
   a `tracing` subscriber that includes either `fmt`, Modality, or
   _both_, depending on the feature combination. Now, Melpomene should
   build even with `--all-features` or similar.
   
   Now that the `fmt` layer is built manually rather than using
   `fmt::init()` "easy mode" helper, I've also changed the filter
   environment variable from "RUST_LOG" to "MELPOMENE_TRACE". I thought
   this was nicer, but we can continue using the default env var if
   that's preferable.

 * melpomene: minor improvements to tracing configuration
 
 * melpomene: add some spans to the kernel/userspace threads
 
 * kernel: change the "initialized heap" event to format the addr in hex

Closes #1