### PR TITLE
fix a whole bunch of annoying clippy lints

### DIFF
--- a/source/abi/src/bbqueue_ipc/bbbuffer.rs
+++ b/source/abi/src/bbqueue_ipc/bbbuffer.rs
@@ -377,25 +377,23 @@ impl<'a> Producer<'a> {
                 inner.write_in_progress.store(false, Release);
                 return Err(Error::InsufficientSize);
             }
+        } else if write != max {
+            // Some (or all) room remaining in un-inverted case
+            sz = min(max - write, sz);
+            write
         } else {
-            if write != max {
-                // Some (or all) room remaining in un-inverted case
-                sz = min(max - write, sz);
-                write
-            } else {
-                // Not inverted, but need to go inverted
+            // Not inverted, but need to go inverted
 
-                // NOTE: We check read > 1, NOT read >= 1, because
-                // write must never == read in an inverted condition, since
-                // we will then not be able to tell if we are inverted or not
-                if read > 1 {
-                    sz = min(read - 1, sz);
-                    0
-                } else {
-                    // Not invertible, no space
-                    inner.write_in_progress.store(false, Release);
-                    return Err(Error::InsufficientSize);
-                }
+            // NOTE: We check read > 1, NOT read >= 1, because
+            // write must never == read in an inverted condition, since
+            // we will then not be able to tell if we are inverted or not
+            if read > 1 {
+                sz = min(read - 1, sz);
+                0
+            } else {
+                // Not invertible, no space
+                inner.write_in_progress.store(false, Release);
+                return Err(Error::InsufficientSize);
             }
         };
 

--- a/source/abi/src/bbqueue_ipc/bbbuffer.rs
+++ b/source/abi/src/bbqueue_ipc/bbbuffer.rs
@@ -304,8 +304,7 @@ impl<'a> Producer<'a> {
         // This is sound, as UnsafeCell, MaybeUninit, and GenericArray
         // are all `#[repr(Transparent)]
         let start_of_buf_ptr = inner.buf.load(Relaxed);
-        let grant_slice =
-            unsafe { from_raw_parts_mut(start_of_buf_ptr.offset(start as isize), sz) };
+        let grant_slice = unsafe { from_raw_parts_mut(start_of_buf_ptr.add(start), sz) };
 
         Ok(GrantW {
             buf: grant_slice,
@@ -409,8 +408,7 @@ impl<'a> Producer<'a> {
         // This is sound, as UnsafeCell, MaybeUninit, and GenericArray
         // are all `#[repr(Transparent)]
         let start_of_buf_ptr = inner.buf.load(Relaxed);
-        let grant_slice =
-            unsafe { from_raw_parts_mut(start_of_buf_ptr.offset(start as isize), sz) };
+        let grant_slice = unsafe { from_raw_parts_mut(start_of_buf_ptr.add(start), sz) };
 
         Ok(GrantW {
             buf: grant_slice,
@@ -501,7 +499,7 @@ impl<'a> Consumer<'a> {
         // This is sound, as UnsafeCell, MaybeUninit, and GenericArray
         // are all `#[repr(Transparent)]
         let start_of_buf_ptr = inner.buf.load(Relaxed);
-        let grant_slice = unsafe { from_raw_parts_mut(start_of_buf_ptr.offset(read as isize), sz) };
+        let grant_slice = unsafe { from_raw_parts_mut(start_of_buf_ptr.add(read), sz) };
 
         Ok(GrantR {
             buf: grant_slice,
@@ -552,8 +550,7 @@ impl<'a> Consumer<'a> {
         }
 
         let start_of_buf_ptr = inner.buf.load(Relaxed);
-        let grant_slice1 =
-            unsafe { from_raw_parts_mut(start_of_buf_ptr.offset(read as isize), sz1) };
+        let grant_slice1 = unsafe { from_raw_parts_mut(start_of_buf_ptr.add(read), sz1) };
         let grant_slice2 = unsafe { from_raw_parts_mut(start_of_buf_ptr, sz2) };
 
         Ok(SplitGrantR {

--- a/source/abi/src/bbqueue_ipc/bbbuffer.rs
+++ b/source/abi/src/bbqueue_ipc/bbbuffer.rs
@@ -277,27 +277,24 @@ impl<'a> Producer<'a> {
                 inner.write_in_progress.store(false, Release);
                 return Err(Error::InsufficientSize);
             }
+        } else if write + sz <= max {
+            // Non inverted condition
+            write
         } else {
-            if write + sz <= max {
-                // Non inverted condition
-                write
-            } else {
-                // Not inverted, but need to go inverted
+            // Not inverted, but need to go inverted
 
-                // NOTE: We check sz < read, NOT <=, because
-                // write must never == read in an inverted condition, since
-                // we will then not be able to tell if we are inverted or not
-                if sz < read {
-                    // Invertible situation
-                    0
-                } else {
-                    // Not invertible, no space
-                    inner.write_in_progress.store(false, Release);
-                    return Err(Error::InsufficientSize);
-                }
+            // NOTE: We check sz < read, NOT <=, because
+            // write must never == read in an inverted condition, since
+            // we will then not be able to tell if we are inverted or not
+            if sz < read {
+                // Invertible situation
+                0
+            } else {
+                // Not invertible, no space
+                inner.write_in_progress.store(false, Release);
+                return Err(Error::InsufficientSize);
             }
         };
-
         // Safe write, only viewed by this task
         inner.reserve.store(start + sz, Release);
 

--- a/source/abi/src/lib.rs
+++ b/source/abi/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(test), no_std)]
 #![doc = include_str!("../README.md")]
+#![allow(clippy::missing_safety_doc)]
 
 use bbqueue_ipc::BBBuffer;
 use core::ptr::null_mut;

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -237,7 +237,7 @@ impl Kernel {
         self.spawn_allocated(atask);
     }
 
-    pub fn spawn_allocated<F: Future + 'static>(&'static self, task: HeapBox<Task<F>>) -> () {
+    pub fn spawn_allocated<F: Future + 'static>(&'static self, task: HeapBox<Task<F>>) {
         self.inner.scheduler.spawn_allocated::<F, HBStorage>(task)
     }
 }

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -167,7 +167,7 @@ impl Kernel {
         };
 
         // TODO: for now we only support a single instance of each driver
-        if guard.drivers.iter().find(|d| d.kind == hdl.kind).is_some() {
+        if guard.drivers.iter().any(|d| d.kind == hdl.kind) {
             return Err(hdl);
         }
 

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -79,17 +79,26 @@ impl Kernel {
     const INIT_IDLE: usize = 2;
     const INIT_LOCK: usize = 3;
 
-    pub unsafe fn new(settings: KernelSettings) -> Result<HeapBox<Self>, ()> {
+    pub unsafe fn new(settings: KernelSettings) -> Result<HeapBox<Self>, &'static str> {
         info!(
             start = ?settings.heap_start,
             size = settings.heap_size,
             "Initializing heap"
         );
-        let (nn_heap, mut guard) = AHeap::bootstrap(settings.heap_start, settings.heap_size)?;
+        let (nn_heap, mut guard) = AHeap::bootstrap(settings.heap_start, settings.heap_size)
+            .map_err(|_| "failed to initialize heap")?;
 
-        let drivers = guard.alloc_fixed_vec(settings.max_drivers)?;
-        let (nn_u2k_buf, u2k_len) = guard.alloc_box_array_with(|| 0, settings.u2k_size)?.leak();
-        let (nn_k2u_buf, k2u_len) = guard.alloc_box_array_with(|| 0, settings.k2u_size)?.leak();
+        let drivers = guard
+            .alloc_fixed_vec(settings.max_drivers)
+            .map_err(|_| "failed to allocate driver vec")?;
+        let (nn_u2k_buf, u2k_len) = guard
+            .alloc_box_array_with(|| 0, settings.u2k_size)
+            .map_err(|_| "failed to allocate u2k ring buf")?
+            .leak();
+        let (nn_k2u_buf, k2u_len) = guard
+            .alloc_box_array_with(|| 0, settings.k2u_size)
+            .map_err(|_| "failed to allocate k2u ring buf")?
+            .leak();
         let u2k_ring = BBBuffer::new();
         let k2u_ring = BBBuffer::new();
 
@@ -106,7 +115,7 @@ impl Kernel {
         // Safety: We only use the static stub once
         let stub: &'static TaskStub = guard
             .alloc_box(TaskStub::new())
-            .map_err(drop)?
+            .map_err(|_| "failed to allocate task stub")?
             .leak()
             .as_ref();
         let scheduler = StaticScheduler::new_with_static_stub(stub);
@@ -126,7 +135,7 @@ impl Kernel {
                 inner_mut: UnsafeCell::new(inner_mut),
                 heap: nn_heap,
             })
-            .map_err(drop)?;
+            .map_err(|_| "failed to allocate new kernel box")?;
 
         new_kernel.status.store(Self::INIT_IDLE, Ordering::SeqCst);
 

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![allow(clippy::missing_safety_doc)]
 
 pub mod bbq;
 

--- a/source/mstd/src/executor/mod.rs
+++ b/source/mstd/src/executor/mod.rs
@@ -88,7 +88,7 @@ impl Terpsichore {
         self.spawn_allocated(atask);
     }
 
-    pub fn spawn_allocated<F: Future + 'static>(&'static self, task: HeapBox<Task<F>>) -> () {
+    pub fn spawn_allocated<F: Future + 'static>(&'static self, task: HeapBox<Task<F>>) {
         self.scheduler.spawn_allocated::<F, HBStorage>(task)
     }
 }

--- a/source/spitebuf/src/lib.rs
+++ b/source/spitebuf/src/lib.rs
@@ -143,7 +143,7 @@ unsafe fn dequeue<T>(buffer: *mut Cell<T>, dequeue_pos: &AtomicUsize, mask: usiz
 
     let mut cell;
     loop {
-        cell = buffer.add(usize::from(pos & mask));
+        cell = buffer.add(pos & mask);
         let seq = (*cell).sequence.load(Ordering::Acquire);
         let dif = (seq as i8).wrapping_sub((pos.wrapping_add(1)) as i8);
 
@@ -183,7 +183,7 @@ unsafe fn enqueue<T>(
 
     let mut cell;
     loop {
-        cell = buffer.add(usize::from(pos & mask));
+        cell = buffer.add(pos & mask);
         let seq = (*cell).sequence.load(Ordering::Acquire);
         let dif = (seq as i8).wrapping_sub(pos as i8);
 

--- a/source/spitebuf/src/lib.rs
+++ b/source/spitebuf/src/lib.rs
@@ -105,7 +105,7 @@ unsafe impl<T, STO: Storage<T>> Sync for MpMcQueue<T, STO> where T: Send {}
 
 impl<T, STO: Storage<T>> Drop for MpMcQueue<T, STO> {
     fn drop(&mut self) {
-        while let Some(_) = self.dequeue_sync() {}
+        while self.dequeue_sync().is_some() {}
         self.cons_wait.close();
         self.prod_wait.close();
     }

--- a/source/spitebuf/src/lib.rs
+++ b/source/spitebuf/src/lib.rs
@@ -10,6 +10,8 @@
 //!
 //! [0]: http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
 
+#![allow(clippy::missing_safety_doc)]
+
 use core::{
     cell::UnsafeCell,
     mem::MaybeUninit,


### PR DESCRIPTION
I have clippy enabled by default in VS Code, and it currently complains
about a bunch of stuff...most of which is just kind of annoying
pedantry. This branch fixes all those lints; in some cases, this
actually does make the code somewhat nicer (IMO), but mostly it makes
the warnings in my VS Code "problems" window go away.

I've applied the fix for each lint in a separate commit. If there are
any of these changes we would prefer not to apply, the individual commit
can be backed out and replaced with an `#[allow(...)]` attribute or
whatever, as appropriate.

Hope this isn't too annoying of a change...I can also just turn off clippy for
this repo, or learn to live with the warnings.