### PR TITLE
melpo: use Tokio to run simulator services (sleeps)

### DIFF
--- a/source/Cargo.lock
+++ b/source/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "mnemos-abi",
  "mnemos-std",
  "postcard",
+ "tokio",
  "tracing 0.1.35",
  "tracing-modality",
  "tracing-subscriber",

--- a/source/melpomene/Cargo.toml
+++ b/source/melpomene/Cargo.toml
@@ -3,7 +3,12 @@ name = "melpomene"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# See more keys and their definitions at
+# https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies.tokio]
+version = "1.19"
+features = ["rt", "time", "macros"]
 
 [dependencies.tracing]
 version = "0.1.35"

--- a/source/melpomene/Cargo.toml
+++ b/source/melpomene/Cargo.toml
@@ -3,8 +3,7 @@ name = "melpomene"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at
-# https://doc.rust-lang.org/cargo/reference/manifest.html
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.tokio]
 version = "1.19"

--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -25,13 +25,13 @@ use tracing::Instrument;
 const HEAP_SIZE: usize = 192 * 1024;
 static KERNEL_LOCK: AtomicBool = AtomicBool::new(true);
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() {
+fn main() {
     setup_tracing();
-    run_melpomene().await
+    let _span = tracing::info_span!("Melpo").entered();
+    run_melpomene();
 }
 
-#[tracing::instrument(name = "Melpo", level = "info")]
+#[tokio::main(flavor = "current_thread")]
 async fn run_melpomene() {
     println!("========================================");
     let kernel = task::spawn_blocking(move || {

--- a/source/melpomene/src/sim_drivers/delay.rs
+++ b/source/melpomene/src/sim_drivers/delay.rs
@@ -9,7 +9,6 @@ use tokio::{task, time};
 struct DelayInner {
     done: bool,
     waker: Option<Waker>,
-
 }
 
 pub struct Delay {


### PR DESCRIPTION
This builds on PR #5, but instead of spawning a separate OS thread for
every `Sleepy` future, we instead change the simulator to run in a
single-threaded Tokio runtime, with each sleep driven by a task spawned
on that runtime. This way, we only need a single thread to drive all of
the simulator services.

In the future, we can also use the same runtime to drive any simulator
services that use I/O (e.g. implementing a simulated serial port using a
host TCP socket). We may also want to use Tokio synchronization
primitives to block the simulator rt on kernel initialization, instead
of the current spin loop, but I'll address that in a separate PR.