### PR TITLE
Use deref to take the underlying bbqueue addr for tracing

### DIFF
--- a/source/kernel/src/bbq.rs
+++ b/source/kernel/src/bbq.rs
@@ -207,7 +207,7 @@ impl BBQBidiHandle {
         name = "BBQueue::send_grant_max",
         level = "trace",
         skip(self),
-        fields(queue = ?fmt::ptr(&self.storage), side = ?self.side),
+        fields(queue = ?fmt::ptr(self.storage.deref()), side = ?self.side),
     )]
     pub async fn send_grant_max(&self, max: usize) -> GrantW {
         loop {
@@ -243,7 +243,7 @@ impl BBQBidiHandle {
         name = "BBQueue::send_grant_exact",
         level = "trace",
         skip(self),
-        fields(queue = ?fmt::ptr(&self.storage), side = ?self.side),
+        fields(queue = ?fmt::ptr(self.storage.deref()), side = ?self.side),
     )]
     pub async fn send_grant_exact(&self, size: usize) -> GrantW {
         loop {
@@ -278,7 +278,7 @@ impl BBQBidiHandle {
         name = "BBQueue::read_grant",
         level = "trace",
         skip(self),
-        fields(queue = ?fmt::ptr(&self.storage), side = ?self.side),
+        fields(queue = ?fmt::ptr(self.storage.deref()), side = ?self.side),
     )]
     pub async fn read_grant(&self) -> GrantR {
         loop {


### PR DESCRIPTION
Have tracing report the address of the underlying storage (rather than the address of the Arc itself) so that it is easier to see related comms in traces.

Before:

```
  10.670354843s TRACE Kernel:Driver B:BBQueue::read_grant{queue=0x7f7758014548 side=BSide}: kernel::bbq: awaiting bbqueue read grant
  11.168783665s  WARN Kernel:Driver A: melpomene: Driver A: Reading...
  11.170023311s TRACE Kernel:Driver A:BBQueue::read_grant{queue=0x7f77580139a0 side=ASide}: kernel::bbq: Got bbqueue read grant size=4
  11.170525095s  WARN Kernel:Driver A: melpomene: Driver A: Got data buf=[245, 245, 245, 245]
```

After

```
  2.079232514s TRACE Kernel:Driver A:BBQueue::send_grant_exact{size=8 queue=0x7f08a8014700 side=ASide}: kernel::bbq: Got bbqueue exact write grant
  2.079650683s  INFO Kernel:Driver A: melpomene: Driver A: Sleeping...
  2.080172776s  WARN Kernel:Driver B: melpomene: Driver B: Reading...
  2.080742401s TRACE Kernel:Driver B:BBQueue::read_grant{queue=0x7f08a8014700 side=BSide}: kernel::bbq: Got bbqueue read grant size=8
  2.081164016s  WARN Kernel:Driver B: melpomene: Driver B: Got data buf=[1, 1, 1, 1, 1, 1, 1, 1]
  2.081413875s  INFO Kernel:Driver B: melpomene: Driver B: Writing...
```