### PR TITLE
Add a simple TCP loopback

### DIFF
--- a/source/kernel/src/bbq.rs
+++ b/source/kernel/src/bbq.rs
@@ -200,9 +200,8 @@ impl GrantR {
     }
 }
 
+// async methods
 impl BBQBidiHandle {
-    // async fn send_grant(buf_len: usize) -> GrantW
-    // async fn read_grant() -> GrantR
     #[tracing::instrument(
         name = "BBQueue::send_grant_max",
         level = "trace",
@@ -306,5 +305,44 @@ impl BBQBidiHandle {
                 }
             }
         }
+    }
+}
+
+// sync methods
+impl BBQBidiHandle {
+    #[tracing::instrument(
+        name = "BBQueue::send_grant_max",
+        level = "trace",
+        skip(self),
+        fields(queue = ?fmt::ptr(&self.storage), side = ?self.side),
+    )]
+    pub fn send_grant_max_sync(&self, max: usize) -> Option<GrantW> {
+        self.producer.grant_max_remaining(max).ok().map(|wgr| {
+            GrantW { grant: wgr, storage: self.storage.clone(), side: self.side }
+        })
+    }
+
+    #[tracing::instrument(
+        name = "BBQueue::send_grant_exact",
+        level = "trace",
+        skip(self),
+        fields(queue = ?fmt::ptr(&self.storage), side = ?self.side),
+    )]
+    pub fn send_grant_exact_sync(&self, size: usize) -> Option<GrantW> {
+        self.producer.grant_exact(size).ok().map(|wgr| {
+            GrantW { grant: wgr, storage: self.storage.clone(), side: self.side }
+        })
+    }
+
+    #[tracing::instrument(
+        name = "BBQueue::read_grant",
+        level = "trace",
+        skip(self),
+        fields(queue = ?fmt::ptr(&self.storage), side = ?self.side),
+    )]
+    pub fn read_grant_sync(&self) -> Option<GrantR> {
+        self.consumer.read().ok().map(|rgr| {
+            GrantR { grant: rgr, storage: self.storage.clone(), side: self.side }
+        })
     }
 }

--- a/source/melpomene/src/sim_drivers.rs
+++ b/source/melpomene/src/sim_drivers.rs
@@ -1,1 +1,48 @@
+use mnemos_kernel::bbq::BBQBidiHandle;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread::{sleep, spawn};
+use std::time::Duration;
+use tracing::{trace, warn};
 
+pub fn spawn_tcp_serial(handle: BBQBidiHandle) {
+    let listener = TcpListener::bind("127.0.0.1:9999").unwrap();
+    let _ = spawn(move || {
+        let mut handle = handle;
+        for stream in listener.incoming() {
+            process_stream(&mut handle, stream.unwrap());
+        }
+    });
+}
+
+fn process_stream(handle: &mut BBQBidiHandle, mut stream: TcpStream) {
+    stream
+        .set_read_timeout(Some(Duration::from_millis(25)))
+        .unwrap();
+    loop {
+        if let Some(outmsg) = handle.read_grant_sync() {
+            trace!(len = outmsg.len(), "Got outgoing message",);
+            stream.write_all(&outmsg).unwrap();
+            let len = outmsg.len();
+            outmsg.release(len);
+        }
+
+        if let Some(mut in_grant) = handle.send_grant_max_sync(256) {
+            match stream.read(&mut in_grant) {
+                Ok(used) if used == 0 => {
+                    warn!("Empty read, socket probably closed.");
+                    return;
+                }
+                Ok(used) => {
+                    trace!(len = used, "Got incoming message",);
+                    in_grant.commit(used);
+                }
+                Err(e) if e.kind() == ErrorKind::TimedOut => {}
+                Err(e) if e.kind() == ErrorKind::WouldBlock => {}
+                Err(e) => panic!("stream: {:?}", e),
+            }
+        }
+
+        sleep(Duration::from_millis(25));
+    }
+}


### PR DESCRIPTION
Hey it's james, back with another terrible thread solution to a simulation problem.

This time, I use an OS thread to take ownership of the bidi buffer and directly feed bytes into and out of a TCP port, mapped to port 9999.

This can be opened locally with ncat to see the loopback:

```shell
stty -icanon -echo && ncat 127.0.0.1 9999
hello world!
```