### PR TITLE
chore: add Cargo alias for running Melpomene

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
+[alias]
+melpomene = "run --bin melpomene --"
+melpo = "melpomene"
+
 [build]
 # Currently needed for `tokio-console` support.
 rustflags = ["--cfg", "tokio_unstable"]


### PR DESCRIPTION
This branch adds `cargo melpomene` and `cargo melpo` aliases for running
Melpomene that are equivalent to `cargo run --bin melpomene -- <ARGS>`
but with slightly fewer characters.

This is very minor but I thought maybe nice to have.

Depends on #18