### PR TITLE
refac(melpomene): run TCP serial driver on Tokio

### DIFF
--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -95,7 +95,7 @@ fn kernel_entry() {
                 // Create the buffer, and spawn the worker task, giving it one of the
                 // queue handles
                 let (mux_ring, tcp_ring) = new_bidi_channel(k.heap(), 4096, 4096).await;
-                spawn_tcp_serial(tcp_ring);
+                spawn_tcp_serial(tcp_ring).await;
 
                 // Now, right now this is a little awkward, but what I'm doing here is spawning
                 // a new virtual mux, and configuring it with:

--- a/source/melpomene/src/sim_drivers/tcp_serial.rs
+++ b/source/melpomene/src/sim_drivers/tcp_serial.rs
@@ -1,48 +1,74 @@
 use mnemos_kernel::comms::bbq::BidiHandle;
-use std::io::{ErrorKind, Read, Write};
-use std::net::{TcpListener, TcpStream};
-use std::thread::{sleep, spawn};
-use std::time::Duration;
-use tracing::{trace, warn};
+use std::net::SocketAddr;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    time,
+};
+use tracing::{info_span, trace, warn, Instrument};
 
-pub fn spawn_tcp_serial(handle: BidiHandle) {
-    let listener = TcpListener::bind("127.0.0.1:9999").unwrap();
-    let _ = spawn(move || {
-        let mut handle = handle;
-        for stream in listener.incoming() {
-            process_stream(&mut handle, stream.unwrap());
-        }
-    });
-}
-
-fn process_stream(handle: &mut BidiHandle, mut stream: TcpStream) {
-    stream
-        .set_read_timeout(Some(Duration::from_millis(25)))
-        .unwrap();
-    loop {
-        if let Some(outmsg) = handle.consumer().read_grant_sync() {
-            trace!(len = outmsg.len(), "Got outgoing message",);
-            stream.write_all(&outmsg).unwrap();
-            let len = outmsg.len();
-            outmsg.release(len);
-        }
-
-        if let Some(mut in_grant) = handle.producer().send_grant_max_sync(256) {
-            match stream.read(&mut in_grant) {
-                Ok(used) if used == 0 => {
-                    warn!("Empty read, socket probably closed.");
-                    return;
-                }
-                Ok(used) => {
-                    trace!(len = used, "Got incoming message",);
-                    in_grant.commit(used);
-                }
-                Err(e) if e.kind() == ErrorKind::TimedOut => {}
-                Err(e) if e.kind() == ErrorKind::WouldBlock => {}
-                Err(e) => panic!("stream: {:?}", e),
+pub async fn spawn_tcp_serial(handle: BidiHandle) {
+    let ip = SocketAddr::from(([127, 0, 0, 1], 9999));
+    let listener = TcpListener::bind(ip).await.unwrap();
+    let _ = tokio::spawn(
+        async move {
+            let mut handle = handle;
+            loop {
+                match listener.accept().await {
+                    Ok((stream, addr)) => {
+                        process_stream(&mut handle, stream)
+                            .instrument(info_span!("process_stream", client.addr = %addr))
+                            .await
+                    }
+                    Err(error) => {
+                        warn!(%error,
+                            "error accepting incoming TCP connection"
+                        );
+                        return;
+                    }
+                };
             }
         }
+        .instrument(info_span!("TCP Serial", ?ip)),
+    );
+}
 
-        sleep(Duration::from_millis(25));
+async fn process_stream(handle: &mut BidiHandle, mut stream: TcpStream) {
+    const READ_TIMEOUT: time::Duration = time::Duration::from_millis(25);
+    loop {
+        // TODO(eliza): it would be nice to have separate tasks waiting for
+        // reads/writes...
+        tokio::select! {
+            outmsg = handle.consumer().read_grant() => {
+                trace!(len = outmsg.len(), "Got outgoing message",);
+                let wall = stream.write_all(&outmsg);
+                wall.await.unwrap();
+                let len = outmsg.len();
+                outmsg.release(len);
+            }
+            mut in_grant = handle.producer().send_grant_max(256) => {
+                match time::timeout(READ_TIMEOUT, stream.read(&mut in_grant)).await {
+                    Ok(Ok(used)) if used == 0 => {
+                        warn!("Empty read, socket probably closed.");
+                        return;
+                    }
+                    Ok(Ok(used)) => {
+                        trace!(len = used, "Got incoming message",);
+                        in_grant.commit(used);
+                    }
+                    // The outer error indicates a timeout; that's fine, just
+                    // nothing to read right now.
+                    Err(_) => {
+                        trace!("read timed out after {:?}", READ_TIMEOUT);
+                    }
+                    // The inner error indicates that the read actually failed.
+                    Ok(Err(error)) => {
+                        warn!(%error, "error reading from TCP stream");
+                        return;
+                    }
+                }
+
+            }
+        }
     }
 }


### PR DESCRIPTION
This branch rewrites the TCP serial port simulated driver to run in
Melpomene's Tokio runtime, rather than spawning its own thread. This
should make Melpomene a bit more efficient, since the runtime thread can
run other simulated drivers while the serial driver task is waiting for
IO, instead of doing a bunch of little sleeps.

I *think* this shouldn't result in any real behavioral change, although
I haven't tested it super extensively. If I open `crowtty` and then kill
it after a while, Melpomene still sees the TCP stream
disconnection...but I wasn't sure how I was supposed to actually start
the simulated serial port after launching `crowtty`? Any suggestions on
further testing would be appreciated! :)