### PR TITLE
feat(melpo): add a simple CLI for configuring the simulator 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "3.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +683,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,7 +956,9 @@ name = "melpomene"
 version = "0.1.0"
 dependencies = [
  "atty",
+ "clap",
  "console-subscriber",
+ "humantime",
  "maitake",
  "mnemos",
  "mnemos-abi",
@@ -1175,6 +1222,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "percent-encoding"
@@ -1622,6 +1675,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1710,21 @@ dependencies = [
  "remove_dir_all",
  "winapi",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -2100,6 +2174,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/source/melpomene/Cargo.toml
+++ b/source/melpomene/Cargo.toml
@@ -45,6 +45,14 @@ optional = true
 version = "1.19"
 features = ["rt", "time", "macros"]
 
+[dependencies.clap]
+version = "3.0"
+features = ["env", "derive"]
+
+[dependencies.humantime]
+version = "2"
+optional = true
+
 # Melpomene does not use any APIs from `maitake` directly. This dependency is
 # instead required in order to enable `maitake`'s support for `tracing` 0.1.x,
 # which is needed to support the Tokio Console while running in the simulator,
@@ -53,9 +61,10 @@ features = ["rt", "time", "macros"]
 version = "0.1.0"
 features = ["tracing-01"]
 
+
 [features]
 # enables Tokio Console support
-trace-console = ["console-subscriber"]
+trace-console = ["console-subscriber", "humantime"]
 trace-fmt = ["tracing-subscriber/fmt", "atty"]
 # Note, the "trace-modality" feature requires the use of the Auxon modality tool.
 # More information: https://auxon.io/products/modality

--- a/source/melpomene/src/cli.rs
+++ b/source/melpomene/src/cli.rs
@@ -1,0 +1,13 @@
+use clap::Parser;
+use std::net::SocketAddr;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about)]
+pub struct Args {
+    /// Address to bind the TCP listener for the simulated serial port.
+    #[clap(long)]
+    pub serial_addr: SocketAddr,
+
+    #[clap(flatten)]
+    pub tracing: crate::sim_tracing::TracingOpts,
+}

--- a/source/melpomene/src/cli.rs
+++ b/source/melpomene/src/cli.rs
@@ -1,13 +1,20 @@
+use crate::{sim_drivers::tcp_serial, sim_tracing};
 use clap::Parser;
 use std::net::SocketAddr;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
 pub struct Args {
-    /// Address to bind the TCP listener for the simulated serial port.
-    #[clap(long)]
-    pub serial_addr: SocketAddr,
+    #[clap(flatten)]
+    pub melpomene: MelpomeneOptions,
 
     #[clap(flatten)]
-    pub tracing: crate::sim_tracing::TracingOpts,
+    pub tracing: sim_tracing::TracingOpts,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct MelpomeneOptions {
+    /// Address to bind the TCP listener for the simulated serial port.
+    #[clap(long, default_value_t = tcp_serial::default_addr())]
+    pub serial_addr: SocketAddr,
 }

--- a/source/melpomene/src/lib.rs
+++ b/source/melpomene/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod cli;
 pub mod sim_drivers;
 pub mod sim_tracing;

--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -4,9 +4,10 @@ use std::{
 };
 
 use abi::bbqueue_ipc::BBBuffer;
+use clap::Parser;
 use melpomene::{
+    cli,
     sim_drivers::{delay::Delay, tcp_serial::spawn_tcp_serial},
-    sim_tracing::setup_tracing,
 };
 use mnemos_kernel::{
     comms::{bbq::new_bidi_channel, kchannel::KChannel},
@@ -24,7 +25,8 @@ const HEAP_SIZE: usize = 192 * 1024;
 static KERNEL_LOCK: AtomicBool = AtomicBool::new(true);
 
 fn main() {
-    setup_tracing();
+    let args = cli::Args::parse();
+    args.tracing.setup_tracing();
     let _span = tracing::info_span!("Melpo").entered();
     run_melpomene();
 }

--- a/source/melpomene/src/sim_drivers/tcp_serial.rs
+++ b/source/melpomene/src/sim_drivers/tcp_serial.rs
@@ -6,9 +6,10 @@ use tokio::{
 };
 use tracing::{info_span, trace, warn, Instrument};
 
-pub async fn spawn_tcp_serial(handle: BidiHandle) {
-    let ip = SocketAddr::from(([127, 0, 0, 1], 9999));
+pub async fn spawn_tcp_serial(ip: SocketAddr, handle: BidiHandle) {
     let listener = TcpListener::bind(ip).await.unwrap();
+    tracing::info!("TCP serial port driver listening on {ip}");
+
     let _ = tokio::spawn(
         async move {
             let mut handle = handle;
@@ -28,6 +29,10 @@ pub async fn spawn_tcp_serial(handle: BidiHandle) {
         }
         .instrument(info_span!("TCP Serial", ?ip)),
     );
+}
+
+pub(crate) fn default_addr() -> SocketAddr {
+    SocketAddr::from(([127, 0, 0, 1], 9999))
 }
 
 async fn process_stream(handle: &mut BidiHandle, mut stream: TcpStream) {

--- a/source/melpomene/src/sim_tracing.rs
+++ b/source/melpomene/src/sim_tracing.rs
@@ -1,39 +1,153 @@
+use std::net::SocketAddr;
+#[cfg(feature = "trace-console")]
+use std::path::PathBuf;
+use tracing_subscriber::filter;
+
+#[derive(Debug, clap::Args)]
+#[clap(
+    next_help_heading = "TRACING OPTIONS",
+    group = clap::ArgGroup::new("tracing-opts")
+)]
+pub struct TracingOpts {
+    /// Address of `modalityd or a modality reflector where trace data should be sent.
+    ///
+    /// This requires that Melpomene be built with the "trace-modality" feature
+    /// flag enabled.
+    #[cfg(feature = "trace-modality")]
+    #[clap(long)]
+    modality_addr: Option<SocketAddr>,
+
+    /// Trace filter for `tracing-subscriber::fmt`.
+    ///
+    /// This requires that Melpomene be built with the "trace-fmt" feature flag
+    /// enabled.
+    #[cfg(feature = "trace-fmt")]
+    #[clap(
+        long = "trace",
+        env = ENV_FILTER,
+        parse(try_from_str = parse_envfilter),
+        default_value_t = filter::EnvFilter::new("info"),
+    )]
+    env_filter: filter::EnvFilter,
+
+    /// Address to bind the `tokio-console` listener on.
+    ///
+    /// This requires that Melpomene be built with the "trace-console" feature
+    /// flag enabled.
+    #[clap(long, env = "TOKIO_CONSOLE_BIND", default_value_t = default_console_addr())]
+    console_addr: SocketAddr,
+
+    /// The interval between publishing updates to connected `tokio-console`
+    /// clients.
+    ///
+    /// This requires that Melpomene be built with the "trace-console" feature
+    /// flag enabled.
+    #[clap(
+        long,
+        env = "TOKIO_CONSOLE_PUBLISH_INTERVAL",
+        default_value_t = duration_secs(1),
+    )]
+    console_publish_interval: humantime::Duration,
+
+    /// How long to retain `tokio-console` data for completed tasks.
+    ///
+    /// This requires that Melpomene be built with the "trace-console" feature
+    /// flag enabled.
+    #[clap(
+        long,
+        env = "TOKIO_CONSOLE_RETENTION",
+        default_value_t = duration_secs(3600),
+    )]
+    console_retention: humantime::Duration,
+
+    /// A file path to save a `tokio-console` recording to.
+    ///
+    /// If a value is present, a recording will be output to that file.
+    /// Otherwise, no recording will be saved.
+    ///
+    /// This requires that Melpomene be built with the "trace-console" feature
+    /// flag enabled.
+    #[clap(long, env = "TOKIO_CONSOLE_RECORD_PATH", value_hint = clap::ValueHint::FilePath)]
+    console_record_path: Option<PathBuf>,
+}
+
+#[cfg(feature = "trace-fmt")]
 const ENV_FILTER: &str = "MELPOMENE_TRACE";
 
-pub fn setup_tracing() {
-    use tracing_subscriber::prelude::*;
-
-    let subscriber = tracing_subscriber::registry();
-
-    // if `trace-fmt` is enabled, add a `tracing-subscriber::fmt` layer along
-    // with an `EnvFilter`
-    #[cfg(feature = "trace-fmt")]
-    let subscriber = {
-        use tracing_subscriber::{filter, fmt};
-
-        let filter = filter::EnvFilter::builder()
-            .with_default_directive(filter::LevelFilter::INFO.into())
-            .with_env_var(ENV_FILTER)
-            .from_env_lossy();
-
-        let fmt = fmt::layer()
-            .with_timer(fmt::time::uptime())
-            .with_ansi(atty::is(atty::Stream::Stdout))
-            .with_filter(filter);
-        subscriber.with(fmt)
-    };
-
-    // if `trace-console` is enabled, add a `console-subscriber` layer.
-    #[cfg(feature = "trace-console")]
-    let subscriber = subscriber.with(console_subscriber::spawn());
-
-    // if `trace-modality` is enabled, add the Modality layer as well.
-    #[cfg(feature = "trace-modality")]
-    let subscriber = {
-        let options = tracing_modality::Options::new().with_name("melpomene");
-        let layer = tracing_modality::ModalityLayer::init_with_options(options).unwrap();
-        subscriber.with(layer)
-    };
-
-    subscriber.init();
+#[cfg(feature = "trace-console")]
+fn default_console_addr() -> SocketAddr {
+    use console_subscriber::Server;
+    SocketAddr::from((Server::DEFAULT_IP, Server::DEFAULT_PORT))
 }
+
+#[cfg(feature = "trace-console")]
+fn duration_secs(secs: u64) -> humantime::Duration {
+    humantime::Duration::from(std::time::Duration::from_secs(secs))
+}
+
+#[cfg(feature = "trace-fmt")]
+fn parse_envfilter(s: &str) -> Result<filter::EnvFilter, filter::ParseError> {
+    filter::EnvFilter::builder()
+        .with_default_directive(filter::LevelFilter::INFO.into())
+        .parse(s)
+}
+
+impl TracingOpts {
+    pub fn setup_tracing(mut self) {
+        use tracing_subscriber::prelude::*;
+
+        let subscriber = tracing_subscriber::registry();
+
+        // if `trace-fmt` is enabled, add a `tracing-subscriber::fmt` layer along
+        // with an `EnvFilter`
+        #[cfg(feature = "trace-fmt")]
+        let subscriber = {
+            use tracing_subscriber::fmt;
+            let filter = self.env_filter;
+
+            let fmt = fmt::layer()
+                .with_timer(fmt::time::uptime())
+                .with_ansi(atty::is(atty::Stream::Stdout))
+                .with_filter(filter);
+
+            subscriber.with(fmt)
+        };
+
+        // if `trace-console` is enabled, add a `console-subscriber` layer.
+        #[cfg(feature = "trace-console")]
+        let subscriber = {
+            let mut console = console_subscriber::ConsoleLayer::builder()
+                .publish_interval(self.console_publish_interval.into())
+                .retention(self.console_retention.into())
+                .server_addr(self.console_addr);
+            eprintln!("Serving tokio-console on {}", self.console_addr);
+
+            if let Some(path) = self.console_record_path.take() {
+                eprintln!("Saving tokio-console recording to {}", path.display());
+                console = console.recording_path(path);
+            }
+
+            subscriber.with(console.spawn())
+        };
+
+        // if `trace-modality` is enabled, add the Modality layer as well.
+        #[cfg(feature = "trace-modality")]
+        let subscriber = {
+            let mut options = tracing_modality::Options::new().with_name("melpomene");
+
+            if let Some(addr) = self.modality_addr {
+                eprintln!("Sending traces to Modality at {addr}");
+                options.set_server_address(addr);
+            } else {
+                eprintln!("Sending traces to Modality");
+            }
+
+            let layer = tracing_modality::ModalityLayer::init_with_options(options).unwrap();
+            subscriber.with(layer)
+        };
+
+        subscriber.init();
+    }
+}
+
+pub fn setup_tracing() {}


### PR DESCRIPTION
This branch adds a simple CLI for configuring Melpomene, using `clap`.
Currently, the CLI can be used for configuring options for various
`tracing` backends, and for setting the address on which to bind the TCP
socket for the simulated serial port. More options will probably be
added in the future for configuring other simulator parameters and
debugging features.

Check out the new help output:
```
:; cargo melpo --help
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/melpomene --help`
melpomene 0.1.0

USAGE:
    melpomene [OPTIONS]

OPTIONS:
    -h, --help
            Print help information

        --serial-addr <SERIAL_ADDR>
            Address to bind the TCP listener for the simulated serial port

            [default: 127.0.0.1:9999]

    -V, --version
            Print version information

TRACING OPTIONS:
        --trace <ENV_FILTER>
            Trace filter for `tracing-subscriber::fmt`.

            This requires that Melpomene be built with the "trace-fmt" feature flag enabled.

            [env: MELPOMENE_TRACE=]
            [default: info]

TRACING OPTIONS (TOKIO-CONSOLE):
        --console-addr <ADDR>
            Address to bind the `tokio-console` listener on.

            This requires that Melpomene be built with the "trace-console" feature flag enabled.

            [env: TOKIO_CONSOLE_BIND=]
            [default: 127.0.0.1:6669]

        --console-publish-interval <PUBLISH_INTERVAL>
            The interval between publishing updates to connected `tokio-console` clients.

            This requires that Melpomene be built with the "trace-console" feature flag enabled.

            [env: TOKIO_CONSOLE_PUBLISH_INTERVAL=]
            [default: 1s]

        --console-record-path <RECORD_PATH>
            A file path to save a `tokio-console` recording to.

            If a value is present, a recording will be output to that file. Otherwise, no recording
            will be saved.

            This requires that Melpomene be built with the "trace-console" feature flag enabled.

            [env: TOKIO_CONSOLE_RECORD_PATH=]

        --console-retention <RETENTION>
            How long to retain `tokio-console` data for completed tasks.

            This requires that Melpomene be built with the "trace-console" feature flag enabled.

            [env: TOKIO_CONSOLE_RETENTION=]
            [default: 1h]
```