### PR TITLE
Fix ambiguous cli arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 [[package]]
 name = "tracing-modality"
 version = "0.1.0"
-source = "git+https://github.com/auxoncorp/modality-tracing-rs?rev=6c9944c688db834d78e3f85c7e385dca939460da#6c9944c688db834d78e3f85c7e385dca939460da"
+source = "git+https://github.com/auxoncorp/modality-tracing-rs?rev=9c23c188466357e7ad0c618b4edfe9514e9bf764#9c23c188466357e7ad0c618b4edfe9514e9bf764"
 dependencies = [
  "anyhow",
  "dirs",

--- a/source/melpomene/Cargo.toml
+++ b/source/melpomene/Cargo.toml
@@ -17,7 +17,7 @@ default-features = false
 # version = "0.1.1"
 optional = true
 git = "https://github.com/auxoncorp/modality-tracing-rs"
-rev = "6c9944c688db834d78e3f85c7e385dca939460da"
+rev = "9c23c188466357e7ad0c618b4edfe9514e9bf764"
 
 [dependencies.uuid]
 version = "1.1.2"

--- a/source/melpomene/src/sim_tracing.rs
+++ b/source/melpomene/src/sim_tracing.rs
@@ -43,7 +43,7 @@ struct ModalityOpts {
     /// This requires that Melpomene be built with the "trace-modality" feature
     /// flag enabled.
     #[clap(long = "modality-addr")]
-    addr: Option<SocketAddr>,
+    modality_addr: Option<SocketAddr>,
 }
 
 #[cfg(feature = "trace-console")]
@@ -58,7 +58,7 @@ struct ConsoleOpts {
     /// This requires that Melpomene be built with the "trace-console" feature
     /// flag enabled.
     #[clap(long = "console-addr", env = "TOKIO_CONSOLE_BIND", default_value_t = default_console_addr())]
-    addr: SocketAddr,
+    console_addr: SocketAddr,
 
     /// The interval between publishing updates to connected `tokio-console`
     /// clients.
@@ -142,8 +142,8 @@ impl TracingOpts {
             let mut console = console_subscriber::ConsoleLayer::builder()
                 .publish_interval(self.console.publish_interval.into())
                 .retention(self.console.retention.into())
-                .server_addr(self.console.addr);
-            eprintln!("Serving tokio-console on {}", self.console.addr);
+                .server_addr(self.console.console_addr);
+            eprintln!("Serving tokio-console on {}", self.console.console_addr);
 
             if let Some(path) = self.console.record_path.take() {
                 eprintln!("Saving tokio-console recording to {}", path.display());
@@ -158,9 +158,9 @@ impl TracingOpts {
         let subscriber = {
             let mut options = tracing_modality::Options::new().with_name("melpomene");
 
-            if let Some(addr) = self.modality.addr {
-                eprintln!("Sending traces to Modality at {addr}");
-                options.set_server_address(addr);
+            if let Some(modality_addr) = self.modality.modality_addr {
+                eprintln!("Sending traces to Modality at {modality_addr}");
+                options.set_server_address(modality_addr);
             } else {
                 eprintln!("Sending traces to Modality");
             }


### PR DESCRIPTION
Prior to this, both the console `addr` and modality `addr` were getting the same default constructor, meaning both the console and modality were trying to bind/connect to port `6699`, which seems like a weird and fun behavior of `flatten`. I've made the names more verbose now to avoid the issue.