### PR TITLE
feat(trace-modality): Render task traces on independent timelines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,7 @@ dependencies = [
  "mnemos",
  "mnemos-abi",
  "mnemos-std",
+ "once_cell",
  "postcard 1.0.1",
  "tokio",
  "tracing 0.1.35",
@@ -2546,7 +2547,6 @@ dependencies = [
 [[package]]
 name = "tracing-modality"
 version = "0.2.0"
-source = "git+https://github.com/auxoncorp/modality-tracing-rs?rev=e54ad9235c509ff219f0760e69ae7832a55f0886#e54ad9235c509ff219f0760e69ae7832a55f0886"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,6 +2134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,7 +2552,7 @@ dependencies = [
 [[package]]
 name = "tracing-modality"
 version = "0.2.0"
-source = "git+https://github.com/auxoncorp/modality-tracing-rs?rev=161544ca8d8ab3b60dfe223086fc8721f5be5d9c#161544ca8d8ab3b60dfe223086fc8721f5be5d9c"
+source = "git+https://github.com/auxoncorp/modality-tracing-rs?rev=d39057e644b2e7dcf648357394fc0b6d8a939a74#d39057e644b2e7dcf648357394fc0b6d8a939a74"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2635,6 +2641,7 @@ checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom",
  "serde",
+ "sha1_smol",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "duplicate"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0a4be4cd710e92098de6ad258e6e7c24af11c29c5142f3c6f2a545652480ff8"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+]
+
+[[package]]
 name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,11 +2545,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-modality"
-version = "0.1.0"
-source = "git+https://github.com/auxoncorp/modality-tracing-rs?rev=9c23c188466357e7ad0c618b4edfe9514e9bf764#9c23c188466357e7ad0c618b4edfe9514e9bf764"
+version = "0.2.0"
+source = "git+https://github.com/auxoncorp/modality-tracing-rs?rev=e54ad9235c509ff219f0760e69ae7832a55f0886#e54ad9235c509ff219f0760e69ae7832a55f0886"
 dependencies = [
  "anyhow",
  "dirs",
+ "duplicate",
  "hex",
  "modality-ingest-client",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 [[package]]
 name = "cordyceps"
 version = "0.3.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=23db951d19cf410e07ed4c2c47ead20d2b592d21#23db951d19cf410e07ed4c2c47ead20d2b592d21"
+source = "git+https://github.com/hawkw/mycelium.git?rev=5cb0341b2c7b91e8e01b26bedb6c4ce536e726b5#5cb0341b2c7b91e8e01b26bedb6c4ce536e726b5"
 dependencies = [
  "loom",
 ]
@@ -1135,7 +1135,7 @@ dependencies = [
 [[package]]
 name = "maitake"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=23db951d19cf410e07ed4c2c47ead20d2b592d21#23db951d19cf410e07ed4c2c47ead20d2b592d21"
+source = "git+https://github.com/hawkw/mycelium.git?rev=5cb0341b2c7b91e8e01b26bedb6c4ce536e726b5#5cb0341b2c7b91e8e01b26bedb6c4ce536e726b5"
 dependencies = [
  "cordyceps",
  "mycelium-bitfield",
@@ -1186,7 +1186,7 @@ dependencies = [
  "tracing 0.1.35",
  "tracing-modality",
  "tracing-subscriber",
- "uuid 1.1.2",
+ "uuid",
 ]
 
 [[package]]
@@ -1297,7 +1297,7 @@ dependencies = [
  "serde",
  "spitebuf",
  "tracing 0.1.35",
- "uuid 1.1.2",
+ "uuid",
 ]
 
 [[package]]
@@ -1336,8 +1336,7 @@ dependencies = [
 [[package]]
 name = "modality-ingest-client"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fee3ff46a80a5570968baad720e5a225406ec87f4d3a6843452736adad41860"
+source = "git+https://github.com/auxoncorp/modality-sdk?rev=4a3b9e3cca08e8225e084f9e8409e818646589ec#4a3b9e3cca08e8225e084f9e8409e818646589ec"
 dependencies = [
  "minicbor",
  "native-tls",
@@ -1345,18 +1344,18 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "url",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
 name = "mycelium-bitfield"
-version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=23db951d19cf410e07ed4c2c47ead20d2b592d21#23db951d19cf410e07ed4c2c47ead20d2b592d21"
+version = "0.1.2"
+source = "git+https://github.com/hawkw/mycelium.git?rev=5cb0341b2c7b91e8e01b26bedb6c4ce536e726b5#5cb0341b2c7b91e8e01b26bedb6c4ce536e726b5"
 
 [[package]]
 name = "mycelium-util"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=23db951d19cf410e07ed4c2c47ead20d2b592d21#23db951d19cf410e07ed4c2c47ead20d2b592d21"
+source = "git+https://github.com/hawkw/mycelium.git?rev=5cb0341b2c7b91e8e01b26bedb6c4ce536e726b5#5cb0341b2c7b91e8e01b26bedb6c4ce536e726b5"
 dependencies = [
  "cordyceps",
  "loom",
@@ -2547,6 +2546,7 @@ dependencies = [
 [[package]]
 name = "tracing-modality"
 version = "0.2.0"
+source = "git+https://github.com/auxoncorp/modality-tracing-rs?rev=161544ca8d8ab3b60dfe223086fc8721f5be5d9c#161544ca8d8ab3b60dfe223086fc8721f5be5d9c"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2561,7 +2561,7 @@ dependencies = [
  "tracing-core 0.1.28",
  "tracing-subscriber",
  "url",
- "uuid 1.1.2",
+ "uuid",
 ]
 
 [[package]]
@@ -2625,15 +2625,6 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
-]
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,17 @@ members = [
     "tools/dumbloader",
 ]
 
+[patch.crates-io.modality-ingest-client]
+git = "https://github.com/auxoncorp/modality-sdk"
+rev = "4a3b9e3cca08e8225e084f9e8409e818646589ec"
+
 [patch.crates-io.maitake]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "23db951d19cf410e07ed4c2c47ead20d2b592d21"
+rev = "5cb0341b2c7b91e8e01b26bedb6c4ce536e726b5"
 
 [patch.crates-io.cordyceps]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "23db951d19cf410e07ed4c2c47ead20d2b592d21"
+rev = "5cb0341b2c7b91e8e01b26bedb6c4ce536e726b5"
 
 [patch.crates-io.mnemos-alloc]
 git = "https://github.com/tosc-rs/mnemos-alloc"

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -17,7 +17,7 @@ use comms::kchannel::KChannel;
 use maitake::{
     self,
     scheduler::{StaticScheduler, TaskStub},
-    task::Storage,
+    task::{Storage, TaskId},
 };
 use maitake::{sync::Mutex, task::Task as MaitakeTask};
 use mnemos_alloc::{containers::HeapBox, heap::AHeap};
@@ -120,6 +120,10 @@ impl Kernel {
         &self.inner
     }
 
+    pub fn task_id(&'static self) -> Option<TaskId> {
+        self.inner.scheduler.current_task().map(|t| t.id())
+    }
+
     pub fn rings(&'static self) -> Rings {
         unsafe {
             Rings {
@@ -202,7 +206,7 @@ impl Kernel {
     }
 
     pub fn spawn_allocated<F: Future + 'static>(&'static self, task: HeapBox<Task<F>>) {
-        self.inner.scheduler.spawn_allocated::<F, HBStorage>(task)
+        let _ = self.inner.scheduler.spawn_allocated::<F, HBStorage>(task);
     }
 }
 

--- a/source/melpomene/Cargo.toml
+++ b/source/melpomene/Cargo.toml
@@ -20,9 +20,8 @@ default-features = false
 [dependencies.tracing-modality]
 # version = "0.1.1"
 optional = true
-path = "/home/james/contracts/modalityv2/tracing-modality-lense/tracing-modality"
-# git = "https://github.com/auxoncorp/modality-tracing-rs"
-# rev = "e54ad9235c509ff219f0760e69ae7832a55f0886"
+git = "https://github.com/auxoncorp/modality-tracing-rs"
+rev = "161544ca8d8ab3b60dfe223086fc8721f5be5d9c"
 
 [dependencies.uuid]
 version = "1.1.2"

--- a/source/melpomene/Cargo.toml
+++ b/source/melpomene/Cargo.toml
@@ -92,4 +92,5 @@ trace-modality = [
 default = [
     "trace-console",
     "trace-fmt",
+    "trace-modality", # TODO
 ]

--- a/source/melpomene/Cargo.toml
+++ b/source/melpomene/Cargo.toml
@@ -17,7 +17,7 @@ default-features = false
 # version = "0.1.1"
 optional = true
 git = "https://github.com/auxoncorp/modality-tracing-rs"
-rev = "9c23c188466357e7ad0c618b4edfe9514e9bf764"
+rev = "e54ad9235c509ff219f0760e69ae7832a55f0886"
 
 [dependencies.uuid]
 version = "1.1.2"

--- a/source/melpomene/Cargo.toml
+++ b/source/melpomene/Cargo.toml
@@ -21,7 +21,7 @@ default-features = false
 # version = "0.1.1"
 optional = true
 git = "https://github.com/auxoncorp/modality-tracing-rs"
-rev = "161544ca8d8ab3b60dfe223086fc8721f5be5d9c"
+rev = "d39057e644b2e7dcf648357394fc0b6d8a939a74"
 
 [dependencies.uuid]
 version = "1.1.2"

--- a/source/melpomene/Cargo.toml
+++ b/source/melpomene/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[dependencies.once_cell]
+version = "1"
+optional = true
+
 [dependencies.tracing]
 version = "0.1.35"
 
@@ -16,8 +20,9 @@ default-features = false
 [dependencies.tracing-modality]
 # version = "0.1.1"
 optional = true
-git = "https://github.com/auxoncorp/modality-tracing-rs"
-rev = "e54ad9235c509ff219f0760e69ae7832a55f0886"
+path = "/home/james/contracts/modalityv2/tracing-modality-lense/tracing-modality"
+# git = "https://github.com/auxoncorp/modality-tracing-rs"
+# rev = "e54ad9235c509ff219f0760e69ae7832a55f0886"
 
 [dependencies.uuid]
 version = "1.1.2"
@@ -84,10 +89,8 @@ trace-fmt = ["tracing-subscriber/fmt", "atty"]
 # More information: https://auxon.io/products/modality
 trace-modality = [
     "tracing-modality",
-    # Note, works around a missing feature set in tracing-modality, can
-    # be changed later
-    "tokio/net",
-    "tokio/sync",
+    "once_cell",
+    "uuid/v4",
 ]
 default = [
     "trace-console",

--- a/source/melpomene/src/lib.rs
+++ b/source/melpomene/src/lib.rs
@@ -1,3 +1,76 @@
 pub mod cli;
 pub mod sim_drivers;
 pub mod sim_tracing;
+
+use std::{collections::HashMap, sync::RwLock, thread};
+
+use maitake::task::TaskId;
+use mnemos_kernel::Kernel;
+use once_cell::sync::Lazy;
+use tracing_modality::{TimelineInfo, TimelineId};
+
+pub struct Timelines {
+    thread_info: TimelineInfo,
+    pub kernel: Option<&'static Kernel>,
+    task_map: HashMap<TaskId, TimelineInfo>,
+}
+
+pub(crate) fn get_timeline() -> TimelineInfo {
+    TIMELINES.with(|tl| {
+        // First, see if we can resolve without mut access
+        let tl_immut = tl.read().unwrap();
+
+        // Has the kernel been registered in this thread?
+        let kernel = match tl_immut.kernel.as_ref() {
+            None => return tl_immut.thread_info.clone(),
+            Some(k) => k,
+        };
+
+        // Are we in a maitake task?
+        let task_id = match kernel.task_id() {
+            None => return tl_immut.thread_info.clone(),
+            Some(tid) => tid,
+        };
+
+        // Has this task already been assigned a UUID?
+        if let Some(tl_id) = tl_immut.task_map.get(&task_id) {
+            return tl_id.clone();
+        }
+
+        // Nope, we need to add one, meaning we need to get mut access to the Timelines
+        // structure to add the new timeline.
+        drop(tl_immut);
+
+        let new_name = format!("kerneltask-{}", task_id);
+        let new_info = TimelineInfo::new(
+            new_name,
+            TimelineId::allocate(),
+        );
+        let mut tl_mut = tl.write().unwrap();
+        tl_mut.task_map.insert(task_id, new_info.clone());
+        new_info
+    })
+}
+
+thread_local! {
+    pub static TIMELINES: Lazy<RwLock<Timelines>>  = Lazy::new(|| {
+        let cur = thread::current();
+        let name = cur
+            .name()
+            .map(Into::into)
+            .unwrap_or_else(|| format!("thread-{:?}", cur.id()));
+
+        let id = TimelineId::allocate();
+
+        let thread_info = TimelineInfo::new(
+            name,
+            id,
+        );
+
+        RwLock::new(Timelines {
+            thread_info,
+            kernel: None,
+            task_map: HashMap::new(),
+        })
+    });
+}

--- a/source/melpomene/src/lib.rs
+++ b/source/melpomene/src/lib.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, sync::RwLock, thread};
 use maitake::task::TaskId;
 use mnemos_kernel::Kernel;
 use once_cell::sync::Lazy;
-use tracing_modality::{TimelineInfo, TimelineId};
+use tracing_modality::{TimelineId, TimelineInfo};
 
 pub struct Timelines {
     thread_info: TimelineInfo,
@@ -42,10 +42,7 @@ pub(crate) fn get_timeline() -> TimelineInfo {
         drop(tl_immut);
 
         let new_name = format!("kerneltask-{}", task_id);
-        let new_info = TimelineInfo::new(
-            new_name,
-            TimelineId::allocate(),
-        );
+        let new_info = TimelineInfo::new(new_name, TimelineId::allocate());
         let mut tl_mut = tl.write().unwrap();
         tl_mut.task_map.insert(task_id, new_info.clone());
         new_info

--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -45,15 +45,17 @@ fn main() {
     let args = cli::Args::parse();
     println!("Starting simulator.");
 
-    args.tracing.setup_tracing();
-    let _span = tracing::info_span!("Melpo").entered();
-    run_melpomene(args.melpomene);
+    run_melpomene(args);
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn run_melpomene(opts: cli::MelpomeneOptions) {
+async fn run_melpomene(args: cli::Args) {
+    args.tracing.setup_tracing().await;
+
+    let _span = tracing::info_span!("Melpo").entered();
+
     let kernel = task::spawn_blocking(move || {
-        kernel_entry(opts);
+        kernel_entry(args.melpomene);
     });
     tracing::info!("Kernel started.");
 

--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -99,6 +99,11 @@ fn kernel_entry(opts: MelpomeneOptions) {
 
     let k = unsafe { Kernel::new(settings).unwrap().leak().as_ref() };
 
+    melpomene::TIMELINES.with(|tl| {
+        let mut tl = tl.write().unwrap();
+        tl.kernel = Some(k);
+    });
+
     // First let's make a dummy driver just to make sure some stuff happens
     let initialization_future = async move {
         // Delay for one second, just for funsies

--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -205,7 +205,7 @@ fn kernel_entry(opts: MelpomeneOptions) {
                     );
 
                     let date_str =
-                        format!("{:02}/{:02}/{:02}", time.month(), time.day(), time.year());
+                        format!("{:04}-{:02}-{:02}", time.year(), time.month(), time.day());
 
                     let date_text = Text::new(&date_str, Point::new(28, 35), datetime_style);
                     let time_text = Text::new(&time_str, Point::new(88, 35), datetime_style);

--- a/source/melpomene/src/sim_tracing.rs
+++ b/source/melpomene/src/sim_tracing.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 #[cfg(feature = "trace-console")]
 use std::path::PathBuf;
+use tracing_modality::TimelineInfo;
 #[cfg(feature = "trace-fmt")]
 use tracing_subscriber::filter;
 
@@ -187,4 +188,8 @@ impl TracingOpts {
 
         subscriber.init();
     }
+}
+
+fn modality_identifier() -> TimelineInfo {
+    todo!()
 }

--- a/source/melpomene/src/sim_tracing.rs
+++ b/source/melpomene/src/sim_tracing.rs
@@ -177,7 +177,9 @@ impl TracingOpts {
                 eprintln!("Sending traces to Modality with default configuration");
             }
 
-            let (layer, handle) = tracing_modality::ModalityLayer::init_with_options(options).await.unwrap();
+            let (layer, handle) = tracing_modality::ModalityLayer::init_with_options(options)
+                .await
+                .unwrap();
 
             // AJM: TODO - leaking handle to avoid shutdown
             core::mem::forget(handle);

--- a/source/melpomene/src/sim_tracing.rs
+++ b/source/melpomene/src/sim_tracing.rs
@@ -117,7 +117,7 @@ fn parse_envfilter(s: &str) -> Result<filter::EnvFilter, filter::ParseError> {
 }
 
 impl TracingOpts {
-    pub fn setup_tracing(mut self) {
+    pub async fn setup_tracing(mut self) {
         use tracing_subscriber::prelude::*;
 
         let subscriber = tracing_subscriber::registry();
@@ -174,7 +174,11 @@ impl TracingOpts {
                 eprintln!("Sending traces to Modality with default configuration");
             }
 
-            let layer = tracing_modality::ModalityLayer::init_with_options(options).unwrap();
+            let (layer, handle) = tracing_modality::ModalityLayer::init_with_options(options).await.unwrap();
+
+            // AJM: TODO - leaking handle to avoid shutdown
+            core::mem::forget(handle);
+
             subscriber.with(layer)
         };
 

--- a/source/melpomene/src/sim_tracing.rs
+++ b/source/melpomene/src/sim_tracing.rs
@@ -1,7 +1,6 @@
 use std::net::SocketAddr;
 #[cfg(feature = "trace-console")]
 use std::path::PathBuf;
-use tracing_modality::TimelineInfo;
 #[cfg(feature = "trace-fmt")]
 use tracing_subscriber::filter;
 
@@ -118,6 +117,7 @@ fn parse_envfilter(s: &str) -> Result<filter::EnvFilter, filter::ParseError> {
 }
 
 impl TracingOpts {
+    #[allow(unused_mut)]
     pub async fn setup_tracing(mut self) {
         use tracing_subscriber::prelude::*;
 
@@ -168,6 +168,8 @@ impl TracingOpts {
         let subscriber = {
             let mut options = tracing_modality::Options::new().with_name("melpomene");
 
+            options.set_timeline_identifier(crate::get_timeline);
+
             if let Some(modality_addr) = self.modality.modality_addr {
                 eprintln!("Sending traces to Modality at {modality_addr}");
                 options.set_server_address(modality_addr);
@@ -188,8 +190,4 @@ impl TracingOpts {
 
         subscriber.init();
     }
-}
-
-fn modality_identifier() -> TimelineInfo {
-    todo!()
 }

--- a/source/mstd/src/executor/mod.rs
+++ b/source/mstd/src/executor/mod.rs
@@ -89,6 +89,6 @@ impl Terpsichore {
     }
 
     pub fn spawn_allocated<F: Future + 'static>(&'static self, task: HeapBox<Task<F>>) {
-        self.scheduler.spawn_allocated::<F, HBStorage>(task)
+        let _ = self.scheduler.spawn_allocated::<F, HBStorage>(task);
     }
 }


### PR DESCRIPTION
Previously, all kernel async tasks would render within the timeline of the tokio executor that is running the kernel loop.

This change allows us to generate unique timelines per-task. This will only work for the kernel at the moment, and will require adjusting for also splitting off userspace task timelines.