### PR TITLE
initial implementation of spawnable forth tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,7 +644,7 @@ dependencies = [
 [[package]]
 name = "forth3"
 version = "0.1.0"
-source = "git+https://github.com/jamesmunns/forth3?rev=518ea1bc14fc94473b85ed8c54a22e4687fc533d#518ea1bc14fc94473b85ed8c54a22e4687fc533d"
+source = "git+https://github.com/jamesmunns/forth3?rev=435940ad54d2209f2a7706cd34dcb2c05b663bc6#435940ad54d2209f2a7706cd34dcb2c05b663bc6"
 dependencies = [
  "cfg-if 1.0.0",
  "hash32 0.3.1",
@@ -1339,7 +1339,7 @@ version = "0.1.0"
 dependencies = [
  "cobs",
  "embedded-graphics",
- "forth3 0.1.0 (git+https://github.com/jamesmunns/forth3?rev=518ea1bc14fc94473b85ed8c54a22e4687fc533d)",
+ "forth3 0.1.0 (git+https://github.com/jamesmunns/forth3?rev=435940ad54d2209f2a7706cd34dcb2c05b663bc6)",
  "futures",
  "heapless",
  "maitake",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "forth3"
 version = "0.1.0"
-source = "git+https://github.com/jamesmunns/forth3?rev=8743d9ef9eea0eb0e4420231e4d6d6cdadcfb2fc#8743d9ef9eea0eb0e4420231e4d6d6cdadcfb2fc"
+source = "git+https://github.com/jamesmunns/forth3?rev=5ce6f8fc6115e276506070d7c94c13f407464848#5ce6f8fc6115e276506070d7c94c13f407464848"
 dependencies = [
  "cfg-if 1.0.0",
  "hash32 0.3.1",
@@ -1222,7 +1222,7 @@ dependencies = [
  "console-subscriber",
  "embedded-graphics",
  "embedded-graphics-simulator",
- "forth3 0.1.0 (git+https://github.com/jamesmunns/forth3?rev=8743d9ef9eea0eb0e4420231e4d6d6cdadcfb2fc)",
+ "forth3 0.1.0 (git+https://github.com/jamesmunns/forth3?rev=5ce6f8fc6115e276506070d7c94c13f407464848)",
  "futures",
  "humantime",
  "input-mgr",

--- a/source/kernel/Cargo.toml
+++ b/source/kernel/Cargo.toml
@@ -66,7 +66,7 @@ version = "0.7.1"
 
 [dependencies.forth3]
 git = "https://github.com/jamesmunns/forth3"
-rev = "518ea1bc14fc94473b85ed8c54a22e4687fc533d"
+rev = "435940ad54d2209f2a7706cd34dcb2c05b663bc6"
 features = ["async"]
 
 [dependencies.portable-atomic]

--- a/source/kernel/src/forth.rs
+++ b/source/kernel/src/forth.rs
@@ -423,7 +423,9 @@ impl dictionary::DropDict for DropDict {
 pub struct Spawnulator(KProducer<Forth>);
 
 impl Spawnulator {
-    const SPAWN_QUEUE_CAPACITY: usize = 16; // 100% arbitrary! :D
+    /// originally i made this 256 but apparently if it's that big, the
+    /// allocation request hangs forever lol...
+    const SPAWN_QUEUE_CAPACITY: usize = 16;
 
     /// Start the spawnulator background task, returning a handle that can be
     /// used to spawn new `Forth` VMs.

--- a/source/kernel/src/forth.rs
+++ b/source/kernel/src/forth.rs
@@ -423,9 +423,7 @@ impl dictionary::DropDict for DropDict {
 pub struct Spawnulator(KProducer<Forth>);
 
 impl Spawnulator {
-    /// originally i made this 256 but apparently if it's that big, the
-    /// allocation request hangs forever lol...
-    const SPAWN_QUEUE_CAPACITY: usize = 16;
+    const SPAWN_QUEUE_CAPACITY: usize = 16; // 100% arbitrary! :D
 
     /// Start the spawnulator background task, returning a handle that can be
     /// used to spawn new `Forth` VMs.

--- a/source/kernel/src/forth.rs
+++ b/source/kernel/src/forth.rs
@@ -358,7 +358,7 @@ async fn spawn_forth_task(forth: &mut forth3::Forth<MnemosContext>) -> Result<()
 
     // TODO(eliza): store the child's stdio in the
     // parent's host context so we can actually do something with it...
-    let (stdio, streams) = params.alloc_stdio(heap).await;
+    let (stdio, _streams) = params.alloc_stdio(heap).await;
     let mut bufs = params.alloc_bufs(heap).await;
     let new_dict = params.alloc_dict(heap).await.map_err(|error| {
         tracing::error!(?error, "Failed to allocate dictionary for child VM");

--- a/source/kernel/src/forth.rs
+++ b/source/kernel/src/forth.rs
@@ -457,13 +457,13 @@ impl dictionary::DropDict for DropDict {
 /// implementation of its `spawn` builtin?
 ///
 /// The answer is that this is, unfortunately, not possible. The function
-/// implementing the `spawn` builtin, [`spawn_forth_task()`], *must* be `async`,
+/// implementing the `spawn` builtin, `spawn_forth_task()`, *must* be `async`,
 /// as it needs to perform allocations for the child task's dictionary, stacks,
-/// etc Therefore, calling [`spawn_forth_task()`] returns an `impl Future` which
+/// etc Therefore, calling `spawn_forth_task()` returns an `impl Future` which
 /// is awaited inside the `Dispatcher::dispatch_async()` future, which is itself
 /// awaited inside `Forth::process_line()` in the  parent VM's [`Forth::run()`]
 /// async method. This means the *layout* of the future generated for
-/// [`spawn_forth_task()`] must be known in order to determine the layout of the
+/// `spawn_forth_task()` must be known in order to determine the layout of the
 /// future generated for [`Forth::run()`]. In order to spawn a new child task, we
 /// must call [`Forth::run()`] and then pass the returned `impl Future` to
 /// [`Kernel::spawn()`]. This means that the generated `impl Future` for

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -249,10 +249,7 @@ impl Kernel {
     /// the spawned task's standard input and standard output streams.
     ///
     /// This should only be called once.
-    pub fn initialize_forth_tid0(
-        &'static self,
-        params: forth::Params,
-    ) -> JoinHandle<BidiHandle> {
+    pub fn initialize_forth_tid0(&'static self, params: forth::Params) -> JoinHandle<BidiHandle> {
         use forth::{Forth, Spawnulator};
         self.initialize(async move {
             tracing::debug!("spawning Task 0...");

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -249,16 +249,18 @@ impl Kernel {
     /// the spawned task's standard input and standard output streams.
     ///
     /// This should only be called once.
-    pub async fn spawn_forth_tid0(&'static self, params: forth::Params) -> crate::comms::bbq::BidiHandle {
+    pub fn initialize_forth_tid0(&'static self, params: forth::Params) -> JoinHandle<crate::comms::bbq::BidiHandle> {
         use forth::{Forth, Spawnulator};
-        tracing::debug!("spawning Task 0...");
-        // TODO(eliza): maybe the spawnulator should live in the driver registry
-        // or something.
-        let spawnulator = Spawnulator::start_spawnulating(self).await;
-        let (tid0, tid0_streams) = Forth::new(self, params, spawnulator).await.expect("spawning forth TID0 should succeed");
-        self.spawn(tid0.run()).await;
-        tracing::info!("Task 0 spawned!");
-        tid0_streams
+        self.initialize(async move {
+            tracing::debug!("spawning Task 0...");
+            // TODO(eliza): maybe the spawnulator should live in the driver registry
+            // or something.
+            let spawnulator = Spawnulator::start_spawnulating(self).await;
+            let (tid0, tid0_streams) = Forth::new(self, params, spawnulator).await.expect("spawning forth TID0 should succeed");
+            self.spawn(tid0.run()).await;
+            tracing::info!("Task 0 spawned!");
+            tid0_streams
+        }).expect("spawning forth TID0 should succeed")
     }
 
     pub fn initialize<F>(&'static self, fut: F) -> Result<JoinHandle<F::Output>, &'static str>

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -249,18 +249,24 @@ impl Kernel {
     /// the spawned task's standard input and standard output streams.
     ///
     /// This should only be called once.
-    pub fn initialize_forth_tid0(&'static self, params: forth::Params) -> JoinHandle<crate::comms::bbq::BidiHandle> {
+    pub fn initialize_forth_tid0(
+        &'static self,
+        params: forth::Params,
+    ) -> JoinHandle<crate::comms::bbq::BidiHandle> {
         use forth::{Forth, Spawnulator};
         self.initialize(async move {
             tracing::debug!("spawning Task 0...");
             // TODO(eliza): maybe the spawnulator should live in the driver registry
             // or something.
             let spawnulator = Spawnulator::start_spawnulating(self).await;
-            let (tid0, tid0_streams) = Forth::new(self, params, spawnulator).await.expect("spawning forth TID0 should succeed");
+            let (tid0, tid0_streams) = Forth::new(self, params, spawnulator)
+                .await
+                .expect("spawning forth TID0 should succeed");
             self.spawn(tid0.run()).await;
             tracing::info!("Task 0 spawned!");
             tid0_streams
-        }).expect("spawning forth TID0 should succeed")
+        })
+        .expect("spawning forth TID0 should succeed")
     }
 
     pub fn initialize<F>(&'static self, fut: F) -> Result<JoinHandle<F::Output>, &'static str>

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -83,7 +83,7 @@ use abi::{
     },
     syscall::{KernelResponse, UserRequest},
 };
-use comms::kchannel::KChannel;
+use comms::{bbq::BidiHandle, kchannel::KChannel};
 use maitake::{
     self,
     scheduler::{LocalStaticScheduler, TaskStub},
@@ -252,7 +252,7 @@ impl Kernel {
     pub fn initialize_forth_tid0(
         &'static self,
         params: forth::Params,
-    ) -> JoinHandle<crate::comms::bbq::BidiHandle> {
+    ) -> JoinHandle<BidiHandle> {
         use forth::{Forth, Spawnulator};
         self.initialize(async move {
             tracing::debug!("spawning Task 0...");

--- a/source/melpomene/Cargo.toml
+++ b/source/melpomene/Cargo.toml
@@ -91,7 +91,7 @@ features = ["tracing-01"]
 
 [dependencies.forth3]
 git = "https://github.com/jamesmunns/forth3"
-rev = "8743d9ef9eea0eb0e4420231e4d6d6cdadcfb2fc"
+rev = "5ce6f8fc6115e276506070d7c94c13f407464848"
 features = ["async"]
 
 [dependencies.futures]

--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -173,6 +173,8 @@ fn kernel_entry(opts: MelpomeneOptions) {
     .instrument(tracing::info_span!("Initialize"));
 
     k.initialize(initialization_future).unwrap();
+    let tid0_future = k.initialize_forth_tid0(Default::default());
+
 
     // Create the interactive console task
     let graphics_console = async move {
@@ -231,8 +233,6 @@ fn kernel_entry(opts: MelpomeneOptions) {
             disp_hdl.draw_framechunk(fc_0).await.unwrap();
         }
 
-        let tid0 = k.spawn_forth_tid0(Default::default()).await;
-
         k.spawn(
             async move {
                 // TODO(eliza): don't spawn the forth task from within the
@@ -247,6 +247,8 @@ fn kernel_entry(opts: MelpomeneOptions) {
                 //
                 // Leave out 4 for the implicit margin of two characters on each gutter.
                 let mut rline = RingLine::<16, 46>::new();
+
+                let tid0 = tid0_future.await.expect("TID 0 initialization task must succeed");
 
                 loop {
                     // Wait until there is a frame buffer ready. There wouldn't be if we've spammed frames

--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -38,7 +38,9 @@ use profont::PROFONT_12_POINT;
 
 const DISPLAY_WIDTH_PX: u32 = 400;
 const DISPLAY_HEIGHT_PX: u32 = 240;
-const HEAP_SIZE: usize = 192 * 1024;
+/// The Allwinner D1 has 1GB of memory, so we can definitely get away with two
+/// 1MB heaps.
+const HEAP_SIZE: usize = 1024 * 1024;
 
 static KERNEL_LOCK: AtomicBool = AtomicBool::new(true);
 
@@ -87,12 +89,25 @@ async fn run_melpomene(opts: cli::MelpomeneOptions) {
 #[tracing::instrument(name = "Kernel", level = "info", skip(opts))]
 fn kernel_entry(opts: MelpomeneOptions) {
     // First, we'll do some stuff that later the linker script will do...
-    let kernel_heap = Box::into_raw(Box::new([0u8; HEAP_SIZE]));
-    let user_heap = Box::into_raw(Box::new([0u8; HEAP_SIZE]));
+    fn alloc_heap() -> (*mut u8, usize) {
+        use std::mem::ManuallyDrop;
+        // use `Vec::with_capacity` to allocate the memory without having to
+        // create a stack array, or initialize the memory.
+        // the vector is intentionally leaked.
+        let mut mem = ManuallyDrop::new(Vec::<u8>::with_capacity(HEAP_SIZE));
+        let slice = mem.spare_capacity_mut();
+        // we use the *actual* size of the allocation, since liballoc may have
+        // given us more than we asked for.
+        let sz = slice.len();
+        (slice.as_mut_ptr().cast(), sz)
+    }
+    
+    let (heap_start, heap_size) = alloc_heap();
+    let (user_heap, user_heap_size) = alloc_heap();
 
     let settings = KernelSettings {
-        heap_start: kernel_heap.cast(),
-        heap_size: HEAP_SIZE,
+        heap_start,
+        heap_size,
         max_drivers: 16,
         k2u_size: 4096,
         u2k_size: 4096,
@@ -316,7 +331,7 @@ fn kernel_entry(opts: MelpomeneOptions) {
             k2u: BBBuffer::take_framed_consumer(rings.k2u.as_ptr()),
         };
         mstd::executor::mailbox::MAILBOX.set_rings(urings);
-        mstd::executor::EXECUTOR.initialize(user_heap.cast(), HEAP_SIZE);
+        mstd::executor::EXECUTOR.initialize(user_heap, user_heap_size);
     }
 
     let _userspace = spawn(|| {

--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -101,7 +101,7 @@ fn kernel_entry(opts: MelpomeneOptions) {
         let sz = slice.len();
         (slice.as_mut_ptr().cast(), sz)
     }
-    
+
     let (heap_start, heap_size) = alloc_heap();
     let (user_heap, user_heap_size) = alloc_heap();
 
@@ -174,7 +174,6 @@ fn kernel_entry(opts: MelpomeneOptions) {
 
     k.initialize(initialization_future).unwrap();
     let tid0_future = k.initialize_forth_tid0(Default::default());
-
 
     // Create the interactive console task
     let graphics_console = async move {

--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -216,12 +216,7 @@ fn kernel_entry(opts: MelpomeneOptions) {
             disp_hdl.draw_framechunk(fc_0).await.unwrap();
         }
 
-        let tid0 = {
-            let (tid0, tid0_streams) = Forth::new(k, forth::Params::new()).await.expect("spawning forth should succeed");
-            k.spawn(tid0.run()).await;
-            tracing::info!("Task 0 spawned!");
-            tid0_streams
-        };
+        let tid0 = k.spawn_forth_tid0(Default::default()).await;
 
         k.spawn(
             async move {


### PR DESCRIPTION
This branch adds an initial working implementation of a `spawn` builtin
word for Forth tasks. The `spawn` word takes the address of a word in
the Forth VM's dictionary, and spawns a new child VM that will begin
executing that word. 

The child task is created with a `bbqueue` bi-directional channel for
its input and output streams, although these are currently not used yet.
Subsequent changes will probably need to give parent tasks a way to
actually send inputs/outputs to their children, if that's something we
want to do. Currently, though, we can basically only see that the child
task is running by checking the kernel logs for evidence of its
activity, or by having it open serial mux ports and communcate on them.

## Potential Future Work

In follow-up branches, we should probably add some new builtins:
 - [ ] a way for tasks to sleep (ideally, using the `maitake` timer
   wheel!)
 - [ ] a way for parents to wait for their children to complete (the
   spawned child task's `JoinHandle`)
 - [ ] a way for parents to kill their children
 - [ ] a way for tasks to explicitly yield to the scheduler
   (`maitake::future::yield_now()`)
 - [ ] a way for tasks to write to each other's unputs and outputs.

## Some Notes

In order to make this work, I had to increase the kernel heap size in
Melpomene significantly. One consequence of the async allocator is that
if a task is trying to make an allocation that there's no space in the
heap for, and no other tasks are going to free memory that will make
that allocation possible, the child task just hangs forever and it's not
obvious why. We may want to consider adding debug logging to the
allocator so that we know when a task can't allocate because the heap is
full. Also, we may want to consider making futures run in
`Kernel::initialize` (rather than `Kernel::spawn`) set some kind of flag
that makes the allocator panic on OOMs instead of waiting for heap
capacity. Since the `initialize` futures run before the OS is actually
ready to run user input, and most tasks started in `initialize` are
parts of the OS that will run for as long as the system is up (and
therefore probably won't release most of their allocations), we may want
OOMs to be fatal *while starting up*, and only make user task
allocations wait for heap capacity. Just a thought.