### PR TITLE
Fold the allocator back into the mnemos repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,6 @@ dependencies = [
 [[package]]
 name = "mnemos-alloc"
 version = "0.1.0"
-source = "git+https://github.com/tosc-rs/mnemos-alloc?rev=3b1b16d7c04f312a27befb1f1f7691f5f63cfb47#3b1b16d7c04f312a27befb1f1f7691f5f63cfb47"
 dependencies = [
  "cordyceps",
  "heapless",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "source/mstd",
     "source/spitebuf",
     "source/melpomene",
+    "source/alloc",
 
     # tools
     "tools/crowtty",
@@ -21,6 +22,4 @@ git = "https://github.com/hawkw/mycelium.git"
 rev = "5149ee6146a9e0c1af56da79bb55578abf6dfddc"
 
 [patch.crates-io.mnemos-alloc]
-git = "https://github.com/tosc-rs/mnemos-alloc"
-rev = "3b1b16d7c04f312a27befb1f1f7691f5f63cfb47"
-# path = "/home/james/tosc/mnemos-alloc"
+path = "./source/alloc"

--- a/source/alloc/.gitignore
+++ b/source/alloc/.gitignore
@@ -1,0 +1,3 @@
+**/target/*
+Cargo.lock
+

--- a/source/alloc/Cargo.toml
+++ b/source/alloc/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "mnemos-alloc"
+version = "0.1.0"
+edition = "2021"
+
+categories = [
+    "embedded",
+    "no-std",
+]
+license = "MIT OR Apache-2.0"
+
+[dependencies.cordyceps]
+version = "0.3"
+default-features = false
+
+[dependencies.maitake]
+version = "0.1"
+default-features = false
+
+[dependencies.heapless]
+version = "0.7.10"
+features = ["defmt-impl"]
+
+[dependencies.linked_list_allocator]
+version = "0.10.1"
+default-features = false
+
+[patch.crates-io.maitake]
+git = "https://github.com/hawkw/mycelium.git"
+rev = "5e46e35cae131d5f60f527e6659dc53b18e30ebb"
+
+[patch.crates-io.cordyceps]
+git = "https://github.com/hawkw/mycelium.git"
+rev = "5e46e35cae131d5f60f527e6659dc53b18e30ebb"

--- a/source/alloc/Cargo.toml
+++ b/source/alloc/Cargo.toml
@@ -24,11 +24,3 @@ features = ["defmt-impl"]
 [dependencies.linked_list_allocator]
 version = "0.10.1"
 default-features = false
-
-[patch.crates-io.maitake]
-git = "https://github.com/hawkw/mycelium.git"
-rev = "5e46e35cae131d5f60f527e6659dc53b18e30ebb"
-
-[patch.crates-io.cordyceps]
-git = "https://github.com/hawkw/mycelium.git"
-rev = "5e46e35cae131d5f60f527e6659dc53b18e30ebb"

--- a/source/alloc/README.md
+++ b/source/alloc/README.md
@@ -1,0 +1,89 @@
+# Mnemos' async allocator
+
+This project is the async allocator layer for [MnemOS].
+
+It serves more as a `liballoc` replacement than a `malloc` replacement - it doesn't actually handle "raw" allocations at all, and instead (currently) leaves that up to the underlying allocator, at this point only [linked_list_allocator].
+
+[MnemOS]: https://mnemos.jamesmunns.com
+[linked_list_allocator]: https://docs.rs/linked_list_allocator/
+
+## How does it work?
+
+> NOTE: Not everything described here has been ported over from `MnemOS`. You can see some of this
+> behavior in the [pre-export] version, before this was broken out into a standalone crate.
+
+[pre-export]: https://github.com/jamesmunns/pellegrino/blob/1ad0f53e4d23a4a8683cce80f8d239504bac440c/oaiu/alloc/src/lib.rs
+
+When you go to allocate something, you don't get back a `T` or a `Result<T>`, you get back an `impl Future<Output = T>`.
+If there is space in the allocator, and it is not currently locked doing something else, this will resolved on the first
+poll. If not, the waiter is placed into an [intrusive waitqueue], which will be woken the next time a free occurs, and there
+might be space.
+
+[intrusive waitqueue]: https://mycelium.elizas.website/maitake/wait/struct.waitqueue
+
+## But why?
+
+This allocator is designed for memory constrained systems. In many cases, especially for small systems with limited memory,
+"OOM" is a temporary state of things, rather than a foregone conclusion.
+By using async/await to allow waiting a little bit, you might be able to resolve this once a couple of chonky allocs have cleared.
+
+Or you'll deadlock. But hey, that's the problem of the OS or the executor, not the allocator!
+
+## But wait, `drop` isn't async. How do you handle that?
+
+Good question! When a `drop` would occur, we try to immediately lock the allocator, and free the memory. If this fails, we
+stick the allocation in a [lock-free mpscqueue]. It will then be processed at the allocator's next convenience, such as
+before allocating the next item, or at some kind of periodic "cleanup" time.
+
+[lock-free mpscqueue]: https://docs.rs/cordyceps/latest/cordyceps/struct.MpscQueue.html
+
+## Why would the allocator be "locked"? `malloc` doesn't need that
+
+Since this is an allocator designed **for** operating systems, we don't necessarily have the benefits of threads to make
+forward progress or to yield when the allocator is busy. The allocator itself is not (currently) thread safe, which means
+that we need to handle the case where we (accidentally or intentionally) are holding the allocator mutex and an allocated
+piece of data is freed
+
+## But wait, what if the queue is full?
+
+It can't be! We use an *intrusive* queue, which means that the space to store the queue elements are in the elements themselves!
+When we do the allocation, there is a small header that allows us to chain it to a linked list (in a thread safe way), which means
+that the free list is only limited to the number of allocations that actually exist!
+
+## But doesn't that add a lot of overhead?
+
+No! We use the power of `union`s, because when an allocation is freed, it no longer needs that juicy space to contain data anymore,
+so we just stick the linked list header there instead! This means that the only overhead over an allocation itself is a single
+pointer - a pointer back to the allocator that created this node. (unless you are allocating something smaller than two pointers,
+then yes, there will be a bit of overhead, but why are you doing that?)
+
+## That sounds terribly unsafe!
+
+Oh it is! Egregiously! See the reviews below:
+
+> "this code is like a fractal footgun forest"
+>
+> - [@dirbaio]
+
+[@dirbaio]: https://twitter.com/Dirbaio/
+
+However, we have the power of [miri](https://github.com/rust-lang/miri) to check our reckless use of `unsafe`, which currently
+gives us a clean bill of health! Try it yourself:
+
+```shell
+MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-strict-provenance -Zmiri-tag-raw-pointers -Zmiri-ignore-leaks" cargo +nightly miri test
+     Running tests/smoke.rs (target/miri/x86_64-unknown-linux-gnu/debug/deps/smoke-d242f69140f2a6cb)
+
+running 2 tests
+test basic ... ok
+test basic_arr ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+To be fair, there's not a LOT of testing yet, but fundamental actions like allocating, freeing (with and without the lock available),
+and using some silly Dynamically Sized Type allocations for arrays, it still hasn't made Miri upset yet!
+
+## Why didn't you just use `alloc`?
+
+I dunno, that didn't sound as fun.

--- a/source/alloc/src/containers.rs
+++ b/source/alloc/src/containers.rs
@@ -127,7 +127,7 @@ impl<T> HeapArc<T> {
         }
     }
 
-    /// Create a clone of a given leaked HeapArc<T>. DOES increase the refcount.
+    /// Create a clone of a given leaked `HeapArc<T>`. DOES increase the refcount.
     pub unsafe fn clone_from_leaked(ptr: NonNull<T>) -> Self {
         let new = Self::from_leaked(ptr);
 
@@ -137,7 +137,7 @@ impl<T> HeapArc<T> {
         new
     }
 
-    /// Re-takes ownership of a leaked HeapArc<T>. Does NOT increase the refcount.
+    /// Re-takes ownership of a leaked `HeapArc<T>`. Does NOT increase the refcount.
     pub unsafe fn from_leaked(ptr: NonNull<T>) -> Self {
         let arc_inner_nn: NonNull<ArcInner<T>> = ArcInner::from_leaked_ptr(ptr);
         Self {

--- a/source/alloc/src/containers.rs
+++ b/source/alloc/src/containers.rs
@@ -1,0 +1,363 @@
+use crate::node::{Active, ActiveArr};
+use core::marker::PhantomData;
+use core::mem::MaybeUninit;
+use core::ptr::{addr_of, addr_of_mut, drop_in_place};
+use core::slice::{from_raw_parts, from_raw_parts_mut};
+use core::sync::atomic::{AtomicUsize, Ordering};
+use core::{
+    fmt,
+    mem::forget,
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+};
+
+/// An Anachro Heap Box Type
+pub struct HeapBox<T> {
+    pub(crate) ptr: NonNull<Active<T>>,
+    pub(crate) pd: PhantomData<Active<T>>,
+}
+
+pub(crate) struct ArcInner<T> {
+    pub(crate) data: T,
+    pub(crate) refcnt: AtomicUsize,
+}
+
+pub struct HeapArc<T> {
+    pub(crate) ptr: NonNull<Active<ArcInner<T>>>,
+    pub(crate) pd: PhantomData<Active<ArcInner<T>>>,
+}
+
+/// An Anachro Heap Array Type
+pub struct HeapArray<T> {
+    pub(crate) ptr: NonNull<ActiveArr<T>>,
+    pub(crate) pd: PhantomData<Active<T>>,
+}
+
+/// An Anachro Heap Array Type
+pub struct HeapFixedVec<T> {
+    pub(crate) ptr: NonNull<ActiveArr<MaybeUninit<T>>>,
+    pub(crate) len: usize,
+    pub(crate) pd: PhantomData<Active<MaybeUninit<T>>>,
+}
+
+// === impl HeapBox ===
+
+unsafe impl<T: Send> Send for HeapBox<T> {}
+unsafe impl<T: Sync> Sync for HeapBox<T> {}
+
+impl<T> Deref for HeapBox<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Active::<T>::data(self.ptr).as_ptr() }
+    }
+}
+
+impl<T> DerefMut for HeapBox<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *Active::<T>::data(self.ptr).as_ptr() }
+    }
+}
+
+impl<T> HeapBox<T> {
+    pub unsafe fn from_leaked(ptr: NonNull<T>) -> Self {
+        Self {
+            ptr: Active::<T>::from_leaked_ptr(ptr),
+            pd: PhantomData,
+        }
+    }
+
+    /// Leak the contents of this box, never to be recovered (probably)
+    pub fn leak(self) -> NonNull<T> {
+        let nn = unsafe { Active::<T>::data(self.ptr) };
+        forget(self);
+        nn
+    }
+}
+
+impl<T> Drop for HeapBox<T> {
+    fn drop(&mut self) {
+        unsafe {
+            let item_ptr = Active::<T>::data(self.ptr).as_ptr();
+            drop_in_place(item_ptr);
+            Active::<T>::yeet(self.ptr);
+        }
+    }
+}
+
+// === impl ArcInner ===
+
+impl<T> ArcInner<T> {
+    pub unsafe fn from_leaked_ptr(data: NonNull<T>) -> NonNull<ArcInner<T>> {
+        let ptr = data
+            .cast::<u8>()
+            .as_ptr()
+            .offset(Self::data_offset())
+            .cast::<ArcInner<T>>();
+        NonNull::new_unchecked(ptr)
+    }
+
+    #[inline(always)]
+    fn data_offset() -> isize {
+        let dummy: ArcInner<MaybeUninit<T>> = ArcInner {
+            data: MaybeUninit::uninit(),
+            refcnt: AtomicUsize::new(0),
+        };
+        let dummy_ptr: *const ArcInner<MaybeUninit<T>> = &dummy;
+        let data_ptr = unsafe { addr_of!((*dummy_ptr).data) };
+        unsafe { dummy_ptr.cast::<u8>().offset_from(data_ptr.cast::<u8>()) }
+    }
+}
+
+// === impl HeapArc ===
+
+// These require the same bounds as `alloc::sync::Arc`'s `Send` and `Sync`
+// impls.
+unsafe impl<T: Send + Sync> Send for HeapArc<T> {}
+unsafe impl<T: Send + Sync> Sync for HeapArc<T> {}
+
+impl<T> HeapArc<T> {
+    /// Leak the contents of this box, never to be recovered (probably)
+    pub fn leak(self) -> NonNull<T> {
+        unsafe {
+            let nn = Active::<ArcInner<T>>::data(self.ptr);
+            forget(self);
+            let data_ptr = addr_of_mut!((*nn.as_ptr()).data);
+            NonNull::new_unchecked(data_ptr)
+        }
+    }
+
+    /// Create a clone of a given leaked HeapArc<T>. DOES increase the refcount.
+    pub unsafe fn clone_from_leaked(ptr: NonNull<T>) -> Self {
+        let new = Self::from_leaked(ptr);
+
+        let aitem_nn = Active::<ArcInner<T>>::data(new.ptr);
+        aitem_nn.as_ref().refcnt.fetch_add(1, Ordering::SeqCst);
+
+        new
+    }
+
+    /// Re-takes ownership of a leaked HeapArc<T>. Does NOT increase the refcount.
+    pub unsafe fn from_leaked(ptr: NonNull<T>) -> Self {
+        let arc_inner_nn: NonNull<ArcInner<T>> = ArcInner::from_leaked_ptr(ptr);
+        Self {
+            ptr: Active::<ArcInner<T>>::from_leaked_ptr(arc_inner_nn),
+            pd: PhantomData,
+        }
+    }
+
+    pub unsafe fn increment_count(ptr: NonNull<T>) {
+        let arc_inner_nn: NonNull<ArcInner<T>> = ArcInner::from_leaked_ptr(ptr);
+        arc_inner_nn.as_ref().refcnt.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+impl<T> Deref for HeapArc<T> {
+    type Target = T;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            let aiptr: *mut ArcInner<T> = Active::<ArcInner<T>>::data(self.ptr).as_ptr();
+            let dptr: *const T = addr_of!((*aiptr).data);
+            &*dptr
+        }
+    }
+}
+
+impl<T> Drop for HeapArc<T> {
+    fn drop(&mut self) {
+        unsafe {
+            let (aiptr, needs_drop) = {
+                let aitem_ptr = Active::<ArcInner<T>>::data(self.ptr).as_ptr();
+                let old = (*aitem_ptr).refcnt.fetch_sub(1, Ordering::SeqCst);
+                debug_assert_ne!(old, 0);
+                (aitem_ptr, old == 1)
+            };
+
+            if needs_drop {
+                drop_in_place(aiptr);
+                Active::<ArcInner<T>>::yeet(self.ptr);
+            }
+        }
+    }
+}
+
+impl<T> Clone for HeapArc<T> {
+    fn clone(&self) -> Self {
+        unsafe {
+            let aitem_nn = Active::<ArcInner<T>>::data(self.ptr);
+            aitem_nn.as_ref().refcnt.fetch_add(1, Ordering::SeqCst);
+
+            HeapArc {
+                ptr: self.ptr,
+                pd: PhantomData,
+            }
+        }
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for HeapArc<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for HeapArc<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T> fmt::Pointer for HeapArc<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.ptr, f)
+    }
+}
+
+// === impl HeapArray ===
+
+unsafe impl<T: Send> Send for HeapArray<T> {}
+unsafe impl<T: Sync> Sync for HeapArray<T> {}
+
+impl<T> Deref for HeapArray<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            let (nn_ptr, count) = ActiveArr::<T>::data(self.ptr);
+            from_raw_parts(nn_ptr.as_ptr(), count)
+        }
+    }
+}
+
+impl<T> DerefMut for HeapArray<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe {
+            let (nn_ptr, count) = ActiveArr::<T>::data(self.ptr);
+            from_raw_parts_mut(nn_ptr.as_ptr(), count)
+        }
+    }
+}
+
+impl<T> HeapArray<T> {
+    // pub unsafe fn from_leaked(ptr: *mut T, count: usize) -> Self {
+    //     Self { ptr, count }
+    // }
+
+    /// Leak the contents of this box, never to be recovered (probably)
+    pub fn leak(self) -> (NonNull<T>, usize) {
+        unsafe {
+            let (nn_ptr, count) = ActiveArr::<T>::data(self.ptr);
+            forget(self);
+            (nn_ptr, count)
+        }
+    }
+}
+
+impl<T> Drop for HeapArray<T> {
+    fn drop(&mut self) {
+        unsafe {
+            let (start, count) = ActiveArr::<T>::data(self.ptr);
+            let start = start.as_ptr();
+            for i in 0..count {
+                drop_in_place(start.add(i));
+            }
+            ActiveArr::<T>::yeet(self.ptr);
+        }
+    }
+}
+
+impl<T> fmt::Debug for HeapArray<T>
+where
+    [T]: fmt::Debug,
+{
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T> fmt::Pointer for HeapArray<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.ptr, f)
+    }
+}
+
+// === impl HeapFixedVec ===
+
+unsafe impl<T: Send> Send for HeapFixedVec<T> {}
+unsafe impl<T: Sync> Sync for HeapFixedVec<T> {}
+
+impl<T> Deref for HeapFixedVec<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            let (nn_ptr, _count) = ActiveArr::<MaybeUninit<T>>::data(self.ptr);
+            from_raw_parts(nn_ptr.as_ptr().cast::<T>(), self.len)
+        }
+    }
+}
+
+impl<T> DerefMut for HeapFixedVec<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe {
+            let (nn_ptr, _count) = ActiveArr::<MaybeUninit<T>>::data(self.ptr);
+            from_raw_parts_mut(nn_ptr.as_ptr().cast::<T>(), self.len)
+        }
+    }
+}
+
+impl<T> HeapFixedVec<T> {
+    pub fn push(&mut self, item: T) -> Result<(), T> {
+        let (nn_ptr, count) = unsafe { ActiveArr::<MaybeUninit<T>>::data(self.ptr) };
+        if count == self.len {
+            return Err(item);
+        }
+        unsafe {
+            nn_ptr.as_ptr().cast::<T>().add(self.len).write(item);
+            self.len += 1;
+        }
+        Ok(())
+    }
+
+    pub fn is_full(&self) -> bool {
+        let (_nn_ptr, count) = unsafe { ActiveArr::<MaybeUninit<T>>::data(self.ptr) };
+        count == self.len
+    }
+}
+
+impl<T> Drop for HeapFixedVec<T> {
+    fn drop(&mut self) {
+        unsafe {
+            let (start, _count) = ActiveArr::<MaybeUninit<T>>::data(self.ptr);
+            let start = start.as_ptr().cast::<T>();
+            for i in 0..self.len {
+                drop_in_place(start.add(i));
+            }
+            ActiveArr::<MaybeUninit<T>>::yeet(self.ptr);
+        }
+    }
+}
+
+impl<T> fmt::Debug for HeapFixedVec<T>
+where
+    [T]: fmt::Debug,
+{
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T> fmt::Pointer for HeapFixedVec<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.ptr, f)
+    }
+}

--- a/source/alloc/src/heap.rs
+++ b/source/alloc/src/heap.rs
@@ -307,10 +307,10 @@ impl AHeap {
 ///
 /// # Safety
 ///
-/// - `ptr` *must* have been returned by a call to [`Heap::allocate_raw`] or
+/// - `ptr` *must* have been returned by a call to [`AHeap::allocate_raw`] or
 ///   [`HeapGuard::alloc_raw`]!
 /// - `layout` *must* be the same `Layout` that was provided to the original
-///   call to [`Heap::allocate_raw`] or[`HeapGuard::alloc_raw`]!
+///   call to [`AHeap::allocate_raw`] or[`HeapGuard::alloc_raw`]!
 pub unsafe fn deallocate_raw(ptr: NonNull<()>, layout: Layout) {
     let ptr = ActiveUnsized::from_raw(ptr, layout);
     ActiveUnsized::yeet(ptr, layout);

--- a/source/alloc/src/heap.rs
+++ b/source/alloc/src/heap.rs
@@ -1,0 +1,504 @@
+///! Allocation types for the Anachro PC.
+use core::{
+    alloc::Layout,
+    cell::UnsafeCell,
+    marker::PhantomData,
+    mem::MaybeUninit,
+    ptr::NonNull,
+    sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering},
+};
+
+use crate::{
+    containers::{ArcInner, HeapArc, HeapArray, HeapBox, HeapFixedVec},
+    node::{Active, ActiveArr, ActiveUnsized, Node, NodeRef, Recycle},
+};
+
+use cordyceps::mpsc_queue::{Links, MpscQueue};
+use linked_list_allocator::Heap;
+use maitake::sync::WaitQueue;
+
+/// An Anachro Heap item
+pub struct AHeap {
+    freelist: MpscQueue<Recycle>,
+    state: AtomicU8,
+    heap: UnsafeCell<Heap>,
+    heap_wait: WaitQueue,
+    inhibit_alloc: AtomicBool,
+    any_frees: AtomicBool,
+}
+
+// SAFETY: Safety is checked through the `state` member, which uses
+// atomic operations to ensure the data is initialized and exclusively
+// accessed.
+unsafe impl Sync for AHeap {}
+
+impl AHeap {
+    /// The AHeap is initialized, and no `HeapGuard`s are active.
+    const INIT_IDLE: u8 = 1;
+
+    /// The AHeap is "locked", and cannot currently be retrieved. In MOST cases
+    /// this also means the heap is initialized, except for the brief period of
+    /// time while the heap is being initialized.
+    const BUSY_LOCKED: u8 = 2;
+
+    /// Construct a thread safe async allocator from a pool of memory.
+    ///
+    /// Safety: The pool of memory MUST be valid for the 'static lifetime, e.g.
+    /// obtained by a leaked buffer, a linker section, or some other mechanism.
+    /// Additionally, we must semantically have exclusive access to this region
+    /// of memory: There must be no other live references, or pointers to this
+    /// region that are dereferenced after this call.
+    pub unsafe fn bootstrap(addr: *mut u8, size: usize) -> Result<(NonNull<Self>, HeapGuard), ()> {
+        // First, we go all bump-allocator to emplace ourselves within this region
+        let mut cursor = addr;
+        let end = (addr as usize).checked_add(size).ok_or(())?;
+        let mut used = 0;
+
+        let stub_ptr;
+        let aheap_ptr;
+
+        // We start with the stub node required for our mpsc queue.
+        {
+            let stub_layout = Layout::new::<Recycle>();
+            let stub_offset = cursor.align_offset(stub_layout.align());
+            let stub_size = stub_layout.size();
+            used += stub_offset;
+            used += stub_size;
+
+            if used > size {
+                return Err(());
+            }
+
+            cursor = cursor.wrapping_add(stub_offset);
+            stub_ptr = cursor.cast::<Recycle>();
+            stub_ptr.write(Recycle {
+                links: Links::new_stub(),
+                node_layout: stub_layout,
+            });
+            cursor = cursor.add(stub_size);
+        }
+
+        // Next we allocate ourselves
+        {
+            let aheap_layout = Layout::new::<Self>();
+            let aheap_offset = cursor.align_offset(aheap_layout.align());
+            let aheap_size = aheap_layout.size();
+            used += aheap_offset;
+            used += aheap_size;
+
+            if used > size {
+                return Err(());
+            }
+
+            cursor = cursor.wrapping_add(aheap_offset);
+            aheap_ptr = cursor.cast::<Self>();
+
+            // Increment the cursor, as we use it for the heap initialization
+            cursor = cursor.add(aheap_size);
+
+            let heap = Heap::new(cursor, end - (cursor as usize));
+
+            aheap_ptr.write(Self {
+                freelist: MpscQueue::new_with_static_stub(&*stub_ptr),
+                state: AtomicU8::new(Self::BUSY_LOCKED),
+                heap: UnsafeCell::new(heap),
+                heap_wait: WaitQueue::new(),
+                inhibit_alloc: AtomicBool::new(false),
+                any_frees: AtomicBool::new(false),
+            });
+        }
+
+        // Everything else is now our allocation space.
+        let aheap = NonNull::new_unchecked(aheap_ptr);
+        let aheap_ref: &'static AHeap = aheap.as_ref();
+
+        // Creating exclusive access to the inner heap is acceptable, as we
+        // have marked ourselves with "BUSY_LOCKED", acting as a mutex.
+        let guard = HeapGuard { aheap: aheap_ref };
+
+        // Well that went great, I think!
+        Ok((aheap, guard))
+    }
+
+    pub(crate) unsafe fn release_node(&'static self, node: NonNull<Recycle>) {
+        // Can we immediately lock the allocator, avoiding the free list?
+        if let Ok(mut guard) = self.lock() {
+            let layout: Layout = (*node.as_ptr()).node_layout;
+            guard.get_heap().deallocate(node.cast::<u8>(), layout);
+            return;
+        }
+
+        // Nope! Stick it in the free list
+        let node_ref = NodeRef { node };
+        self.freelist.enqueue(node_ref);
+    }
+
+    pub fn poll(&'static self) {
+        let mut hg = self.lock().unwrap();
+
+        // Clean any pending allocs
+        hg.clean_allocs();
+
+        // Did we perform any deallocations?
+        if self.any_frees.swap(false, Ordering::SeqCst) {
+            // Clear the inhibit flag
+            self.inhibit_alloc.store(false, Ordering::SeqCst);
+
+            // Wake any tasks waiting on alloc
+            self.heap_wait.wake_all();
+        }
+    }
+
+    pub fn lock(&'static self) -> Result<HeapGuard, u8> {
+        self.state.compare_exchange(
+            Self::INIT_IDLE,
+            Self::BUSY_LOCKED,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        )?;
+
+        // SAFETY: We are already in the BUSY_LOCKED state, we have exclusive access.
+        Ok(HeapGuard { aheap: self })
+    }
+
+    pub async fn allocate<T>(&'static self, mut item: T) -> HeapBox<T> {
+        loop {
+            // Is the heap inhibited?
+            if !self.inhibit_alloc.load(Ordering::Acquire) {
+                // Can we get an exclusive heap handle?
+                if let Ok(mut hg) = self.lock() {
+                    // Can we allocate our item?
+                    match hg.alloc_box(item) {
+                        Ok(hb) => {
+                            // Yes! Return our allocated item
+                            return hb;
+                        }
+                        Err(it) => {
+                            // Nope, the allocation failed.
+                            item = it;
+                        }
+                    }
+                }
+                // We weren't inhibited before, but something failed. Inhibit
+                // further allocations to prevent starving waiting allocations
+                self.inhibit_alloc.store(true, Ordering::Release);
+            }
+
+            // Didn't succeed, wait until we've done some de-allocations
+            self.heap_wait.wait().await.unwrap();
+        }
+    }
+
+    pub async fn allocate_arc<T>(&'static self, mut item: T) -> HeapArc<T> {
+        loop {
+            // Is the heap inhibited?
+            if !self.inhibit_alloc.load(Ordering::Acquire) {
+                // Can we get an exclusive heap handle?
+                if let Ok(mut hg) = self.lock() {
+                    // Can we allocate our item?
+                    match hg.alloc_arc(item) {
+                        Ok(hb) => {
+                            // Yes! Return our allocated item
+                            return hb;
+                        }
+                        Err(it) => {
+                            // Nope, the allocation failed.
+                            item = it;
+                        }
+                    }
+                }
+                // We weren't inhibited before, but something failed. Inhibit
+                // further allocations to prevent starving waiting allocations
+                self.inhibit_alloc.store(true, Ordering::Release);
+            }
+
+            // Didn't succeed, wait until we've done some de-allocations
+            self.heap_wait.wait().await.unwrap();
+        }
+    }
+
+    pub async fn allocate_array_with<F, T>(&'static self, f: F, count: usize) -> HeapArray<T>
+    where
+        F: Fn() -> T,
+    {
+        loop {
+            // Is the heap inhibited?
+            if !self.inhibit_alloc.load(Ordering::Acquire) {
+                // Can we get an exclusive heap handle?
+                if let Ok(mut hg) = self.lock() {
+                    // Can we allocate our item?
+                    //
+                    // NOTE: We borrow `f`, since `&Fn() -> T` still impls `Fn() -> T`, and allows
+                    // us to potentially call it multiple times.
+                    match hg.alloc_box_array_with(&f, count) {
+                        Ok(hb) => {
+                            // Yes! Return our allocated item
+                            return hb;
+                        }
+                        Err(_) => {
+                            // Nope, the allocation failed.
+                        }
+                    }
+                }
+                // We weren't inhibited before, but something failed. Inhibit
+                // further allocations to prevent starving waiting allocations
+                self.inhibit_alloc.store(true, Ordering::Release);
+            }
+
+            // Didn't succeed, wait until we've done some de-allocations
+            self.heap_wait.wait().await.unwrap();
+        }
+    }
+
+    pub async fn allocate_fixed_vec<T>(&'static self, capacity: usize) -> HeapFixedVec<T> {
+        loop {
+            // Is the heap inhibited?
+            if !self.inhibit_alloc.load(Ordering::Acquire) {
+                // Can we get an exclusive heap handle?
+                if let Ok(mut hg) = self.lock() {
+                    match hg.alloc_fixed_vec(capacity) {
+                        Ok(hb) => {
+                            // Yes! Return our allocated item
+                            return hb;
+                        }
+                        Err(_) => {
+                            // Nope, the allocation failed.
+                        }
+                    }
+                }
+                // We weren't inhibited before, but something failed. Inhibit
+                // further allocations to prevent starving waiting allocations
+                self.inhibit_alloc.store(true, Ordering::Release);
+            }
+
+            // Didn't succeed, wait until we've done some de-allocations
+            self.heap_wait.wait().await.unwrap();
+        }
+    }
+
+    pub async fn allocate_raw(&'static self, layout: Layout) -> NonNull<()> {
+        loop {
+            // Is the heap inhibited?
+            if !self.inhibit_alloc.load(Ordering::Acquire) {
+                // Can we get an exclusive heap handle?
+                if let Ok(mut hg) = self.lock() {
+                    match hg.alloc_raw(layout) {
+                        Ok(hb) => {
+                            // Yes! Return our allocated item
+                            return hb;
+                        }
+                        Err(_) => {
+                            // Nope, the allocation failed.
+                        }
+                    }
+                }
+                // We weren't inhibited before, but something failed. Inhibit
+                // further allocations to prevent starving waiting allocations
+                self.inhibit_alloc.store(true, Ordering::Release);
+            }
+
+            // Didn't succeed, wait until we've done some de-allocations
+            self.heap_wait.wait().await.unwrap();
+        }
+    }
+}
+
+/// Deallocate an unsized allocation with the provided `Layout`.
+///
+/// # Safety
+///
+/// - `ptr` *must* have been returned by a call to [`Heap::allocate_raw`] or
+///   [`HeapGuard::alloc_raw`]!
+/// - `layout` *must* be the same `Layout` that was provided to the original
+///   call to [`Heap::allocate_raw`] or[`HeapGuard::alloc_raw`]!
+pub unsafe fn deallocate_raw(ptr: NonNull<()>, layout: Layout) {
+    let ptr = ActiveUnsized::from_raw(ptr, layout);
+    ActiveUnsized::yeet(ptr, layout);
+}
+
+/// A guard type that provides mutually exclusive access to the allocator as
+/// long as the guard is held.
+pub struct HeapGuard {
+    aheap: &'static AHeap,
+}
+
+// Public HeapGuard methods
+impl HeapGuard {
+    fn get_heap(&mut self) -> &mut Heap {
+        unsafe { &mut *self.aheap.heap.get() }
+    }
+
+    fn clean_allocs(&mut self) {
+        let mut any = false;
+        // Then, free all pending memory in order to maximize space available.
+        let free_list = &self.aheap.freelist;
+        let heap = self.get_heap();
+
+        while let Some(node_ref) = free_list.dequeue() {
+            // defmt::println!("[ALLOC] FREE: {=usize}", layout.size());
+            // SAFETY: We have mutually exclusive access to the allocator, and
+            // the pointer and layout are correctly calculated by the relevant
+            // FreeBox types.
+
+            let layout = unsafe { node_ref.node.as_ref().node_layout };
+            let ptr = node_ref.node.cast::<u8>();
+
+            unsafe {
+                heap.deallocate(ptr, layout);
+                any = true;
+            }
+        }
+
+        if any {
+            self.aheap.any_frees.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Attempt to allocate a HeapBox using the allocator
+    ///
+    /// If space was available, the allocation will be returned. If not, an
+    /// error will be returned
+    pub fn alloc_box<T>(&mut self, data: T) -> Result<HeapBox<T>, T> {
+        // Clean up any pending allocs
+        self.clean_allocs();
+
+        // Then, attempt to allocate the requested T.
+        let nnu8 = match self.get_heap().allocate_first_fit(Layout::new::<Node<T>>()) {
+            Ok(t) => t,
+            Err(_) => return Err(data),
+        };
+        let nn = nnu8.cast::<Active<T>>();
+
+        // And initialize it with the contents given to us
+        unsafe {
+            Active::<T>::write_heap(nn, self.aheap);
+            Active::<T>::data(nn).as_ptr().write(data);
+        }
+
+        Ok(HeapBox {
+            ptr: nn,
+            pd: PhantomData,
+        })
+    }
+
+    /// Attempt to allocate a HeapArc using the allocator
+    ///
+    /// If space was available, the allocation will be returned. If not, an
+    /// error will be returned
+    pub fn alloc_arc<T>(&mut self, data: T) -> Result<HeapArc<T>, T> {
+        // Clean up any pending allocs
+        self.clean_allocs();
+
+        // Then, attempt to allocate the requested T.
+        let nnu8 = match self
+            .get_heap()
+            .allocate_first_fit(Layout::new::<Node<ArcInner<T>>>())
+        {
+            Ok(t) => t,
+            Err(_) => return Err(data),
+        };
+        let nn = nnu8.cast::<Active<ArcInner<T>>>();
+
+        // And initialize it with the contents given to us
+        unsafe {
+            Active::<ArcInner<T>>::write_heap(nn, self.aheap);
+            Active::<ArcInner<T>>::data(nn).as_ptr().write(ArcInner {
+                data,
+                refcnt: AtomicUsize::new(1),
+            });
+        }
+
+        Ok(HeapArc {
+            ptr: nn,
+            pd: PhantomData,
+        })
+    }
+
+    pub fn alloc_box_array_with<T, F>(&mut self, f: F, count: usize) -> Result<HeapArray<T>, ()>
+    where
+        F: Fn() -> T,
+    {
+        // Clean up any pending allocs
+        self.clean_allocs();
+
+        // Then figure out the layout of the requested array. This call fails
+        // if the total size exceeds ISIZE_MAX, which is exceedingly unlikely
+        // (unless the caller calculated something wrong)
+        let layout = unsafe { ActiveArr::<T>::layout_for_arr(count) };
+
+        // Then, attempt to allocate the requested T.
+        let nnu8 = self.get_heap().allocate_first_fit(layout)?;
+        let aa_ptr = nnu8.cast::<ActiveArr<T>>();
+
+        // And initialize it with the contents given to us
+        unsafe {
+            ActiveArr::<T>::write_heap(aa_ptr, self.aheap);
+            ActiveArr::<T>::write_capacity(aa_ptr, count);
+            let (start, count) = ActiveArr::<T>::data(aa_ptr);
+            let start = start.as_ptr();
+            for i in 0..count {
+                start.add(i).write((f)());
+            }
+        }
+
+        Ok(HeapArray {
+            ptr: aa_ptr,
+            pd: PhantomData,
+        })
+    }
+
+    pub fn alloc_fixed_vec<T>(&mut self, capacity: usize) -> Result<HeapFixedVec<T>, ()> {
+        // Clean up any pending allocs
+        self.clean_allocs();
+
+        // Then figure out the layout of the requested array. This call fails
+        // if the total size exceeds ISIZE_MAX, which is exceedingly unlikely
+        // (unless the caller calculated something wrong)
+        let layout = unsafe { ActiveArr::<MaybeUninit<T>>::layout_for_arr(capacity) };
+
+        // Then, attempt to allocate the requested T.
+        let nnu8 = self.get_heap().allocate_first_fit(layout)?;
+        let aa_ptr = nnu8.cast::<ActiveArr<MaybeUninit<T>>>();
+
+        // And initialize it with the contents given to us
+        unsafe {
+            ActiveArr::<MaybeUninit<T>>::write_heap(aa_ptr, self.aheap);
+            ActiveArr::<MaybeUninit<T>>::write_capacity(aa_ptr, capacity);
+            let (start, count) = ActiveArr::<MaybeUninit<T>>::data(aa_ptr);
+            let start = start.as_ptr();
+            for i in 0..count {
+                start.add(i).write(MaybeUninit::uninit());
+            }
+        }
+
+        Ok(HeapFixedVec {
+            ptr: aa_ptr,
+            pd: PhantomData,
+            len: 0,
+        })
+    }
+
+    pub fn alloc_raw(&mut self, layout: Layout) -> Result<NonNull<()>, ()> {
+        // Clean up any pending allocs
+        self.clean_allocs();
+
+        // calculate the layout of the requested allocation
+        let (layout, offset) = ActiveUnsized::layout(layout);
+
+        // Then, attempt to allocate the requested T.
+        let nnu8 = self.get_heap().allocate_first_fit(layout)?;
+        let ptr = nnu8.cast::<ActiveUnsized>();
+
+        unsafe {
+            ActiveUnsized::write_heap(ptr, self.aheap);
+            let data_ptr = ptr.as_ptr().cast::<u8>().add(offset).cast::<()>();
+            Ok(NonNull::new_unchecked(data_ptr))
+        }
+    }
+}
+
+impl Drop for HeapGuard {
+    fn drop(&mut self) {
+        self.aheap.state.store(AHeap::INIT_IDLE, Ordering::SeqCst)
+    }
+}

--- a/source/alloc/src/lib.rs
+++ b/source/alloc/src/lib.rs
@@ -1,0 +1,5 @@
+#![no_std]
+
+pub mod containers;
+pub mod heap;
+pub mod node;

--- a/source/alloc/src/node.rs
+++ b/source/alloc/src/node.rs
@@ -23,7 +23,7 @@ use crate::heap::AHeap;
 /// The Node type is never ACTUALLY created or used directly, but instead
 /// is used as a "superset" of its children to ensure that the alignment
 /// and necessary size are respected at the time of allocation. Allocation
-/// is ALWAYS done as a Node<T>, meaning that conversions from an active
+/// is ALWAYS done as a `Node<T>`, meaning that conversions from an active
 /// type to a Recycle type are always sound.
 #[allow(dead_code)]
 #[repr(C)]
@@ -42,7 +42,7 @@ pub(crate) union Node<T> {
 /// An Active node type
 ///
 /// This type represents a live allocation of a single item, similar to a
-/// Box<T> in liballoc.
+/// `Box<T>` in liballoc.
 ///
 /// It contains a pointer to the allocator, as well as storage for the item.
 ///
@@ -115,7 +115,7 @@ pub(crate) struct Recycle {
 }
 
 impl<T> Active<T> {
-    /// Convert an Active<T> into a Recycle, and release it to be freed
+    /// Convert an `Active<T>` into a `Recycle`, and release it to be freed
     ///
     /// This function does NOT handle dropping of the contained T, which
     /// must be done BEFORE calling this function.
@@ -152,9 +152,9 @@ impl<T> Active<T> {
         NonNull::new_unchecked(ptr)
     }
 
-    /// Set the heap pointer contained within the given Active<T>.
+    /// Set the heap pointer contained within the given `Active<T>`.
     ///
-    /// This should ONLY be used to initialize the Active<T> at time of allocation.
+    /// This should ONLY be used to initialize the `Active<T>` at time of allocation.
     #[inline(always)]
     pub(crate) unsafe fn write_heap(this: NonNull<Active<T>>, heap: *const AHeap) {
         let ptr = this.as_ptr();
@@ -163,8 +163,8 @@ impl<T> Active<T> {
 
     /// Obtain a pointer to the underlying data storage
     ///
-    /// Although Active<T> does not have the same provenance challenges that the
-    /// ActiveArr<T> type has, we use the same `data` interface for reasons of
+    /// Although `Active<T>` does not have the same provenance challenges that the
+    /// `ActiveArr<T>` type has, we use the same `data` interface for reasons of
     /// consistency. This also ensures that reordering or other modifications of
     /// the underlying node type do not require changes elsewhere.
     #[inline(always)]
@@ -178,7 +178,7 @@ impl<T> Active<T> {
 impl<T> ActiveArr<T> {
     /// Obtain a valid layout for an ActiveArr
     ///
-    /// As we can't directly create a `Layout` type for our Node<T>/ActiveArr<T>
+    /// As we can't directly create a `Layout` type for our `Node<T>`/`ActiveArr<T>`
     /// because of the `!Sized` nature of `[T]`, we instead do manual layout
     /// surgery here instead. This function takes the alignment necessary for
     /// a `Node<T>`, but also increases the size to accomodate a `[T]` with
@@ -200,9 +200,9 @@ impl<T> ActiveArr<T> {
         Layout::from_size_align_unchecked(size, layout_node.align())
     }
 
-    /// Set the heap pointer contained within the given ActiveArr<T>.
+    /// Set the heap pointer contained within the given `ActiveArr<T>`.
     ///
-    /// This should ONLY be used to initialize the ActiveArr<T> at time of allocation.
+    /// This should ONLY be used to initialize the `ActiveArr<T>` at time of allocation.
     #[inline(always)]
     pub(crate) unsafe fn write_heap(this: NonNull<ActiveArr<T>>, heap: *const AHeap) {
         let ptr = this.as_ptr();
@@ -229,7 +229,7 @@ impl<T> ActiveArr<T> {
         (nn, size)
     }
 
-    /// Convert an Active<T> into a Recycle, and release it to be freed
+    /// Convert an `Active<T>` into a Recycle, and release it to be freed
     ///
     /// This function does NOT handle dropping of the contained `[T]`, which
     /// must be done BEFORE calling this function.

--- a/source/alloc/src/node.rs
+++ b/source/alloc/src/node.rs
@@ -1,0 +1,330 @@
+//! # `mnemos-alloc` Allocation Nodes
+//!
+//! These types represent the "behind the scenes" underlying types necessary
+//! to safely enable the behaviors of the async allocation layer.
+//!
+//! These types are used by the `heap` module when allocating or freeing
+//! an element, and are the "inner" types used by the `containers` module
+//! to provide user-accessible types.
+//!
+//! This module has VERY PARTICULAR safety guarantees and concerns, and as
+//! such these abstractions are not made crate-public, and kept private
+//! within this module as much as is reasonably possible.
+
+use cordyceps::{mpsc_queue::Links, Linked};
+use core::mem::{ManuallyDrop, MaybeUninit};
+use core::ptr::{addr_of, null};
+use core::{alloc::Layout, ptr::NonNull};
+
+use crate::heap::AHeap;
+
+/// The heap allocation Node type
+///
+/// The Node type is never ACTUALLY created or used directly, but instead
+/// is used as a "superset" of its children to ensure that the alignment
+/// and necessary size are respected at the time of allocation. Allocation
+/// is ALWAYS done as a Node<T>, meaning that conversions from an active
+/// type to a Recycle type are always sound.
+#[allow(dead_code)]
+#[repr(C)]
+pub(crate) union Node<T> {
+    // These are "active" types - e.g. they contain a live allocation
+    active: ManuallyDrop<Active<T>>,
+    active_arr: ManuallyDrop<ActiveArr<T>>,
+    active_unsized: ManuallyDrop<ActiveUnsized>,
+
+    // This is the "recycle" type - after the contents of the allocation
+    // has been retired, but the node still needs to be dropped via the
+    // actual underlying allocator
+    recycle: ManuallyDrop<Recycle>,
+}
+
+/// An Active node type
+///
+/// This type represents a live allocation of a single item, similar to a
+/// Box<T> in liballoc.
+///
+/// It contains a pointer to the allocator, as well as storage for the item.
+///
+/// The contained data MUST be valid for the lifetime of the `Active<T>`.
+#[repr(C)]
+pub(crate) struct Active<T> {
+    heap: *const AHeap,
+    data: T,
+}
+
+/// An Active Array node type
+///
+/// This type represents a live allocation of a dynamic number of items,
+/// similar to a `Box<[T]>` in liballoc. Note that this is NOT the same as
+/// a `Vec<T>`, which can be dynamically resized. The underlying storage
+/// here is always a fixed size, however that fixed size is chosen at
+/// runtime, rather than at compile time.
+///
+/// It contains a pointer to the allocator, as well as storage for the items.
+///
+/// The contained data MUST be valid for the lifetime of the `ActiveArr<T>`.
+///
+/// The ActiveArr type itself actually contains storage for zero `T` items, however
+/// it uses a `[T; 0]` to force the correct alignment of the `data` field. This
+/// allows us to add `size_of::<T>() * N` bytes directly following the item, which
+/// can be indexed starting at the address of the `data` field. This is done by
+/// over-allocating space, and using the `ActiveArr::data` function to obtain
+/// access to the array storage.
+///
+/// NOTE: Although the `data` field is not public (even within the crate),
+/// EXTREME CARE must be taken NOT to access the data field through a reference
+/// to an ActiveArr type. Creating a reference (rather than a pointer) to the
+/// ActiveArr type itself serves as a "narrowing" of the provenance, which means
+/// that accessing out of bound elements of `data` (which is ALL of them, as
+/// data "officially" has an array length of zero) is undefined behavior.
+///
+/// The `ActiveArr::data` function handles this by using the `addr_of!` macro
+/// to obtain the pointer of the underlying array storage, WITHOUT narrowing
+/// the provenance of the outer "supersized" allocation.
+#[repr(C)]
+pub(crate) struct ActiveArr<T> {
+    heap: *const AHeap,
+    capacity: usize,
+    data: [T; 0],
+}
+
+#[repr(C)]
+pub(crate) struct ActiveUnsized {
+    heap: *const AHeap,
+}
+
+/// A Recycle node type
+///
+/// Recycle is the "terminal state" of all allocations. After the actual
+/// heap allocated data has been dropped, all active allocations become
+/// a Recycle node. Allocations remain in this state until they have been
+/// freed by the underlying allocator.
+///
+/// In the fast path, a Recycle node is dropped directly by the allocator.
+/// In the slow path, the intrusive linked list header contained within
+/// a Recycle node is used to "send" the allocation to a lock-free, intrusive
+/// MpscQueue, where it will live until the allocator cleans up the pending
+/// freelist items.
+#[repr(C)]
+pub(crate) struct Recycle {
+    // THIS MUST be the first item!
+    pub(crate) links: Links<Recycle>,
+    // This is the layout of the ENTIRE Node<T>, NOT just the payload.
+    pub(crate) node_layout: Layout,
+}
+
+impl<T> Active<T> {
+    /// Convert an Active<T> into a Recycle, and release it to be freed
+    ///
+    /// This function does NOT handle dropping of the contained T, which
+    /// must be done BEFORE calling this function.
+    #[inline]
+    pub(crate) unsafe fn yeet(mut ptr: NonNull<Active<T>>) {
+        let heap = ptr.as_mut().heap;
+        let ptr: NonNull<Recycle> = ptr.cast();
+
+        ptr.as_ptr().write(Recycle {
+            links: Links::new(),
+            node_layout: Layout::new::<Node<T>>(),
+        });
+
+        (*heap).release_node(ptr);
+    }
+
+    #[inline(always)]
+    fn data_offset() -> isize {
+        let dummy: Active<MaybeUninit<T>> = Active {
+            heap: null(),
+            data: MaybeUninit::uninit(),
+        };
+        let data_ptr = addr_of!(dummy.data);
+        let dummy_ptr: *const Active<MaybeUninit<T>> = &dummy;
+        unsafe { dummy_ptr.cast::<u8>().offset_from(data_ptr.cast::<u8>()) }
+    }
+
+    pub(crate) unsafe fn from_leaked_ptr(data: NonNull<T>) -> NonNull<Active<T>> {
+        let ptr = data
+            .cast::<u8>()
+            .as_ptr()
+            .offset(Self::data_offset())
+            .cast::<Active<T>>();
+        NonNull::new_unchecked(ptr)
+    }
+
+    /// Set the heap pointer contained within the given Active<T>.
+    ///
+    /// This should ONLY be used to initialize the Active<T> at time of allocation.
+    #[inline(always)]
+    pub(crate) unsafe fn write_heap(this: NonNull<Active<T>>, heap: *const AHeap) {
+        let ptr = this.as_ptr();
+        core::ptr::addr_of_mut!((*ptr).heap).write(heap);
+    }
+
+    /// Obtain a pointer to the underlying data storage
+    ///
+    /// Although Active<T> does not have the same provenance challenges that the
+    /// ActiveArr<T> type has, we use the same `data` interface for reasons of
+    /// consistency. This also ensures that reordering or other modifications of
+    /// the underlying node type do not require changes elsewhere.
+    #[inline(always)]
+    pub(crate) unsafe fn data(this: NonNull<Active<T>>) -> NonNull<T> {
+        let ptr = this.as_ptr();
+        let dptr = core::ptr::addr_of_mut!((*ptr).data);
+        NonNull::new_unchecked(dptr)
+    }
+}
+
+impl<T> ActiveArr<T> {
+    /// Obtain a valid layout for an ActiveArr
+    ///
+    /// As we can't directly create a `Layout` type for our Node<T>/ActiveArr<T>
+    /// because of the `!Sized` nature of `[T]`, we instead do manual layout
+    /// surgery here instead. This function takes the alignment necessary for
+    /// a `Node<T>`, but also increases the size to accomodate a `[T]` with
+    /// a size of the given `ct` parameter.
+    ///
+    /// The given layout will always have a size >= the size of a `Node<T>`, even
+    /// if the `ActiveArr<T> + [T]` would be smaller than a `Node<T>`.
+    #[inline]
+    pub(crate) unsafe fn layout_for_arr(ct: usize) -> Layout {
+        let layout_node = Layout::new::<Node<T>>();
+        let layout_acta = Layout::new::<ActiveArr<T>>();
+        let arr_size = core::mem::size_of::<T>() * ct;
+        let size = layout_acta.size() + arr_size;
+        let size = core::cmp::max(layout_node.size(), size);
+
+        // We take the ALIGNMENT from the `Node`, which is a superset
+        // type, and the SIZE from either the (ActiveArr + Array) OR
+        // Node, whichever is larger
+        Layout::from_size_align_unchecked(size, layout_node.align())
+    }
+
+    /// Set the heap pointer contained within the given ActiveArr<T>.
+    ///
+    /// This should ONLY be used to initialize the ActiveArr<T> at time of allocation.
+    #[inline(always)]
+    pub(crate) unsafe fn write_heap(this: NonNull<ActiveArr<T>>, heap: *const AHeap) {
+        let ptr = this.as_ptr();
+        core::ptr::addr_of_mut!((*ptr).heap).write(heap);
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn write_capacity(this: NonNull<ActiveArr<T>>, capacity: usize) {
+        let ptr = this.as_ptr();
+        core::ptr::addr_of_mut!((*ptr).capacity).write(capacity);
+    }
+
+    /// Obtain a pointer to the start of the array storage, as well as the length of the array
+    ///
+    /// NOTE: This VERY CAREFULLY avoids issues of provenance due to accessing "out of bounds"
+    /// of the `data` field of the `ActiveArr` type. See the docs of the ActiveArr type for
+    /// a more detailed discussion of these particularities.
+    #[inline(always)]
+    pub(crate) unsafe fn data(this: NonNull<ActiveArr<T>>) -> (NonNull<T>, usize) {
+        let size = this.as_ref().capacity;
+        let tptr = this.as_ptr();
+        let daddr = core::ptr::addr_of_mut!((*tptr).data);
+        let nn = NonNull::new_unchecked(daddr.cast::<T>());
+        (nn, size)
+    }
+
+    /// Convert an Active<T> into a Recycle, and release it to be freed
+    ///
+    /// This function does NOT handle dropping of the contained `[T]`, which
+    /// must be done BEFORE calling this function.
+    #[inline]
+    pub(crate) unsafe fn yeet(mut ptr: NonNull<ActiveArr<T>>) {
+        let heap = ptr.as_mut().heap;
+        let capacity = ptr.as_mut().capacity;
+
+        let ptr: NonNull<Recycle> = ptr.cast();
+        let layout = Self::layout_for_arr(capacity);
+
+        ptr.as_ptr().write(Recycle {
+            links: Links::new(),
+            node_layout: layout,
+        });
+
+        (*heap).release_node(ptr);
+    }
+}
+
+impl ActiveUnsized {
+    /// Obtain a valid layout for an ActiveUnsized with an inner allocation of
+    /// the requested `Layout`.
+    #[inline]
+    pub(crate) fn layout(layout_inner: Layout) -> (Layout, usize) {
+        let layout_node = Layout::new::<Node<()>>();
+        let (mut layout, offset) = Layout::new::<*const AHeap>().extend(layout_inner).unwrap();
+        // round up to ensure we can fit a `Node`
+        if layout_node.size() > layout.size() {
+            layout = layout_node;
+        }
+        (layout, offset)
+    }
+
+    /// Set the heap pointer contained within the given `ActiveUnsized`.
+    ///
+    /// This should ONLY be used to initialize the `ActiveUnsized` at time of allocation.
+    #[inline(always)]
+    pub(crate) unsafe fn write_heap(this: NonNull<Self>, heap: *const AHeap) {
+        let ptr = this.as_ptr();
+        core::ptr::addr_of_mut!((*ptr).heap).write(heap);
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn from_raw(data: NonNull<()>, layout_inner: Layout) -> NonNull<Self> {
+        let (_layout, offset) = Self::layout(layout_inner);
+        let ptr = data.cast::<u8>().as_ptr().sub(offset).cast::<Self>();
+        NonNull::new_unchecked(ptr)
+    }
+
+    /// Convert an `ActiveUnsized` into a Recycle, and release it to be freed.
+    ///
+    /// # Safety
+    ///
+    /// The provided `Layout` *must* be the same as the `ActiveUnsized`'s
+    /// original allocated `Layout`!
+    #[inline]
+    pub(crate) unsafe fn yeet(mut ptr: NonNull<Self>, layout: Layout) {
+        let heap = ptr.as_mut().heap;
+
+        let ptr: NonNull<Recycle> = ptr.cast();
+        let (layout, _) = Self::layout(layout);
+
+        ptr.as_ptr().write(Recycle {
+            links: Links::new(),
+            node_layout: layout,
+        });
+
+        (*heap).release_node(ptr);
+    }
+}
+
+impl<T> Drop for Node<T> {
+    fn drop(&mut self) {
+        panic!("Nodes should never be directly dropped!");
+    }
+}
+
+/// A handle that is used by the mpsc freelist to hold a linked list of Recycle nodes
+pub(crate) struct NodeRef {
+    pub(crate) node: NonNull<Recycle>,
+}
+
+unsafe impl Linked<Links<Recycle>> for Recycle {
+    type Handle = NodeRef;
+
+    fn into_ptr(r: Self::Handle) -> NonNull<Self> {
+        r.node
+    }
+
+    unsafe fn from_ptr(ptr: NonNull<Self>) -> Self::Handle {
+        NodeRef { node: ptr }
+    }
+
+    unsafe fn links(ptr: NonNull<Self>) -> NonNull<Links<Recycle>> {
+        ptr.cast::<Links<Recycle>>()
+    }
+}

--- a/source/alloc/tests/smoke.rs
+++ b/source/alloc/tests/smoke.rs
@@ -1,0 +1,177 @@
+use std::ptr::{addr_of_mut, NonNull};
+use std::{alloc::Layout, ops::Deref};
+
+use mnemos_alloc::heap::deallocate_raw;
+use mnemos_alloc::{
+    containers::{HeapArray, HeapBox},
+    heap::AHeap,
+};
+
+#[derive(Debug, Eq, PartialEq)]
+struct Demo {
+    one: u64,
+    two: u8,
+    three: [u16; 7],
+}
+
+#[test]
+fn basic() {
+    const SIZE: usize = 16 * 1024;
+
+    let bufptr = Box::into_raw(Box::new([0u8; SIZE]));
+    let (_heap, mut guard) = unsafe { AHeap::bootstrap(bufptr.cast::<u8>(), SIZE).unwrap() };
+
+    let alloc_1 = guard
+        .alloc_box(Demo {
+            one: 123,
+            two: 222,
+            three: [0xABAB; 7],
+        })
+        .map_err(drop)
+        .unwrap();
+    let alloc_2 = guard
+        .alloc_box(Demo {
+            one: 111,
+            two: 212,
+            three: [0xCACA; 7],
+        })
+        .map_err(drop)
+        .unwrap();
+
+    drop(alloc_1);
+    drop(guard);
+    drop(alloc_2);
+}
+
+#[test]
+fn basic_arr() {
+    const SIZE: usize = 16 * 1024;
+
+    let bufptr = Box::into_raw(Box::new([0u8; SIZE]));
+    let (_heap, mut guard) = unsafe { AHeap::bootstrap(bufptr.cast::<u8>(), SIZE).unwrap() };
+
+    let alloc_1: HeapArray<u16> = guard.alloc_box_array_with(|| 0xACAC, 42).unwrap();
+    let alloc_2: HeapArray<u16> = guard.alloc_box_array_with(|| 0x4242, 27).unwrap();
+
+    drop(alloc_1);
+    drop(guard);
+    drop(alloc_2);
+}
+
+#[test]
+fn basic_raw() {
+    const SIZE: usize = 16 * 1024;
+
+    const ALLOC_1_F64S: usize = 12;
+    const ALLOC_2_U64S: usize = 17;
+
+    let bufptr = Box::into_raw(Box::new([0u8; SIZE]));
+    let (_heap, mut guard) = unsafe { AHeap::bootstrap(bufptr.cast::<u8>(), SIZE).unwrap() };
+
+    #[repr(C)]
+    struct Tail {
+        a: u8,
+        b: u128,
+        c: [u64; 0],
+    }
+
+    #[repr(align(32))]
+    struct Items {
+        d: [u8; 64],
+    }
+
+    let layout_1 = Layout::array::<f64>(ALLOC_1_F64S).unwrap();
+    let (layout_2, _) = Layout::new::<Tail>()
+        .extend(Layout::array::<u64>(ALLOC_2_U64S).unwrap())
+        .unwrap();
+    let layout_3 = Layout::new::<Items>();
+
+    let alloc_1: NonNull<()> = guard.alloc_raw(layout_1).unwrap();
+    let alloc_2: NonNull<()> = guard.alloc_raw(layout_2).unwrap();
+    let alloc_3: NonNull<()> = guard.alloc_raw(layout_3).unwrap();
+
+    // Write the full contents of alloc 1
+    for i in 0..ALLOC_1_F64S {
+        unsafe {
+            alloc_1.cast::<f64>().as_ptr().add(i).write(1.2345f64);
+        }
+    }
+    // read it back
+    let sli = unsafe { core::slice::from_raw_parts(alloc_1.cast::<f64>().as_ptr(), ALLOC_1_F64S) };
+    assert!(sli.iter().all(|f| *f == 1.2345f64));
+
+    unsafe {
+        // Write the full contents of alloc 2
+        let ptr2 = alloc_2.cast::<Tail>().as_ptr();
+        addr_of_mut!((*ptr2).a).write(10);
+        addr_of_mut!((*ptr2).b).write(u128::MAX - 3);
+        let base = addr_of_mut!((*ptr2).c).cast::<u64>();
+        for i in 0..ALLOC_2_U64S {
+            base.add(i).write(u64::MAX - (i as u64));
+        }
+
+        // read it back
+        assert_eq!((&*ptr2).a, 10);
+        assert_eq!((&*ptr2).b, u128::MAX - 3);
+        let sli = core::slice::from_raw_parts(base, ALLOC_2_U64S);
+        assert!(sli
+            .iter()
+            .enumerate()
+            .all(|(i, u)| *u == (u64::MAX - i as u64)));
+    }
+
+    unsafe {
+        // Write the full contents of alloc 3
+        let ptr3 = alloc_3.cast::<Items>().as_ptr();
+        ptr3.as_mut().unwrap().d.iter_mut().for_each(|i| *i = 123);
+        (&*ptr3).d.iter().for_each(|i| assert_eq!(*i, 123));
+    }
+
+    unsafe {
+        deallocate_raw(alloc_1, layout_1);
+    }
+    drop(guard);
+    unsafe {
+        deallocate_raw(alloc_2, layout_2);
+        deallocate_raw(alloc_3, layout_3);
+    }
+}
+
+#[test]
+fn leak_unleak() {
+    const SIZE: usize = 16 * 1024;
+
+    let bufptr = Box::into_raw(Box::new([0u8; SIZE]));
+    let (_heap, mut guard) = unsafe { AHeap::bootstrap(bufptr.cast::<u8>(), SIZE).unwrap() };
+
+    let alloc_1 = guard
+        .alloc_box(Demo {
+            one: 123,
+            two: 222,
+            three: [0xABAB; 7],
+        })
+        .map_err(drop)
+        .unwrap();
+
+    let leaked_nn: NonNull<Demo> = alloc_1.leak();
+
+    assert_eq!(
+        unsafe { leaked_nn.as_ref() },
+        &Demo {
+            one: 123,
+            two: 222,
+            three: [0xABAB; 7],
+        }
+    );
+
+    let unleaked: HeapBox<Demo> = unsafe { HeapBox::from_leaked(leaked_nn) };
+
+    assert_eq!(
+        unleaked.deref(),
+        &Demo {
+            one: 123,
+            two: 222,
+            three: [0xABAB; 7],
+        }
+    );
+}


### PR DESCRIPTION
This undoes a decision from about a year ago to move the allocator into its own crate.

Merged as an "unrelated history", meaning all history is retained.

This should NOT be a squash merge.