### PR TITLE
Restore missing commit from mnemos-alloc repo.

### DIFF
--- a/source/alloc/src/heap.rs
+++ b/source/alloc/src/heap.rs
@@ -31,6 +31,7 @@ pub struct AHeap {
 // atomic operations to ensure the data is initialized and exclusively
 // accessed.
 unsafe impl Sync for AHeap {}
+unsafe impl Send for AHeap {}
 
 impl AHeap {
     /// The AHeap is initialized, and no `HeapGuard`s are active.

--- a/source/alloc/tests/smoke.rs
+++ b/source/alloc/tests/smoke.rs
@@ -175,3 +175,16 @@ fn leak_unleak() {
         }
     );
 }
+
+#[test]
+fn allocating_futures_are_send() {
+    const SIZE: usize = 16 * 1024;
+    fn assert_send<T: Send>(_t: T) {}
+
+    let bufptr = Box::into_raw(Box::new([0u8; SIZE]));
+    let (heap, mut guard) = unsafe { AHeap::bootstrap(bufptr.cast::<u8>(), SIZE).unwrap() };
+    let heap = unsafe { heap.as_ref() };
+    assert_send(heap.allocate_arc(1));
+    assert_send(heap.allocate_array_with(|| 1, 1));
+    assert_send(heap.allocate(1));
+}


### PR DESCRIPTION
This commit was missed when I merged from the upstream repo:

https://github.com/tosc-rs/mnemos-alloc/pull/9

commit 3b1b16d7c04f312a27befb1f1f7691f5f63cfb47
Author: Eliza Weisman <eliza@buoyant.io>
Date:   Thu Jun 1 08:15:12 2023 -0700

  add missing `Send` impl for `AHeap` (#9)

  Currently, any Future that awaits one of the AHeap allocate,
  allocate_arc, allocate_array_with, or allocate_fixed_vec methods
  is !Send. This is because these methods return a Future which
  contains a &self receiver, and the AHeap type itself is !Send.
  This is sad and not very great.

  This branch adds a missing Send impl to AHeap. This should be safe
  for the same reason that the existing unsafe impl Sync for AHeap is
  safe.

  * add test asserting heap futures are Send
  * add missing Send impl for AHeap