### PR TITLE
feat(melpo): fake "wait for interrupt"

### DIFF
--- a/source/melpomene/Cargo.toml
+++ b/source/melpomene/Cargo.toml
@@ -51,7 +51,7 @@ optional = true
 
 [dependencies.tokio]
 version = "1.19"
-features = ["rt", "time", "macros"]
+features = ["rt", "time", "macros", "sync"]
 
 [dependencies.clap]
 version = "3.0"


### PR DESCRIPTION
This branch changes Melpomene's kernel main loop to behave somewhat more
like a "real" kernel on hardware would, by waiting for a (simulated)
interrupt or timer when the kernel executor has nothing else to do.
Since the simulator does not handle real hardware interrupts, we fake an
"interrupt" using a `tokio::sync::Notify` that the simulated kernel task
awaits when it is waiting for an interrupt. The simulated drivers wake
this `Notify` when they receive a "hardware interrupt".