### PR TITLE
feat(forth3): return interpreter actions from builtins

### DIFF
--- a/source/forth3/src/dictionary.rs
+++ b/source/forth3/src/dictionary.rs
@@ -690,8 +690,7 @@ pub mod test {
     use crate::{
         dictionary::{BuiltinEntry, DictLocation, DictionaryBump, DictionaryEntry},
         leakbox::{alloc_dict, LeakBox, LeakBoxDict},
-        vm::InterpretAction,
-        Error, Forth, Word,
+        Forth, ForthResult, Word,
     };
 
     #[cfg(feature = "async")]
@@ -773,7 +772,7 @@ pub mod test {
 
     #[test]
     fn allocs_work() {
-        fn stubby(_f: &mut Forth<()>) -> Result<InterpretAction, Error> {
+        fn stubby(_f: &mut Forth<()>) -> ForthResult {
             panic!("Don't ACTUALLY call me!");
         }
 
@@ -790,7 +789,7 @@ pub mod test {
 
     #[test]
     fn fork_onto_works() {
-        fn stubby(_f: &mut Forth<()>) -> Result<InterpretAction, Error> {
+        fn stubby(_f: &mut Forth<()>) -> ForthResult {
             panic!("Don't ACTUALLY call me!");
         }
 

--- a/source/forth3/src/dictionary.rs
+++ b/source/forth3/src/dictionary.rs
@@ -690,6 +690,7 @@ pub mod test {
     use crate::{
         dictionary::{BuiltinEntry, DictLocation, DictionaryBump, DictionaryEntry},
         leakbox::{alloc_dict, LeakBox, LeakBoxDict},
+        vm::InterpretAction,
         Error, Forth, Word,
     };
 
@@ -772,7 +773,7 @@ pub mod test {
 
     #[test]
     fn allocs_work() {
-        fn stubby(_f: &mut Forth<()>) -> Result<(), Error> {
+        fn stubby(_f: &mut Forth<()>) -> Result<InterpretAction, Error> {
             panic!("Don't ACTUALLY call me!");
         }
 
@@ -789,7 +790,7 @@ pub mod test {
 
     #[test]
     fn fork_onto_works() {
-        fn stubby(_f: &mut Forth<()>) -> Result<(), Error> {
+        fn stubby(_f: &mut Forth<()>) -> Result<InterpretAction, Error> {
             panic!("Don't ACTUALLY call me!");
         }
 

--- a/source/forth3/src/dictionary.rs
+++ b/source/forth3/src/dictionary.rs
@@ -216,7 +216,7 @@ pub trait AsyncBuiltins<'forth, T: 'static> {
     /// VM. This allows the VM's stacks to be mutated by the async builtin function.
     ///
     /// [`Future`]: core::future::Future
-    type Future: core::future::Future<Output = Result<(), crate::Error>>;
+    type Future: core::future::Future<Output = Result<crate::vm::InterpretAction, crate::Error>>;
 
     /// A static slice of [`AsyncBuiltinEntry`]s describing the builtins
     /// provided by this implementation of `AsyncBuiltin`s.

--- a/source/forth3/src/lib.rs
+++ b/source/forth3/src/lib.rs
@@ -26,7 +26,7 @@ use dictionary::AsyncBuiltinEntry;
 
 #[cfg(feature = "async")]
 pub use crate::vm::AsyncForth;
-pub use crate::vm::Forth;
+pub use crate::vm::{Forth, ForthResult, InterpretAction};
 use crate::{
     dictionary::{BumpError, DictionaryEntry},
     output::OutputError,
@@ -200,7 +200,7 @@ impl<T: 'static> CallContext<T> {
 ///
 /// It takes the current "full context" (e.g. `Fif`), as well as the CFA pointer
 /// to the dictionary entry.
-type WordFunc<T> = fn(&mut Forth<T>) -> Result<vm::InterpretAction, Error>;
+type WordFunc<T> = fn(&mut Forth<T>) -> ForthResult;
 
 pub enum Lookup<T: 'static> {
     Dict(DictLocation<T>),
@@ -257,7 +257,7 @@ pub mod test {
         testutil::{all_runtest, blocking_runtest_with},
         vm,
         word::Word,
-        Error, Forth,
+        Error, Forth, ForthResult,
     };
 
     #[derive(Default)]
@@ -698,7 +698,7 @@ pub mod test {
     }
 
     impl<'forth> Future for CountingFut<'forth> {
-        type Output = Result<vm::InterpretAction, Error>;
+        type Output = ForthResult;
 
         fn poll(
             mut self: core::pin::Pin<&mut Self>,

--- a/source/forth3/src/lib.rs
+++ b/source/forth3/src/lib.rs
@@ -686,7 +686,7 @@ pub mod test {
 
     fn print_dict(name: &str, forth: &mut Forth<TestContext>) {
         forth.input.fill("dict").unwrap();
-        forth.execute().unwrap();
+        forth.process_line().unwrap();
         println!("{name} {}", forth.output.as_str());
         forth.output.clear();
     }

--- a/source/forth3/src/lib.rs
+++ b/source/forth3/src/lib.rs
@@ -204,7 +204,7 @@ impl<T: 'static> CallContext<T> {
 ///
 /// It takes the current "full context" (e.g. `Fif`), as well as the CFA pointer
 /// to the dictionary entry.
-type WordFunc<T> = fn(&mut Forth<T>) -> Result<(), Error>;
+type WordFunc<T> = fn(&mut Forth<T>) -> Result<vm::InterpretAction, Error>;
 
 pub enum Lookup<T: 'static> {
     Dict(DictLocation<T>),
@@ -689,7 +689,7 @@ pub mod test {
 
     fn print_dict(name: &str, forth: &mut Forth<TestContext>) {
         forth.input.fill("dict").unwrap();
-        forth.process_line().unwrap();
+        forth.execute().unwrap();
         println!("{name} {}", forth.output.as_str());
         forth.output.clear();
     }

--- a/source/forth3/src/testutil/mod.rs
+++ b/source/forth3/src/testutil/mod.rs
@@ -188,7 +188,7 @@ fn blocking_steps_with<T>(steps: &[Step], forth: &mut Forth<T>) {
         #[cfg(not(miri))]
         println!("> {input}");
         forth.input.fill(input).unwrap();
-        let res = forth.execute();
+        let res = forth.process_line();
         check_output(res, outcome, forth.output.as_str());
         forth.output.clear();
     }

--- a/source/forth3/src/testutil/mod.rs
+++ b/source/forth3/src/testutil/mod.rs
@@ -55,7 +55,7 @@
 
 use crate::{
     leakbox::{LBForth, LBForthParams},
-    Error, Forth,
+    vm, Error, Forth,
 };
 
 /// Run the given forth ui test against ALL enabled forth VMs
@@ -151,12 +151,12 @@ where
     }
 }
 
-fn check_output(res: Result<(), Error>, outcome: &Outcome, output: &str) {
+fn check_output(res: Result<vm::InterpretAction, Error>, outcome: &Outcome, output: &str) {
     #[cfg(not(miri))]
     println!("< {output}");
     match (res, outcome) {
-        (Ok(()), Outcome::OkAnyOutput) => {}
-        (Ok(()), Outcome::OkWithOutput(exp)) => {
+        (Ok(_), Outcome::OkAnyOutput) => {}
+        (Ok(_), Outcome::OkWithOutput(exp)) => {
             let act_lines = output.lines().collect::<Vec<&str>>();
             assert_eq!(act_lines.len(), exp.len());
             act_lines.iter().zip(exp.iter()).for_each(|(a, e)| {
@@ -188,7 +188,7 @@ fn blocking_steps_with<T>(steps: &[Step], forth: &mut Forth<T>) {
         #[cfg(not(miri))]
         println!("> {input}");
         forth.input.fill(input).unwrap();
-        let res = forth.process_line();
+        let res = forth.execute();
         check_output(res, outcome, forth.output.as_str());
         forth.output.clear();
     }

--- a/source/forth3/src/testutil/mod.rs
+++ b/source/forth3/src/testutil/mod.rs
@@ -101,7 +101,7 @@ pub fn async_blockon_runtest(contents: &str) {
 
     struct TestAsyncDispatcher;
     impl<'forth> AsyncBuiltins<'forth, ()> for TestAsyncDispatcher {
-        type Future = futures::future::Ready<Result<(), Error>>;
+        type Future = futures::future::Ready<Result<vm::InterpretAction, Error>>;
         const BUILTINS: &'static [AsyncBuiltinEntry<()>] = &[];
         fn dispatch_async(&self, _id: &FaStr, _forth: &'forth mut Forth<()>) -> Self::Future {
             unreachable!("no async builtins should be called in this test")

--- a/source/forth3/src/vm/async_vm.rs
+++ b/source/forth3/src/vm/async_vm.rs
@@ -180,22 +180,31 @@ where
         &mut self.vm
     }
 
-    pub async fn process_line(&mut self) -> Result<(), Error> {
+    pub async fn process_line(&mut self) -> Result<InterpretAction, Error> {
         let res = async {
             loop {
                 match self.vm.start_processing_line()? {
                     ProcessAction::Done => {
                         self.vm.output.push_str("ok.\n")?;
-                        break Ok(());
+                        break Ok(InterpretAction::Done);
                     }
                     ProcessAction::Continue => {}
-                    ProcessAction::Execute => while self.async_pig().await? != Step::Done {},
+                    ProcessAction::Execute => {
+                        // Loop until execution completes.
+                        let mut step = InterpretAction::Continue;
+                        while step == InterpretAction::Continue {
+                            step = self.async_pig().await?;
+                        }
+                        if step == InterpretAction::AcceptInput {
+                            return Ok(InterpretAction::AcceptInput);
+                        }
+                    }
                 }
             }
         }
         .await;
         match res {
-            Ok(_) => Ok(()),
+            Ok(res) => Ok(res),
             Err(e) => {
                 self.vm.data_stack.clear();
                 self.vm.return_stack.clear();
@@ -206,7 +215,7 @@ where
     }
 
     // Single step execution (async version).
-    async fn async_pig(&mut self) -> Result<Step, Error> {
+    async fn async_pig(&mut self) -> Result<InterpretAction, Error> {
         let Self {
             ref mut vm,
             ref builtins,
@@ -214,7 +223,7 @@ where
 
         let top = match vm.call_stack.try_peek() {
             Ok(t) => t,
-            Err(StackError::StackEmpty) => return Ok(Step::Done),
+            Err(StackError::StackEmpty) => return Ok(InterpretAction::Done),
             Err(e) => return Err(Error::Stack(e)),
         };
 
@@ -225,20 +234,19 @@ where
                 EntryKind::RuntimeBuiltin => (top.eh.cast::<BuiltinEntry<T>>().as_ref().func)(vm),
                 EntryKind::Dictionary => (top.eh.cast::<DictionaryEntry<T>>().as_ref().func)(vm),
                 EntryKind::AsyncBuiltin => builtins.dispatch_async(&top.eh.as_ref().name, vm).await,
-            }
+            }?
         };
 
-        match res {
-            Ok(_) => {
-                let _ = vm.call_stack.pop();
-            }
-            Err(Error::PendingCallAgain) => {
-                // ok, just don't pop
-            }
-            Err(e) => return Err(e),
+        if res != InterpretAction::Continue {
+            // current word completed, so remove it from the call stack.
+            let _ = self.vm.call_stack.pop();
         }
 
-        Ok(Step::NotDone)
+        if res == InterpretAction::Done {
+            return Ok(InterpretAction::Continue);
+        }
+
+        Ok(res)
     }
 
     pub fn release(self) -> T {

--- a/source/forth3/src/vm/async_vm.rs
+++ b/source/forth3/src/vm/async_vm.rs
@@ -180,7 +180,7 @@ where
         &mut self.vm
     }
 
-    pub async fn process_line(&mut self) -> Result<InterpretAction, Error> {
+    pub async fn process_line(&mut self) -> ForthResult {
         let res = async {
             loop {
                 match self.vm.start_processing_line()? {
@@ -215,7 +215,7 @@ where
     }
 
     // Single step execution (async version).
-    async fn async_pig(&mut self) -> Result<InterpretAction, Error> {
+    async fn async_pig(&mut self) -> ForthResult {
         let Self {
             ref mut vm,
             ref builtins,

--- a/source/forth3/src/vm/builtins.rs
+++ b/source/forth3/src/vm/builtins.rs
@@ -8,6 +8,8 @@ use crate::{
     Error, Forth, Lookup, Mode, ReplaceErr,
 };
 
+use super::InterpretAction;
+
 #[cfg(feature = "floats")]
 pub mod floats;
 
@@ -188,7 +190,7 @@ impl<T: 'static> Forth<T> {
         builtin!("(variable)", Self::variable),
     ];
 
-    pub fn dict_free(&mut self) -> Result<(), Error> {
+    pub fn dict_free(&mut self) -> Result<InterpretAction, Error> {
         let capa = self.dict.alloc.capacity();
         let used = self.dict.alloc.used();
         let free = capa - used;
@@ -197,10 +199,10 @@ impl<T: 'static> Forth<T> {
             "{}/{} bytes free ({} used)",
             free, capa, used
         )?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn list_stack(&mut self) -> Result<(), Error> {
+    pub fn list_stack(&mut self) -> Result<InterpretAction, Error> {
         let depth = self.data_stack.depth();
         write!(&mut self.output, "<{}> ", depth)?;
         for d in (0..depth).rev() {
@@ -208,10 +210,10 @@ impl<T: 'static> Forth<T> {
             write!(&mut self.output, "{} ", unsafe { val.data })?;
         }
         self.output.push_str("\n")?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn list_builtins(&mut self) -> Result<(), Error> {
+    pub fn list_builtins(&mut self) -> Result<InterpretAction, Error> {
         let Self {
             builtins, output, ..
         } = self;
@@ -221,10 +223,10 @@ impl<T: 'static> Forth<T> {
             output.write_str(", ")?;
         }
         output.write_str("\n")?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn list_dict(&mut self) -> Result<(), Error> {
+    pub fn list_dict(&mut self) -> Result<InterpretAction, Error> {
         let Self { output, dict, .. } = self;
         output.write_str("dictionary: ")?;
         for item in dict.entries() {
@@ -238,11 +240,11 @@ impl<T: 'static> Forth<T> {
             output.write_str(", ")?;
         }
         output.write_str("\n")?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
     // addr offset w+
-    pub fn word_add(&mut self) -> Result<(), Error> {
+    pub fn word_add(&mut self) -> Result<InterpretAction, Error> {
         let w_offset = self.data_stack.try_pop()?;
         let w_addr = self.data_stack.try_pop()?;
         let new_addr = unsafe {
@@ -250,74 +252,74 @@ impl<T: 'static> Forth<T> {
             w_addr.ptr.cast::<Word>().offset(offset)
         };
         self.data_stack.push(Word::ptr(new_addr))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn byte_var_load(&mut self) -> Result<(), Error> {
+    pub fn byte_var_load(&mut self) -> Result<InterpretAction, Error> {
         let w = self.data_stack.try_pop()?;
         let ptr = unsafe { w.ptr.cast::<u8>() };
         let val = unsafe { Word::data(i32::from(ptr.read())) };
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn byte_var_store(&mut self) -> Result<(), Error> {
+    pub fn byte_var_store(&mut self) -> Result<InterpretAction, Error> {
         let w_addr = self.data_stack.try_pop()?;
         let w_val = self.data_stack.try_pop()?;
         unsafe {
             w_addr.ptr.cast::<u8>().write((w_val.data & 0xFF) as u8);
         }
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
     // TODO: Check alignment?
-    pub fn var_load(&mut self) -> Result<(), Error> {
+    pub fn var_load(&mut self) -> Result<InterpretAction, Error> {
         let w = self.data_stack.try_pop()?;
         let ptr = unsafe { w.ptr.cast::<Word>() };
         let val = unsafe { ptr.read() };
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
     // TODO: Check alignment?
-    pub fn var_store(&mut self) -> Result<(), Error> {
+    pub fn var_store(&mut self) -> Result<InterpretAction, Error> {
         let w_addr = self.data_stack.try_pop()?;
         let w_val = self.data_stack.try_pop()?;
         unsafe {
             w_addr.ptr.cast::<Word>().write(w_val);
         }
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn zero_const(&mut self) -> Result<(), Error> {
+    pub fn zero_const(&mut self) -> Result<InterpretAction, Error> {
         self.data_stack.push(Word::data(0))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn one_const(&mut self) -> Result<(), Error> {
+    pub fn one_const(&mut self) -> Result<InterpretAction, Error> {
         self.data_stack.push(Word::data(1))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn constant(&mut self) -> Result<(), Error> {
+    pub fn constant(&mut self) -> Result<InterpretAction, Error> {
         let me = self.call_stack.try_peek()?;
         let de = me.eh.cast::<DictionaryEntry<T>>();
         let cfa = unsafe { DictionaryEntry::<T>::pfa(de) };
         let val = unsafe { cfa.as_ptr().read() };
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn variable(&mut self) -> Result<(), Error> {
+    pub fn variable(&mut self) -> Result<InterpretAction, Error> {
         let me = self.call_stack.try_peek()?;
         let de = me.eh.cast::<DictionaryEntry<T>>();
         let cfa = unsafe { DictionaryEntry::<T>::pfa(de) };
         let val = Word::ptr(cfa.as_ptr());
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn forget(&mut self) -> Result<(), Error> {
+    pub fn forget(&mut self) -> Result<InterpretAction, Error> {
         // TODO: If anything we've defined in the dict has escaped into
         // the stack, variables, etc., we're definitely going to be in trouble.
         //
@@ -370,53 +372,53 @@ impl<T: 'static> Forth<T> {
             }
         }
 
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn over(&mut self) -> Result<(), Error> {
+    pub fn over(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_peek_back_n(1)?;
         self.data_stack.push(a)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn over_2(&mut self) -> Result<(), Error> {
+    pub fn over_2(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_peek_back_n(2)?;
         let b = self.data_stack.try_peek_back_n(3)?;
         self.data_stack.push(b)?;
         self.data_stack.push(a)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn rot(&mut self) -> Result<(), Error> {
+    pub fn rot(&mut self) -> Result<InterpretAction, Error> {
         let n1 = self.data_stack.try_pop()?;
         let n2 = self.data_stack.try_pop()?;
         let n3 = self.data_stack.try_pop()?;
         self.data_stack.push(n2)?;
         self.data_stack.push(n1)?;
         self.data_stack.push(n3)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn ds_drop(&mut self) -> Result<(), Error> {
+    pub fn ds_drop(&mut self) -> Result<InterpretAction, Error> {
         let _a = self.data_stack.try_pop()?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn ds_drop_2(&mut self) -> Result<(), Error> {
+    pub fn ds_drop_2(&mut self) -> Result<InterpretAction, Error> {
         let _a = self.data_stack.try_pop()?;
         let _b = self.data_stack.try_pop()?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn swap(&mut self) -> Result<(), Error> {
+    pub fn swap(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack.push(a)?;
         self.data_stack.push(b)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn swap_2(&mut self) -> Result<(), Error> {
+    pub fn swap_2(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         let c = self.data_stack.try_pop()?;
@@ -425,15 +427,15 @@ impl<T: 'static> Forth<T> {
         self.data_stack.push(a)?;
         self.data_stack.push(d)?;
         self.data_stack.push(c)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn space(&mut self) -> Result<(), Error> {
+    pub fn space(&mut self) -> Result<InterpretAction, Error> {
         self.output.push_bstr(b" ")?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn spaces(&mut self) -> Result<(), Error> {
+    pub fn spaces(&mut self) -> Result<InterpretAction, Error> {
         let num = self.data_stack.try_pop()?;
         let num = unsafe { num.data };
 
@@ -443,21 +445,21 @@ impl<T: 'static> Forth<T> {
         for _ in 0..num {
             self.space()?;
         }
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn cr(&mut self) -> Result<(), Error> {
+    pub fn cr(&mut self) -> Result<InterpretAction, Error> {
         self.output.push_bstr(b"\n")?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    fn skip_literal(&mut self) -> Result<(), Error> {
+    fn skip_literal(&mut self) -> Result<InterpretAction, Error> {
         let parent = self.call_stack.try_peek_back_n_mut(1)?;
         parent.offset(1)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn invert(&mut self) -> Result<(), Error> {
+    pub fn invert(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let val = if a == Word::data(0) {
             Word::data(-1)
@@ -465,18 +467,18 @@ impl<T: 'static> Forth<T> {
             Word::data(0)
         };
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn and(&mut self) -> Result<(), Error> {
+    pub fn and(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         let val = Word::data(unsafe { a.data & b.data });
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn equal(&mut self) -> Result<(), Error> {
+    pub fn equal(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         let val = if a == b {
@@ -485,41 +487,41 @@ impl<T: 'static> Forth<T> {
             Word::data(0)
         };
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn greater(&mut self) -> Result<(), Error> {
+    pub fn greater(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         let val = if unsafe { b.data > a.data } { -1 } else { 0 };
         self.data_stack.push(Word::data(val))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn less(&mut self) -> Result<(), Error> {
+    pub fn less(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         let val = if unsafe { b.data < a.data } { -1 } else { 0 };
         self.data_stack.push(Word::data(val))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn zero_equal(&mut self) -> Result<(), Error> {
+    pub fn zero_equal(&mut self) -> Result<InterpretAction, Error> {
         self.data_stack.push(Word::data(0))?;
         self.equal()
     }
 
-    pub fn zero_greater(&mut self) -> Result<(), Error> {
+    pub fn zero_greater(&mut self) -> Result<InterpretAction, Error> {
         self.data_stack.push(Word::data(0))?;
         self.greater()
     }
 
-    pub fn zero_less(&mut self) -> Result<(), Error> {
+    pub fn zero_less(&mut self) -> Result<InterpretAction, Error> {
         self.data_stack.push(Word::data(0))?;
         self.less()
     }
 
-    pub fn div_mod(&mut self) -> Result<(), Error> {
+    pub fn div_mod(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         if unsafe { a.data == 0 } {
@@ -529,10 +531,10 @@ impl<T: 'static> Forth<T> {
         self.data_stack.push(rem)?;
         let val = unsafe { Word::data(b.data / a.data) };
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn div(&mut self) -> Result<(), Error> {
+    pub fn div(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         let val = unsafe {
@@ -542,10 +544,10 @@ impl<T: 'static> Forth<T> {
             Word::data(b.data / a.data)
         };
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn modu(&mut self) -> Result<(), Error> {
+    pub fn modu(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         let val = unsafe {
@@ -555,36 +557,36 @@ impl<T: 'static> Forth<T> {
             Word::data(b.data % a.data)
         };
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn loop_i(&mut self) -> Result<(), Error> {
+    pub fn loop_i(&mut self) -> Result<InterpretAction, Error> {
         let a = self.return_stack.try_peek()?;
         self.data_stack.push(a)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn loop_itick(&mut self) -> Result<(), Error> {
+    pub fn loop_itick(&mut self) -> Result<InterpretAction, Error> {
         let a = self.return_stack.try_peek_back_n(1)?;
         self.data_stack.push(a)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn loop_j(&mut self) -> Result<(), Error> {
+    pub fn loop_j(&mut self) -> Result<InterpretAction, Error> {
         let a = self.return_stack.try_peek_back_n(2)?;
         self.data_stack.push(a)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn loop_leave(&mut self) -> Result<(), Error> {
+    pub fn loop_leave(&mut self) -> Result<InterpretAction, Error> {
         let _ = self.return_stack.try_pop()?;
         let a = self.return_stack.try_peek()?;
         self.return_stack
             .push(unsafe { Word::data(a.data.wrapping_sub(1)) })?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn jump_doloop(&mut self) -> Result<(), Error> {
+    pub fn jump_doloop(&mut self) -> Result<InterpretAction, Error> {
         let a = self.return_stack.try_pop()?;
         let b = self.return_stack.try_peek()?;
         let ctr = unsafe { Word::data(a.data + 1) };
@@ -598,14 +600,14 @@ impl<T: 'static> Forth<T> {
         }
     }
 
-    pub fn emit(&mut self) -> Result<(), Error> {
+    pub fn emit(&mut self) -> Result<InterpretAction, Error> {
         let val = self.data_stack.try_pop()?;
         let val = unsafe { val.data };
         self.output.push_bstr(&[val as u8])?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn jump_if_zero(&mut self) -> Result<(), Error> {
+    pub fn jump_if_zero(&mut self) -> Result<InterpretAction, Error> {
         let do_jmp = unsafe {
             let val = self.data_stack.try_pop()?;
             val.data == 0
@@ -617,59 +619,59 @@ impl<T: 'static> Forth<T> {
         }
     }
 
-    pub fn jump(&mut self) -> Result<(), Error> {
+    pub fn jump(&mut self) -> Result<InterpretAction, Error> {
         let parent = self.call_stack.try_peek_back_n_mut(1)?;
         let offset = parent.get_current_val()?;
         parent.offset(offset)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn dup(&mut self) -> Result<(), Error> {
+    pub fn dup(&mut self) -> Result<InterpretAction, Error> {
         let val = self.data_stack.try_peek()?;
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn dup_2(&mut self) -> Result<(), Error> {
+    pub fn dup_2(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack.push(b)?;
         self.data_stack.push(a)?;
         self.data_stack.push(b)?;
         self.data_stack.push(a)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn return_to_data_stack(&mut self) -> Result<(), Error> {
+    pub fn return_to_data_stack(&mut self) -> Result<InterpretAction, Error> {
         let val = self.return_stack.try_pop()?;
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn data_to_return_stack(&mut self) -> Result<(), Error> {
+    pub fn data_to_return_stack(&mut self) -> Result<InterpretAction, Error> {
         let val = self.data_stack.try_pop()?;
         self.return_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn data2_to_return2_stack(&mut self) -> Result<(), Error> {
+    pub fn data2_to_return2_stack(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.return_stack.push(b)?;
         self.return_stack.push(a)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn pop_print(&mut self) -> Result<(), Error> {
+    pub fn pop_print(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         write!(&mut self.output, "{} ", unsafe { a.data })?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn unsigned_pop_print(&mut self) -> Result<(), Error> {
+    pub fn unsigned_pop_print(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         write!(&mut self.output, "{} ", unsafe { a.data } as u32)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
     /// # Add (`+`)
@@ -682,7 +684,7 @@ impl<T: 'static> Forth<T> {
     /// > .
     /// < 3 ok.
     /// # "#)
-    pub fn add(&mut self) -> Result<(), Error> {
+    pub fn add(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
 
@@ -693,48 +695,48 @@ impl<T: 'static> Forth<T> {
             let b = b.ptr as isize;
             a.wrapping_add(b)
         }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn mul(&mut self) -> Result<(), Error> {
+    pub fn mul(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack
             .push(Word::data(unsafe { a.data.wrapping_mul(b.data) }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn abs(&mut self) -> Result<(), Error> {
+    pub fn abs(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         self.data_stack
             .push(Word::data(unsafe { a.data.wrapping_abs() }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn negate(&mut self) -> Result<(), Error> {
+    pub fn negate(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         self.data_stack
             .push(Word::data(unsafe { a.data.wrapping_neg() }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn min(&mut self) -> Result<(), Error> {
+    pub fn min(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack
             .push(Word::data(unsafe { a.data.min(b.data) }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn max(&mut self) -> Result<(), Error> {
+    pub fn max(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack
             .push(Word::data(unsafe { a.data.max(b.data) }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn minus(&mut self) -> Result<(), Error> {
+    pub fn minus(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         // NOTE: CURSED BECAUSE OF POINTER MATH
@@ -744,10 +746,10 @@ impl<T: 'static> Forth<T> {
             let b = b.ptr as isize;
             b.wrapping_sub(a)
         }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn star_slash(&mut self) -> Result<(), Error> {
+    pub fn star_slash(&mut self) -> Result<InterpretAction, Error> {
         let n3 = self.data_stack.try_pop()?;
         let n2 = self.data_stack.try_pop()?;
         let n1 = self.data_stack.try_pop()?;
@@ -756,10 +758,10 @@ impl<T: 'static> Forth<T> {
                 .wrapping_mul(n2.data as i64)
                 .wrapping_div(n3.data as i64) as i32
         }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn star_slash_mod(&mut self) -> Result<(), Error> {
+    pub fn star_slash_mod(&mut self) -> Result<InterpretAction, Error> {
         let n3 = self.data_stack.try_pop()?;
         let n2 = self.data_stack.try_pop()?;
         let n1 = self.data_stack.try_pop()?;
@@ -771,10 +773,10 @@ impl<T: 'static> Forth<T> {
             self.data_stack.push(Word::data(rem as i32))?;
             self.data_stack.push(Word::data(quo as i32))?;
         }
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn colon(&mut self) -> Result<(), Error> {
+    pub fn colon(&mut self) -> Result<InterpretAction, Error> {
         let old_mode = core::mem::replace(&mut self.mode, Mode::Compile);
         let name = self.munch_name()?;
 
@@ -814,7 +816,7 @@ impl<T: 'static> Forth<T> {
                         }
                         self.dict.tail = Some(dict_base);
                         self.mode = old_mode;
-                        return Ok(());
+                        return Ok(InterpretAction::Done);
                     }
                     Some(_) => {}
                     None => {
@@ -825,7 +827,7 @@ impl<T: 'static> Forth<T> {
         }
     }
 
-    pub fn write_str_lit(&mut self) -> Result<(), Error> {
+    pub fn write_str_lit(&mut self) -> Result<InterpretAction, Error> {
         let parent = self.call_stack.try_peek_back_n_mut(1)?;
 
         // The length in bytes is stored in the next word.
@@ -844,21 +846,21 @@ impl<T: 'static> Forth<T> {
             self.output.push_bstr(u8_sli)?;
         }
         parent.offset(len_words as i32)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
     /// `(literal)` is used mid-interpret to put the NEXT word of the parent's
     /// CFA array into the stack as a value.
-    pub fn literal(&mut self) -> Result<(), Error> {
+    pub fn literal(&mut self) -> Result<InterpretAction, Error> {
         let parent = self.call_stack.try_peek_back_n_mut(1)?;
         let literal = parent.get_current_word()?;
         parent.offset(1)?;
         self.data_stack.push(literal)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
     /// Looks up a name in the dictionary and places its address on the stack.
-    pub fn addr_of(&mut self) -> Result<(), Error> {
+    pub fn addr_of(&mut self) -> Result<InterpretAction, Error> {
         self.input.advance();
         let name = self.input.cur_word().ok_or(Error::AddrOfMissingName)?;
         match self.lookup(name)? {
@@ -880,10 +882,10 @@ impl<T: 'static> Forth<T> {
             _ => return Err(Error::AddrOfNotAWord),
         }
 
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn execute(&mut self) -> Result<(), Error> {
+    pub fn execute(&mut self) -> Result<InterpretAction, Error> {
         let w = self.data_stack.try_pop()?;
         // pop the execute word off the stack
         self.call_stack.pop();
@@ -897,6 +899,6 @@ impl<T: 'static> Forth<T> {
             })?;
         };
 
-        Err(Error::PendingCallAgain)
+        Ok(InterpretAction::Continue)
     }
 }

--- a/source/forth3/src/vm/builtins/floats.rs
+++ b/source/forth3/src/vm/builtins/floats.rs
@@ -1,8 +1,8 @@
-use crate::{word::Word, Error, Forth};
+use crate::{vm::InterpretAction, word::Word, Error, Forth};
 use core::{fmt::Write, ops::Neg};
 
 impl<T: 'static> Forth<T> {
-    pub fn float_div_mod(&mut self) -> Result<(), Error> {
+    pub fn float_div_mod(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         if unsafe { a.float == 0.0 } {
@@ -12,10 +12,10 @@ impl<T: 'static> Forth<T> {
         self.data_stack.push(rem)?;
         let val = unsafe { Word::float(b.float / a.float) };
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn float_div(&mut self) -> Result<(), Error> {
+    pub fn float_div(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         let val = unsafe {
@@ -25,10 +25,10 @@ impl<T: 'static> Forth<T> {
             Word::float(b.float / a.float)
         };
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn float_modu(&mut self) -> Result<(), Error> {
+    pub fn float_modu(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         let val = unsafe {
@@ -38,41 +38,41 @@ impl<T: 'static> Forth<T> {
             Word::float(b.float % a.float)
         };
         self.data_stack.push(val)?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn float_pop_print(&mut self) -> Result<(), Error> {
+    pub fn float_pop_print(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         write!(&mut self.output, "{} ", unsafe { a.float })?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn float_add(&mut self) -> Result<(), Error> {
+    pub fn float_add(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack
             .push(Word::float(unsafe { a.float + b.float }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn float_mul(&mut self) -> Result<(), Error> {
+    pub fn float_mul(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack
             .push(Word::float(unsafe { a.float * b.float }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
     #[cfg(feature = "use-std")]
-    pub fn float_abs(&mut self) -> Result<(), Error> {
+    pub fn float_abs(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         self.data_stack
             .push(Word::float(unsafe { a.float.abs() }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
     #[cfg(not(feature = "use-std"))]
-    pub fn float_abs(&mut self) -> Result<(), Error> {
+    pub fn float_abs(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         self.data_stack.push(Word::float(unsafe {
             if a.float.is_sign_negative() {
@@ -81,37 +81,37 @@ impl<T: 'static> Forth<T> {
                 a.float
             }
         }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn float_negate(&mut self) -> Result<(), Error> {
+    pub fn float_negate(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         self.data_stack
             .push(Word::float(unsafe { a.float.neg() }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn float_min(&mut self) -> Result<(), Error> {
+    pub fn float_min(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack
             .push(Word::float(unsafe { a.float.min(b.float) }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn float_max(&mut self) -> Result<(), Error> {
+    pub fn float_max(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack
             .push(Word::float(unsafe { a.float.max(b.float) }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 
-    pub fn float_minus(&mut self) -> Result<(), Error> {
+    pub fn float_minus(&mut self) -> Result<InterpretAction, Error> {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack
             .push(Word::float(unsafe { b.float - a.float }))?;
-        Ok(())
+        Ok(InterpretAction::Done)
     }
 }

--- a/source/forth3/src/vm/builtins/floats.rs
+++ b/source/forth3/src/vm/builtins/floats.rs
@@ -1,8 +1,12 @@
-use crate::{vm::InterpretAction, word::Word, Error, Forth};
+use crate::{
+    vm::{ForthResult, InterpretAction},
+    word::Word,
+    Error, Forth,
+};
 use core::{fmt::Write, ops::Neg};
 
 impl<T: 'static> Forth<T> {
-    pub fn float_div_mod(&mut self) -> Result<InterpretAction, Error> {
+    pub fn float_div_mod(&mut self) -> ForthResult {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         if unsafe { a.float == 0.0 } {
@@ -15,7 +19,7 @@ impl<T: 'static> Forth<T> {
         Ok(InterpretAction::Done)
     }
 
-    pub fn float_div(&mut self) -> Result<InterpretAction, Error> {
+    pub fn float_div(&mut self) -> ForthResult {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         let val = unsafe {
@@ -28,7 +32,7 @@ impl<T: 'static> Forth<T> {
         Ok(InterpretAction::Done)
     }
 
-    pub fn float_modu(&mut self) -> Result<InterpretAction, Error> {
+    pub fn float_modu(&mut self) -> ForthResult {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         let val = unsafe {
@@ -41,13 +45,13 @@ impl<T: 'static> Forth<T> {
         Ok(InterpretAction::Done)
     }
 
-    pub fn float_pop_print(&mut self) -> Result<InterpretAction, Error> {
+    pub fn float_pop_print(&mut self) -> ForthResult {
         let a = self.data_stack.try_pop()?;
         write!(&mut self.output, "{} ", unsafe { a.float })?;
         Ok(InterpretAction::Done)
     }
 
-    pub fn float_add(&mut self) -> Result<InterpretAction, Error> {
+    pub fn float_add(&mut self) -> ForthResult {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack
@@ -55,7 +59,7 @@ impl<T: 'static> Forth<T> {
         Ok(InterpretAction::Done)
     }
 
-    pub fn float_mul(&mut self) -> Result<InterpretAction, Error> {
+    pub fn float_mul(&mut self) -> ForthResult {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack
@@ -64,7 +68,7 @@ impl<T: 'static> Forth<T> {
     }
 
     #[cfg(feature = "use-std")]
-    pub fn float_abs(&mut self) -> Result<InterpretAction, Error> {
+    pub fn float_abs(&mut self) -> ForthResult {
         let a = self.data_stack.try_pop()?;
         self.data_stack
             .push(Word::float(unsafe { a.float.abs() }))?;
@@ -72,7 +76,7 @@ impl<T: 'static> Forth<T> {
     }
 
     #[cfg(not(feature = "use-std"))]
-    pub fn float_abs(&mut self) -> Result<InterpretAction, Error> {
+    pub fn float_abs(&mut self) -> ForthResult {
         let a = self.data_stack.try_pop()?;
         self.data_stack.push(Word::float(unsafe {
             if a.float.is_sign_negative() {
@@ -84,14 +88,14 @@ impl<T: 'static> Forth<T> {
         Ok(InterpretAction::Done)
     }
 
-    pub fn float_negate(&mut self) -> Result<InterpretAction, Error> {
+    pub fn float_negate(&mut self) -> ForthResult {
         let a = self.data_stack.try_pop()?;
         self.data_stack
             .push(Word::float(unsafe { a.float.neg() }))?;
         Ok(InterpretAction::Done)
     }
 
-    pub fn float_min(&mut self) -> Result<InterpretAction, Error> {
+    pub fn float_min(&mut self) -> ForthResult {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack
@@ -99,7 +103,7 @@ impl<T: 'static> Forth<T> {
         Ok(InterpretAction::Done)
     }
 
-    pub fn float_max(&mut self) -> Result<InterpretAction, Error> {
+    pub fn float_max(&mut self) -> ForthResult {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack
@@ -107,7 +111,7 @@ impl<T: 'static> Forth<T> {
         Ok(InterpretAction::Done)
     }
 
-    pub fn float_minus(&mut self) -> Result<InterpretAction, Error> {
+    pub fn float_minus(&mut self) -> ForthResult {
         let a = self.data_stack.try_pop()?;
         let b = self.data_stack.try_pop()?;
         self.data_stack

--- a/source/forth3/src/vm/mod.rs
+++ b/source/forth3/src/vm/mod.rs
@@ -29,6 +29,9 @@ mod async_vm;
 #[cfg(feature = "async")]
 pub use self::async_vm::AsyncForth;
 
+/// Result type returned by a Forth VM execution step.
+pub type ForthResult = Result<InterpretAction, Error>;
+
 /// Forth is the "context" of the VM/interpreter.
 pub struct Forth<T: 'static> {
     mode: Mode,
@@ -256,7 +259,7 @@ impl<T> Forth<T> {
         }
     }
 
-    pub fn process_line(&mut self) -> Result<InterpretAction, Error> {
+    pub fn process_line(&mut self) -> ForthResult {
         let res = (|| {
             loop {
                 match self.start_processing_line()? {
@@ -403,7 +406,7 @@ impl<T> Forth<T> {
     }
 
     // Single step execution
-    fn steppa_pig(&mut self) -> Result<InterpretAction, Error> {
+    fn steppa_pig(&mut self) -> ForthResult {
         let top = match self.call_stack.try_peek() {
             Ok(t) => t,
             Err(StackError::StackEmpty) => return Ok(InterpretAction::Done),
@@ -441,7 +444,7 @@ impl<T> Forth<T> {
     }
 
     /// Interpret is the run-time target of the `:` (colon) word.
-    pub fn interpret(&mut self) -> Result<InterpretAction, Error> {
+    pub fn interpret(&mut self) -> ForthResult {
         let mut top = self.call_stack.try_peek()?;
 
         if let Some(word) = top.get_word_at_cur_idx() {

--- a/source/forth3/src/vm/mod.rs
+++ b/source/forth3/src/vm/mod.rs
@@ -58,12 +58,6 @@ enum ProcessAction {
     Done,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq)]
-enum Step {
-    Done,
-    NotDone,
-}
-
 impl<T> Forth<T> {
     pub unsafe fn new(
         dstack_buf: (*mut Word, usize),
@@ -273,7 +267,7 @@ impl<T> Forth<T> {
                     ProcessAction::Continue => {}
                     ProcessAction::Execute => {
                         // Loop until execution completes.
-                        let mut step = self.steppa_pig()?;
+                        let mut step = InterpretAction::Continue;
                         while step == InterpretAction::Continue {
                             step = self.steppa_pig()?;
                         }

--- a/tools/f3repl/src/main.rs
+++ b/tools/f3repl/src/main.rs
@@ -23,8 +23,8 @@ fn main() {
         stdout().flush().unwrap();
         stdin().read_line(&mut inp).unwrap();
         forth.input.fill(&inp).unwrap();
-        match forth.execute() {
-            Ok(()) => {
+        match forth.process_line() {
+            Ok(_) => {
                 print!("{}", forth.output.as_str());
             }
             Err(e) => {

--- a/tools/f3repl/src/main.rs
+++ b/tools/f3repl/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
         stdout().flush().unwrap();
         stdin().read_line(&mut inp).unwrap();
         forth.input.fill(&inp).unwrap();
-        match forth.process_line() {
+        match forth.execute() {
             Ok(()) => {
                 print!("{}", forth.output.as_str());
             }


### PR DESCRIPTION
This branch changes the `forth3` API to prepare for Forth-driven IO. In
particular, builtin words and VM execution steps are changed from
returning a `Ok(())` branch when the builtin/execution step succeeds to
returning a new `InterpretAction` type in the `Ok` branch, which
determines what action the host should perform next.

`InterpretAction` is an enum which currently has three variants:

- `InterpretAction::Done`, which has the same semantics that returning
  `Ok(())` currently has: if returned from a builtin, it indicates that
  the VM should pop the current callstack frame and keep executing, and
  if returned by the VM to the host, it indicates that the VM's
  callstack is empty.
- `InterpretAction::Continue`, which replaces the
  `Error::PendingCallAgain` variant (it seemed more morally correct for
  this to be an `Ok` return rather than an `Err`), and indicates that
  the VM should continue executing what's currently on the stack when
  returned from a builtin
- `InterpretAction::AcceptInput`, which indicates that the VM needs to
  wait for the host to fill its input buffer.

In the future, `InterpretAction::AcceptInput` will be used to provide an
improved abstraction for communicating to the host that the VM is
requesting IO. We may also add a variant indicating that the VM needs
the host to drain its output buffer. When we add implementations of
Forth words such as `quit`, which fill the input buffer, they will
return the `AcceptInput` variant, allowing us to request IO from
builtins provided by `forth3` without requiring them to actually *do*
the IO. This lets us avoid making the entire VM generic over some `Read`
and `Write` traits (or `AsyncRead`/`AsyncWrite` traits), which don't
exist in no-std, by temporarily breaking out of a VM's run loop and
returning to the host when I/O is needed.