### PR TITLE
Handle multiple lines in forth output

### DIFF
--- a/source/kernel/src/forth.rs
+++ b/source/kernel/src/forth.rs
@@ -115,7 +115,7 @@ impl Forth {
                 Err(error) => {
                     tracing::error!(?error);
                     // TODO(ajm): Provide some kind of fixed length error string?
-                    const ERROR: &[u8] = b"ERROR.";
+                    const ERROR: &[u8] = b"ERROR.\n";
                     let mut send = self.stdio.producer().send_grant_exact(ERROR.len()).await;
                     send.copy_from_slice(ERROR);
                     send.commit(ERROR.len());

--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -316,10 +316,13 @@ async fn kernel_entry(opts: MelpomeneOptions) {
                             tracing::trace!(len, "Received output from TID0");
                             for &b in output.iter() {
                                 // TODO(eliza): what if this errors lol
-                                let _ = rline.append_remote_char(b);
+                                if b == b'\n' {
+                                    rline.submit_remote_editing();
+                                } else {
+                                    let _ = rline.append_remote_char(b);
+                                }
                             }
                             output.release(len);
-                            rline.submit_remote_editing();
                         }
                     }
                 }


### PR DESCRIPTION
Before this, outputting newlines in forth would skip them.