### PR TITLE
chore: add a Justfile to automate D1 flashing

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,74 @@
+#!/usr/bin/env -S just --justfile
+# justfile for Mnemos
+# see https://just.systems/man for more details
+
+
+# Overrides the default Rust toolchain set in `rust-toolchain.toml`.
+toolchain := ""
+
+# disables cargo nextest
+no-nextest := ''
+
+_cargo := "cargo" + if toolchain != "" { " +" + toolchain } else { "" }
+
+_rustflags := env_var_or_default("RUSTFLAGS", "")
+
+# If we're running in Github Actions and cargo-action-fmt is installed, then add
+# a command suffix that formats errors.
+_fmt := if env_var_or_default("GITHUB_ACTIONS", "") != "true" { "" } else {
+    ```
+    if command -v cargo-action-fmt >/dev/null 2>&1; then
+        echo "--message-format=json | cargo-action-fmt"
+    fi
+    ```
+}
+
+# arguments to pass to all RustDoc invocations
+_rustdoc := _cargo + " doc --no-deps --all-features"
+
+# default recipe to display help information
+default:
+    @echo "justfile for Mnemos"
+    @echo "see https://just.systems/man for more details"
+    @echo ""
+    @just --list
+
+build-d1: (_get-cargo-binutils)
+    {{ _cargo }} objcopy 
+
+
+_get-cargo-binutils:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "./bin/_util.sh"
+
+    if {{ _cargo }} --list | grep -q 'objcopy'; then
+        status "Found" "cargo objcopy"
+        exit 0
+    fi
+
+    err "missing cargo-objcopy executable"
+    if confirm "      install it?"; then
+        cargo install cargo-binutils
+    fi
+
+
+_get-nextest:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "./bin/_util.sh"
+
+    if [ -n "{{ no-nextest }}" ]; then
+        status "Configured" "not to use cargo nextest"
+        exit 0
+    fi
+
+    if {{ _cargo }} --list | grep -q 'nextest'; then
+        status "Found" "cargo nextest"
+        exit 0
+    fi
+
+    err "missing cargo-nextest executable"
+    if confirm "      install it?"; then
+        cargo install cargo-nextest
+    fi

--- a/tools/_util.sh
+++ b/tools/_util.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# utility functions used in other shell scripts.
+#
+# currently, this includes:
+# - cargo-style stderr logging (`err`, `note`, and `status` functions)
+# - confirmation prompts (`confirm` function)
+set -euo pipefail
+
+# Log an error to stderr
+#
+# Args:
+#     $1: message to log
+err() {
+    echo -e "\e[31m\e[1merror:\e[0m" "$@" 1>&2;
+}
+
+# Log a note to stderr
+#
+# Args:
+#     $1: message to log
+note() {
+    echo -e "\e[31m\e[1mnote:\e[0m" "$@" 1>&2;
+}
+
+# Log a cargo-style status message to stderr
+#
+# Args:
+#     $1: a "tag" for the log message (should be 12 characters or less in
+#     length)
+#    $2: message to log
+status() {
+    local width=12
+    local tag="$1"
+    local msg="$2"
+    printf "\e[32m\e[1m%${width}s\e[0m %s\n" "$tag" "$msg"
+}
+
+# Prompt the user to confirm an action
+#
+# Args:
+#    $1: message to display to the user along with the `[y/N]` prompt
+#
+# Returns:
+#    0 if the user confirmed, 1 otherwise
+confirm() {
+    while read -r -p "$1 [Y/n] " input
+    do
+        case "$input" in
+            [yY][eE][sS]|[yY])
+                return 0
+                ;;
+            [nN][oO]|[nN])
+                return 1
+                ;;
+            *)
+                err "invalid input $input"
+                ;;
+        esac
+    done
+}
+
+# Returns the path to a Mycelium crate.
+#
+# Args:
+#     $1: crate name
+#
+# Returns:
+#     0 if the crate exists, 0 if it does not exist.
+crate_path() {
+    local crate="$1"
+    local mycoprefix='mycelium-';
+    if [[ -d $crate ]]; then
+        echo "$crate"
+    elif [[ -d "${crate#"$mycoprefix"}" ]]; then
+        echo "${crate#"$mycoprefix"}"
+    else
+        err "unknown crate $crate"
+        return 1;
+    fi
+}

--- a/tools/_util.sh
+++ b/tools/_util.sh
@@ -58,23 +58,3 @@ confirm() {
         esac
     done
 }
-
-# Returns the path to a Mycelium crate.
-#
-# Args:
-#     $1: crate name
-#
-# Returns:
-#     0 if the crate exists, 0 if it does not exist.
-crate_path() {
-    local crate="$1"
-    local mycoprefix='mycelium-';
-    if [[ -d $crate ]]; then
-        echo "$crate"
-    elif [[ -d "${crate#"$mycoprefix"}" ]]; then
-        echo "${crate#"$mycoprefix"}"
-    else
-        err "unknown crate $crate"
-        return 1;
-    fi
-}


### PR DESCRIPTION
Currently, flashing an Allwinner D1 board with mnemOS requires a bunch
of manual steps. This branch adds a quick Justfile with `build-d1` and
`flash-d1` recipes.

We may want to improve the build tooling more later, but this works for
now.