### PR TITLE
feat(trace): add UART tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,13 +312,37 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2686c4115cb0810d9a984776e197823d08ec94f176549a89a9efded477c456dc"
+dependencies = [
+ "clap_builder",
+ "clap_derive 4.3.2",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e53afce1efce6ed1f633cf0e57612fe51db54a1ee4fd8f8503d078fe02d69ae"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags 1.3.2",
+ "clap_lex 0.5.0",
+ "strsim",
 ]
 
 [[package]]
@@ -286,6 +359,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +378,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "cloudabi"
@@ -314,6 +405,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console-api"
@@ -458,6 +555,7 @@ dependencies = [
 name = "crowtty"
 version = "0.1.0"
 dependencies = [
+ "clap 4.3.5",
  "cobs",
  "mnemos-trace-proto",
  "postcard 1.0.4",
@@ -1103,6 +1201,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,7 +1383,7 @@ version = "0.1.0"
 dependencies = [
  "atty",
  "chrono",
- "clap",
+ "clap 3.2.25",
  "console-subscriber",
  "embedded-graphics",
  "embedded-graphics-simulator",
@@ -2806,6 +2916,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ name = "crowtty"
 version = "0.1.0"
 dependencies = [
  "cobs",
+ "mnemos-trace-proto",
  "postcard 1.0.4",
  "serde",
  "serialport",
@@ -1399,6 +1400,7 @@ dependencies = [
  "maitake",
  "mnemos-abi",
  "mnemos-alloc",
+ "mnemos-trace-proto",
  "mycelium-util",
  "portable-atomic",
  "postcard 1.0.4",
@@ -1441,6 +1443,14 @@ dependencies = [
  "mnemos-abi",
  "mnemos-alloc",
  "postcard 1.0.4",
+]
+
+[[package]]
+name = "mnemos-trace-proto"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "tracing-serde-structured",
 ]
 
 [[package]]
@@ -2727,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "tracing-serde-structured"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/tracing-serde-structured?branch=eliza/tracing-02#d07ba882696ec2b8d390df279fee8046b282f60c"
+source = "git+https://github.com/hawkw/tracing-serde-structured?branch=eliza/tracing-02#2533f8a82155588473f8701366f36c60f1efe984"
 dependencies = [
  "hash32 0.2.1",
  "heapless",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if 1.0.0",
@@ -447,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -459,8 +459,10 @@ name = "crowtty"
 version = "0.1.0"
 dependencies = [
  "cobs",
+ "postcard 1.0.4",
  "serde",
  "serialport",
+ "tracing-serde-structured",
 ]
 
 [[package]]
@@ -486,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "defmt"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956673bd3cb347512bf988d1e8d89ac9a82b64f6eec54d3c01c3529dac019882"
+checksum = "a8a2d011b2fee29fb7d659b83c43fce9a2cb4df453e16d441a51448e448f3f98"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -496,15 +498,15 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4abc4821bd84d3d8f49945ddb24d029be9385ed9b77c99bf2f6296847a6a9f0"
+checksum = "54f0216f6c5acb5ae1a47050a6645024e6edafc2ee32d421955eccfef12ef92e"
 dependencies = [
  "defmt-parser",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -683,9 +685,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -810,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1014,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1037,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1125,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1140,9 +1142,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libudev"
@@ -1191,9 +1193,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg 1.1.0",
  "scopeguard",
@@ -1201,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "loom"
@@ -1290,7 +1292,7 @@ dependencies = [
  "tracing 0.1.37",
  "tracing-modality",
  "tracing-subscriber",
- "uuid 1.3.3",
+ "uuid 1.3.4",
 ]
 
 [[package]]
@@ -1301,9 +1303,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -1397,13 +1399,16 @@ dependencies = [
  "maitake",
  "mnemos-abi",
  "mnemos-alloc",
+ "mycelium-util",
  "portable-atomic",
  "postcard 1.0.4",
  "serde",
  "spitebuf",
  "tracing 0.1.37",
- "tracing 0.2.0 (git+https://github.com/tokio-rs/tracing?branch=master)",
- "uuid 1.3.3",
+ "tracing 0.2.0",
+ "tracing-core 0.2.0",
+ "tracing-serde-structured",
+ "uuid 1.3.4",
 ]
 
 [[package]]
@@ -1466,7 +1471,7 @@ dependencies = [
  "cordyceps",
  "loom",
  "mycelium-bitfield",
- "tracing 0.2.0 (git+https://github.com/tokio-rs/tracing)",
+ "tracing 0.2.0",
 ]
 
 [[package]]
@@ -1598,15 +1603,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.54"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
@@ -1636,9 +1641,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
@@ -1648,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.5.0"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "overload"
@@ -1660,9 +1665,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
@@ -1793,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -2054,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2149,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -2255,18 +2260,18 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2275,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "itoa",
  "ryu",
@@ -2400,15 +2405,16 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg 1.1.0",
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2634,35 +2640,25 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
- "tracing-attributes 0.1.24",
+ "tracing-attributes 0.1.26",
  "tracing-core 0.1.31",
 ]
 
 [[package]]
 name = "tracing"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing?branch=master#e603c2a254d157a25a7a1fbfd4da46ad7e05f555"
+source = "git+https://github.com/tokio-rs/tracing#2906278ba7afde87067a5af7c4eab51ebc410619"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes 0.2.0 (git+https://github.com/tokio-rs/tracing?branch=master)",
- "tracing-core 0.2.0 (git+https://github.com/tokio-rs/tracing?branch=master)",
-]
-
-[[package]]
-name = "tracing"
-version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing#29146260fb4615d271d2e899ad95a753bb42915e"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes 0.2.0 (git+https://github.com/tokio-rs/tracing)",
- "tracing-core 0.2.0 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-attributes 0.2.0",
+ "tracing-core 0.2.0",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2672,17 +2668,7 @@ dependencies = [
 [[package]]
 name = "tracing-attributes"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing?branch=master#e603c2a254d157a25a7a1fbfd4da46ad7e05f555"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.18",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing#29146260fb4615d271d2e899ad95a753bb42915e"
+source = "git+https://github.com/tokio-rs/tracing#2906278ba7afde87067a5af7c4eab51ebc410619"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2702,12 +2688,10 @@ dependencies = [
 [[package]]
 name = "tracing-core"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing?branch=master#e603c2a254d157a25a7a1fbfd4da46ad7e05f555"
-
-[[package]]
-name = "tracing-core"
-version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing#29146260fb4615d271d2e899ad95a753bb42915e"
+source = "git+https://github.com/tokio-rs/tracing#2906278ba7afde87067a5af7c4eab51ebc410619"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "tracing-log"
@@ -2737,7 +2721,18 @@ dependencies = [
  "tracing-core 0.1.31",
  "tracing-subscriber",
  "url",
- "uuid 1.3.3",
+ "uuid 1.3.4",
+]
+
+[[package]]
+name = "tracing-serde-structured"
+version = "0.1.0"
+source = "git+https://github.com/hawkw/tracing-serde-structured?branch=eliza/tracing-02#d07ba882696ec2b8d390df279fee8046b282f60c"
+dependencies = [
+ "hash32 0.2.1",
+ "heapless",
+ "serde",
+ "tracing-core 0.2.0",
 ]
 
 [[package]]
@@ -2793,9 +2788,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2813,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
 dependencies = [
  "getrandom",
  "serde",
@@ -2853,11 +2848,10 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -2875,9 +2869,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -2885,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
@@ -2900,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2910,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2923,9 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "weezl"
@@ -2970,7 +2964,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2990,35 +2984,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "clap 4.3.5",
  "cobs",
  "mnemos-trace-proto",
+ "owo-colors",
  "postcard 1.0.4",
  "serde",
  "serialport",
@@ -1213,6 +1214,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1789,15 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+dependencies = [
+ "supports-color",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2494,6 +2510,16 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "supports-color"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
+dependencies = [
+ "atty",
+ "is_ci",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ members = [
 git = "https://github.com/hawkw/mycelium.git"
 rev = "cbcfc62a6ea3646fb43f2c159cfdc19b3d932004"
 
+[patch.crates-io.mycelium-util]
+git = "https://github.com/hawkw/mycelium.git"
+rev = "cbcfc62a6ea3646fb43f2c159cfdc19b3d932004"
+
+
 [patch.crates-io.cordyceps]
 git = "https://github.com/hawkw/mycelium.git"
 rev = "cbcfc62a6ea3646fb43f2c159cfdc19b3d932004"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "source/melpomene",
     "source/alloc",
     "source/forth3",
+    "source/trace-proto",
 
     # tools
     "tools/crowtty",

--- a/source/kernel/Cargo.toml
+++ b/source/kernel/Cargo.toml
@@ -41,12 +41,29 @@ optional = true
 [dependencies.tracing-02]
 package = "tracing"
 git = "https://github.com/tokio-rs/tracing"
-branch = "master"
+# branch = "master"
 features = ["attributes"]
 default-features = false
 optional = true
 
+[dependencies.tracing-core-02]
+package = "tracing-core"
+git = "https://github.com/tokio-rs/tracing"
+# branch = "master"
+default-features = false
+optional = true
+
+[dependencies.tracing-serde-structured]
+git = "https://github.com/hawkw/tracing-serde-structured"
+branch = "eliza/tracing-02"
+default-features = false
+optional = true
+
 [dependencies.maitake]
+version = "0.1.0"
+default-features = false
+
+[dependencies.mycelium-util]
 version = "0.1.0"
 default-features = false
 
@@ -86,6 +103,7 @@ version = "1"
 
 [features]
 default = ["tracing-01"]
+tracing-02 = ["dep:tracing-02", "tracing-core-02", "tracing-serde-structured"]
 
 # The `_oops_all_tracing_features` feature is a "trap" for when the package is built
 # with `--all-features`, which is usually just for docs and testing.

--- a/source/kernel/Cargo.toml
+++ b/source/kernel/Cargo.toml
@@ -59,6 +59,10 @@ branch = "eliza/tracing-02"
 default-features = false
 optional = true
 
+[dependencies.mnemos-trace-proto]
+path = "../trace-proto"
+optional = true
+
 [dependencies.maitake]
 version = "0.1.0"
 default-features = false
@@ -103,7 +107,7 @@ version = "1"
 
 [features]
 default = ["tracing-01"]
-tracing-02 = ["dep:tracing-02", "tracing-core-02", "tracing-serde-structured"]
+tracing-02 = ["dep:tracing-02", "tracing-core-02", "tracing-serde-structured", "mnemos-trace-proto"]
 
 # The `_oops_all_tracing_features` feature is a "trap" for when the package is built
 # with `--all-features`, which is usually just for docs and testing.

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -75,6 +75,8 @@ pub mod drivers;
 pub(crate) mod fmt;
 pub mod forth;
 pub mod registry;
+#[cfg(feature = "tracing-02")]
+pub mod trace;
 
 use abi::{
     bbqueue_ipc::{

--- a/source/kernel/src/trace.rs
+++ b/source/kernel/src/trace.rs
@@ -1,0 +1,120 @@
+use crate::{drivers::serial_mux, comms::bbq};
+use portable_atomic::{AtomicU64, AtomicPtr, Ordering};
+pub use tracing_02::*;
+use level_filters::LevelFilter;
+use tracing_core_02::span::Current;
+use tracing_serde_structured::AsSerde;
+use mycelium_util::sync::{spin::Mutex, InitOnce};
+
+pub struct SerialCollector {
+    tx: InitOnce<bbq::SpscProducer>,
+    /// ID of the current span.
+    ///
+    /// **Note**: This collector only works correctly on single-threaded hardware!
+    current_span: AtomicU64,
+    current_meta: AtomicPtr<Metadata<'static>>,
+
+    /// ID of the next span.
+    next_id: AtomicU64,
+
+    max_level: LevelFilter,
+}
+
+// === impl SerialCollector ===
+
+impl SerialCollector {
+    pub const PORT: u16 = 3;
+    const CAPACITY: usize = 1024 * 4;
+
+    pub const fn new(max_level: LevelFilter) -> Self {
+        Self {
+            tx: InitOnce::uninitialized(),
+            current_span: AtomicU64::new(0),
+            current_meta: AtomicPtr::new(core::ptr::null_mut()),
+            next_id: AtomicU64::new(1),
+            max_level,
+        }
+    }
+
+    pub async fn start(&'static self, k: &'static crate::Kernel) {
+        let mut mux = serial_mux::SerialMuxClient::from_registry(k).await.expect("cannot initialize serial tracing, no serial mux exists!");
+        let port = mux.open_port(3, 1024).await.expect("cannot initialize serial tracing, cannot open port 3!");
+        let (tx, rx) = bbq::new_spsc_channel(k.heap(), Self::CAPACITY).await;
+        self.tx.init(tx);
+        k.spawn(Self::worker(rx, port)).await;
+        let dispatch = tracing_02::Dispatch::from_static(self);
+        tracing_02::dispatch::set_global_default(dispatch).expect("cannot set global default tracing dispatcher");
+    }
+
+    async fn worker(rx: bbq::Consumer, port: serial_mux::PortHandle) {
+        loop {
+            let rgr = rx.read_grant().await;
+            let len = rgr.len();
+            port.send(&rgr[..]).await;
+            rgr.release(len);
+        }
+    }
+}
+
+impl Collect for SerialCollector {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        // TODO(eliza): more sophisticated filtering
+        metadata.level() <= &self.max_level
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        Some(self.max_level)
+    }
+
+    fn new_span(&self, span: &span::Attributes<'_>) -> span::Id {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        span::Id::from_u64(id)
+    }
+
+    fn record(&self, span: &span::Id, values: &span::Record<'_>) {
+        // todo!("eliza")
+    }
+
+    fn enter(&self, span: &span::Id) {
+        // todo!("eliza");
+    }
+
+    fn exit(&self, span: &span::Id) {
+        // todo!("eliza")
+    }
+
+    fn record_follows_from(&self, span: &span::Id, follows: &span::Id) {
+        // nop for now
+    }
+
+    fn event(&self, event: &Event<'_>) {
+        if let Some(mut wgr) = self.tx.get().send_grant_max_sync(1024) {
+            let len = match postcard::to_slice_cobs(&event.as_serde(), &mut wgr[..]) {
+                Ok(encoded) => encoded.len(),
+                Err(_) => 0, // we will release any bytes written to be clobbered.
+            };
+            wgr.commit(len);
+
+        } else {
+            // drop the new event
+            // XXX(eliza): it would be nicer to get ring-buffer behavior
+            // (dropping the oldest, rather than the newest, entry)...we
+            // probably need a new channel type for that.
+        }
+    }
+
+    fn current_span(&self) -> Current {
+        let id = match core::num::NonZeroU64::new(self.current_span.load(Ordering::Acquire)) {
+            Some(id) => Id::from_non_zero_u64(id),
+            None => return Current::none(),
+        };
+        let meta = match core::ptr::NonNull::new(self.current_meta.load(Ordering::Acquire)) {
+            Some(meta) => unsafe {
+                // safety: it's guaranteed to have been an `&'static Metadata<'static>`
+                meta.as_ref()
+            },
+            None => return Current::none(),
+        };
+        Current::new(id, meta)
+    }
+}

--- a/source/trace-proto/Cargo.toml
+++ b/source/trace-proto/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "mnemos-trace-proto"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+std = ["tracing-serde-structured/std", "serde/std"]
+
+[dependencies.serde]
+version = "1"
+default-features = false
+features = ["derive"]
+
+[dependencies.tracing-serde-structured]
+git = "https://github.com/hawkw/tracing-serde-structured"
+branch = "eliza/tracing-02"
+default-features = false

--- a/source/trace-proto/src/lib.rs
+++ b/source/trace-proto/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use tracing_serde_structured::{SerializeEvent, SerializeId, SerializeAttributes};
+use tracing_serde_structured::{SerializeAttributes, SerializeEvent, SerializeId};
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub enum TraceEvent<'a> {

--- a/source/trace-proto/src/lib.rs
+++ b/source/trace-proto/src/lib.rs
@@ -1,0 +1,21 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use tracing_serde_structured::{SerializeEvent, SerializeId, SerializeAttributes};
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum TraceEvent<'a> {
+    #[serde(borrow)]
+    Event(SerializeEvent<'a>),
+
+    NewSpan {
+        id: SerializeId,
+
+        #[serde(borrow)]
+        attributes: SerializeAttributes<'a>,
+    },
+
+    Enter(SerializeId),
+    Exit(SerializeId),
+    CloneSpan(SerializeId),
+    DropSpan(SerializeId),
+}

--- a/tools/crowtty/Cargo.toml
+++ b/tools/crowtty/Cargo.toml
@@ -11,6 +11,10 @@ serialport = "4.0.1"
 [dependencies.cobs]
 version = "0.2"
 
+[dependencies.clap]
+version = "4.0"
+features = ["derive"]
+
 [dependencies.serde]
 version = "1.0"
 features = ["derive"]

--- a/tools/crowtty/Cargo.toml
+++ b/tools/crowtty/Cargo.toml
@@ -22,3 +22,7 @@ version = "1"
 git = "https://github.com/hawkw/tracing-serde-structured"
 branch = "eliza/tracing-02"
 default-features = true
+
+[dependencies.mnemos-trace-proto]
+path = "../../source/trace-proto"
+features = ["std"]

--- a/tools/crowtty/Cargo.toml
+++ b/tools/crowtty/Cargo.toml
@@ -22,6 +22,10 @@ features = ["derive"]
 [dependencies.postcard]
 version = "1"
 
+[dependencies.owo-colors]
+version = "3.5"
+features = ["supports-colors"]
+
 [dependencies.tracing-serde-structured]
 git = "https://github.com/hawkw/tracing-serde-structured"
 branch = "eliza/tracing-02"

--- a/tools/crowtty/Cargo.toml
+++ b/tools/crowtty/Cargo.toml
@@ -14,3 +14,11 @@ version = "0.2"
 [dependencies.serde]
 version = "1.0"
 features = ["derive"]
+
+[dependencies.postcard]
+version = "1"
+
+[dependencies.tracing-serde-structured]
+git = "https://github.com/hawkw/tracing-serde-structured"
+branch = "eliza/tracing-02"
+default-features = true

--- a/tools/crowtty/src/main.rs
+++ b/tools/crowtty/src/main.rs
@@ -1,13 +1,13 @@
 use serde::{Deserialize, Serialize};
 use serialport::SerialPort;
 use std::collections::HashMap;
+use std::fmt;
 use std::io::{ErrorKind, Read, Write};
 use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread::{sleep, spawn, JoinHandle};
-use std::time::{Instant, Duration};
-use std::path::PathBuf;
-use std::fmt;
+use std::time::{Duration, Instant};
 
 #[derive(Serialize, Deserialize)]
 pub struct Chunk {
@@ -56,8 +56,8 @@ enum Command {
 
         /// baud rate (usually 115200 for hw)
         #[arg(default_value_t = 115200)]
-        baud: u32
-    }
+        baud: u32,
+    },
 }
 
 impl std::io::Write for Connect {
@@ -145,7 +145,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 };
 
-                println!("{tag} Listening to port {} ({})", 10_000 + work.port, work.port);
+                println!(
+                    "{tag} Listening to port {} ({})",
+                    10_000 + work.port,
+                    work.port
+                );
 
                 skt.set_read_timeout(Some(Duration::from_millis(10))).ok();
                 // skt.set_nonblocking(true).ok();
@@ -230,7 +234,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let mut enc_msg = cobs::encode_vec(&nmsg);
                 enc_msg.push(0);
                 if verbose {
-                    println!("{} Sending {} bytes to port {port_idx}", tag.port(*port_idx), enc_msg.len());
+                    println!(
+                        "{} Sending {} bytes to port {port_idx}",
+                        tag.port(*port_idx),
+                        enc_msg.len()
+                    );
                 }
                 port.write_all(&enc_msg)?;
             }
@@ -258,7 +266,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 if let Some(hdl) = manager.workers.get_mut(&port) {
                     if verbose {
-                        println!("{} Got {} bytes from port {port}", tag.port(port), remain.len());
+                        println!(
+                            "{} Got {} bytes from port {port}",
+                            tag.port(port),
+                            remain.len()
+                        );
                     }
                     hdl.out.send(remain.to_vec()).ok();
                 }
@@ -314,8 +326,17 @@ impl fmt::Display for LogTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use owo_colors::OwoColorize;
         let elapsed = self.start.elapsed();
-        let port = self.port.as_ref().map(|p| p as &dyn fmt::Display).unwrap_or(&" " as &dyn fmt::Display);
-        format_args!("[{port} +{:04}.{:09}s]", elapsed.as_secs(), elapsed.subsec_nanos())
-            .if_supports_color(owo_colors::Stream::Stdout, |text| text.dimmed()).fmt(f)
+        let port = self
+            .port
+            .as_ref()
+            .map(|p| p as &dyn fmt::Display)
+            .unwrap_or(&" " as &dyn fmt::Display);
+        format_args!(
+            "[{port} +{:04}.{:09}s]",
+            elapsed.as_secs(),
+            elapsed.subsec_nanos()
+        )
+        .if_supports_color(owo_colors::Stream::Stdout, |text| text.dimmed())
+        .fmt(f)
     }
 }

--- a/tools/crowtty/src/main.rs
+++ b/tools/crowtty/src/main.rs
@@ -18,6 +18,8 @@ enum Connect {
     Tcp(TcpStream),
 }
 
+mod trace;
+
 impl std::io::Write for Connect {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         match self {
@@ -180,49 +182,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let trace_handle = {
         let (inp_send, inp_recv) = channel();
         let (out_send, out_recv) = channel::<Vec<u8>>();
-        let trace_start = std::time::Instant::now();
         let thread_hdl = spawn(move || {
-            use std::fmt::Write;
-            use postcard::accumulator::{CobsAccumulator, FeedResult};
-            use tracing_serde_structured::{SerializeEvent, SerializeRecordFields};
-
-            // don't drop it so the channel doesn't close
+            // don't drop this
             let _inp_send = inp_send;
-
-            let mut cobs_buf: CobsAccumulator<1024> = CobsAccumulator::new();
-            let mut textbuf = String::new();
-
-            while let Ok(chunk) = out_recv.recv() {
-                let mut window = &chunk[..];
-
-                'cobs: while !window.is_empty() {
-                    window = match cobs_buf.feed_ref::<SerializeEvent<'_>>(window) {
-                        FeedResult::Consumed => break 'cobs,
-                        FeedResult::OverFull(new_wind) => new_wind,
-                        FeedResult::DeserError(new_wind) => new_wind,
-                        FeedResult::Success { data, remaining } => {
-                            let now = trace_start.elapsed();
-
-                            let target = data.metadata.target.as_str();
-                            let level = data.metadata.level;
-                            write!(&mut textbuf, "[3: {now:?}]: {level:?} {target}").unwrap();
-                            let SerializeRecordFields::De(fields) = data.fields else {
-                                unreachable!("we are deserializing!");
-                            };
-                            for (key, value) in fields {
-                                let key = key.as_str();
-                                write!(&mut textbuf, " {key}={value:?}").unwrap();
-
-                            }
-                            println!("{textbuf}");
-                            textbuf.clear();
-
-                            remaining
-                        }
-                    };
-                }
-            }
-            println!("trace channel over");
+            trace::decode(out_recv)
         });
         WorkerHandle {
             out: out_send,

--- a/tools/crowtty/src/trace.rs
+++ b/tools/crowtty/src/trace.rs
@@ -61,7 +61,7 @@ impl TraceState {
             TraceEvent::Event(ev) => {
                 let target = ev.metadata.target.as_str();
                 let level = ev.metadata.level;
-                write!(&mut self.textbuf, "[+{elapsed:?} {level:?}]").unwrap();
+                write!(&mut self.textbuf, "[+{elapsed:?} {level:?}] ").unwrap();
                 self.write_span_cx();
                 write!(&mut self.textbuf, " {target}: ").unwrap();
                 let SerializeRecordFields::De(ref fields) = ev.fields else {

--- a/tools/crowtty/src/trace.rs
+++ b/tools/crowtty/src/trace.rs
@@ -1,7 +1,9 @@
 use postcard::accumulator::{CobsAccumulator, FeedResult};
-use std::{time::Instant, sync::mpsc, fmt::Write, collections::HashMap, num::NonZeroU64};
-use tracing_serde_structured::{SerializeRecordFields, SerializeSpanFields, SerializeValue, CowString};
+use std::{time::Instant, sync::mpsc, fmt::{self, Write}, collections::HashMap, num::NonZeroU64};
+use tracing_serde_structured::{SerializeRecordFields, SerializeSpanFields, SerializeValue, CowString, SerializeLevel};
 use mnemos_trace_proto::TraceEvent;
+
+use owo_colors::{OwoColorize, Stream};
 use crate::LogTag;
 
 pub(crate) fn decode(rx: mpsc::Receiver<Vec<u8>>, tag: LogTag) {
@@ -51,22 +53,26 @@ struct Span {
 impl TraceState {
     fn write_span_cx(&mut self) {
         let spans = self.stack.iter().filter_map(|id| self.spans.get(id));
+        let mut any = false;
         for span in spans {
             self.textbuf.push_str(span.repr.as_str());
             self.textbuf.push(':');
+            any = true;
+        }
+        if any {
+            self.textbuf.push(' ');
         }
     }
 
     fn event(&mut self, ev: TraceEvent<'_>) {
         let now = Instant::now();
-        let elapsed = now - self.trace_start;
         match ev {
             TraceEvent::Event(ev) => {
                 let target = ev.metadata.target.as_str();
-                let level = ev.metadata.level;
-                write!(&mut self.textbuf, "{} {level:<5?} ", self.tag).unwrap();
+                let target = target.if_supports_color(Stream::Stdout, |target| target.italic());
+                let level = DisplayLevel(ev.metadata.level);
+                write!(&mut self.textbuf, "{} {level} {target}: ", self.tag).unwrap();
                 self.write_span_cx();
-                write!(&mut self.textbuf, "{target}: ").unwrap();
                 let SerializeRecordFields::De(ref fields) = ev.fields else {
                     unreachable!("we are deserializing!");
                 };
@@ -76,17 +82,19 @@ impl TraceState {
             }
             TraceEvent::NewSpan { id, attributes} => {
                 let mut repr = String::new();
-                repr.push_str(attributes.metadata.name.as_str());
-                repr.push('{');
+                let name = attributes.metadata.name.as_str();
+                write!(repr, "{}", format_args!("{name}{{").if_supports_color(Stream::Stdout, |x| x.bold())).unwrap();
                 let SerializeSpanFields::De(ref fields) = attributes.fields else {
                     unreachable!("we are deserializing!");
                 };
                 write_fields(&mut repr, fields);
-                repr.push('}');
-
-                let level = attributes.metadata.level;
+                write!(repr, "{}", "}".if_supports_color(Stream::Stderr, |x| x.bold())).unwrap();
+                
+                let level = DisplayLevel(attributes.metadata.level);
                 let target = attributes.metadata.target.as_str();
-                write!(&mut self.textbuf, "{} {level:<5?} ", self.tag).unwrap();
+                let target = target.if_supports_color(Stream::Stdout, |target| target.italic());
+
+                write!(&mut self.textbuf, "{} {level} ", self.tag).unwrap();
                 self.write_span_cx();
                 write!(&mut self.textbuf, "-> {target}::{repr}").unwrap();
                 println!("{}", self.textbuf);
@@ -114,7 +122,7 @@ fn write_fields<'a>(to: &mut String, fields: impl IntoIterator<Item = (&'a CowSt
     if let Some((key, val)) = fields.next() {
         write_kv(key, val, to);
         for (key, val) in fields {
-            to.push_str(", ");
+            write!(to, "{}", ", ".if_supports_color(Stream::Stdout, |delim| delim.dimmed())).unwrap();
             write_kv(key, val, to);
         }
     }
@@ -124,8 +132,8 @@ fn write_kv(key: &CowString<'_>, val: &SerializeValue<'_>, to: &mut String) {
     use tracing_serde_structured::DebugRecord;
 
     let key = key.as_str();
-    to.push_str(key);
-    to.push('=');
+    let key = key.if_supports_color(Stream::Stdout, |k| k.bold());
+    write!(to, "{key}{}", "=".if_supports_color(Stream::Stdout, |delim| delim.dimmed())).unwrap();
 
     match val {
         SerializeValue::Debug(DebugRecord::De(d)) => to.push_str(d.as_str()),
@@ -136,5 +144,19 @@ fn write_kv(key: &CowString<'_>, val: &SerializeValue<'_>, to: &mut String) {
         SerializeValue::U64(x) => write!(to, "{x}").unwrap(),
         SerializeValue::Bool(x)  => write!(to, "{x}").unwrap(),
         _ => to.push_str("???"),
+    }
+}
+
+struct DisplayLevel(SerializeLevel);
+
+impl fmt::Display for DisplayLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            SerializeLevel::Trace => write!(f, "{}", "TRCE".if_supports_color(Stream::Stdout, |l| l.purple())),
+            SerializeLevel::Debug => write!(f, "{}", "DBUG".if_supports_color(Stream::Stdout, |l| l.blue())),
+            SerializeLevel::Info => write!(f, "{}", "INFO".if_supports_color(Stream::Stdout, |l| l.green())),
+            SerializeLevel::Warn => write!(f, "{}", "WARN".if_supports_color(Stream::Stdout, |l| l.yellow())),
+            SerializeLevel::Error => write!(f, "{}", "ERR!".if_supports_color(Stream::Stdout, |l| l.red())),
+        }
     }
 }


### PR DESCRIPTION
This branch adds an initial implementation of a `tracing` collector that
writes traces to virtual serial port 3 in a COBS+`postcard` binary
format. In addition, it adds a trace viewer capability to `crowtty` when
demuxing port 3, so that the traces written to port 3 are displayed in
`crowtty`'s output. The previous output from `crowtty` that records
every chunk of bytes read/written is now only displayed when a
`--verbose` argument is passed.

Normal `crowtty` output: 

![image](https://github.com/tosc-rs/mnemos/assets/2796466/45d2deb1-27fa-4bbd-a80d-2a43165b094a)

Verbose mode:
![image](https://github.com/tosc-rs/mnemos/assets/2796466/abfbcb75-bd35-43c0-9c3b-6c11146cc664)