### PR TITLE
feat(trace): host-controlled tracing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "rust-analyzer.linkedProjects": [
-        "./platforms/allwinner-d1/drivers/Cargo.toml",
-        "./platforms/allwinner-d1/drivers/Cargo.toml",
-        "./platforms/allwinner-d1/drivers/Cargo.toml"
-    ]
-}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,7 @@ dependencies = [
  "postcard 1.0.4",
  "serde",
  "serialport",
+ "tracing 0.2.0",
  "tracing-serde-structured",
 ]
 

--- a/platforms/allwinner-d1/boards/Cargo.lock
+++ b/platforms/allwinner-d1/boards/Cargo.lock
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "tracing"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing#2906278ba7afde87067a5af7c4eab51ebc410619"
+source = "git+https://github.com/tokio-rs/tracing#c6e8a8f679f40d2528008918e2d636e0b48b8107"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes 0.2.0",
@@ -902,7 +902,7 @@ dependencies = [
 [[package]]
 name = "tracing-attributes"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing#2906278ba7afde87067a5af7c4eab51ebc410619"
+source = "git+https://github.com/tokio-rs/tracing#c6e8a8f679f40d2528008918e2d636e0b48b8107"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -922,7 +922,7 @@ dependencies = [
 [[package]]
 name = "tracing-core"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing#2906278ba7afde87067a5af7c4eab51ebc410619"
+source = "git+https://github.com/tokio-rs/tracing#c6e8a8f679f40d2528008918e2d636e0b48b8107"
 
 [[package]]
 name = "tracing-log"

--- a/platforms/allwinner-d1/boards/lichee-rv/src/main.rs
+++ b/platforms/allwinner-d1/boards/lichee-rv/src/main.rs
@@ -25,8 +25,7 @@ const HEAP_SIZE: usize = 384 * 1024 * 1024;
 #[used]
 static AHEAP: Ram<HEAP_SIZE> = Ram::new();
 
-static COLLECTOR: trace::SerialCollector =
-    trace::SerialCollector::new(trace::level_filters::LevelFilter::DEBUG);
+static COLLECTOR: trace::SerialCollector = trace::SerialCollector::new();
 
 /// A helper to initialize the kernel
 fn initialize_kernel() -> Result<&'static Kernel, ()> {

--- a/source/kernel/Cargo.toml
+++ b/source/kernel/Cargo.toml
@@ -21,6 +21,7 @@ name = "kernel"
 [dependencies.futures]
 version = "0.3.21"
 default-features = false
+features = ["async-await"]
 
 [dependencies.uuid]
 version = "1.1.2"

--- a/source/kernel/src/trace.rs
+++ b/source/kernel/src/trace.rs
@@ -1,8 +1,8 @@
 use crate::{comms::bbq, drivers::serial_mux};
 use level_filters::LevelFilter;
-use mnemos_trace_proto::TraceEvent;
+use mnemos_trace_proto::{HostRequest, TraceEvent};
 use mycelium_util::sync::InitOnce;
-use portable_atomic::{AtomicPtr, AtomicU64, AtomicUsize, Ordering};
+use portable_atomic::{AtomicPtr, AtomicU64, AtomicU8, AtomicUsize, Ordering};
 
 pub use tracing_02::*;
 use tracing_core_02::span::Current;
@@ -25,7 +25,7 @@ pub struct SerialCollector {
     // TODO(eliza): Currently, this is recorded but not actually consumed...
     dropped_events: AtomicUsize,
 
-    max_level: LevelFilter,
+    max_level: AtomicU8,
 }
 
 // === impl SerialCollector ===
@@ -34,14 +34,18 @@ impl SerialCollector {
     pub const PORT: u16 = 3;
     const CAPACITY: usize = 1024 * 4;
 
-    pub const fn new(max_level: LevelFilter) -> Self {
+    pub const fn new() -> Self {
+        Self::with_max_level(LevelFilter::INFO)
+    }
+
+    pub const fn with_max_level(max_level: LevelFilter) -> Self {
         Self {
             tx: InitOnce::uninitialized(),
             current_span: AtomicU64::new(0),
             current_meta: AtomicPtr::new(core::ptr::null_mut()),
             next_id: AtomicU64::new(1),
             dropped_events: AtomicUsize::new(0),
-            max_level,
+            max_level: AtomicU8::new(level_to_u8(max_level)),
         }
     }
 
@@ -55,7 +59,7 @@ impl SerialCollector {
             .expect("cannot initialize serial tracing, cannot open port 3!");
         let (tx, rx) = bbq::new_spsc_channel(k.heap(), Self::CAPACITY).await;
         self.tx.init(tx);
-        k.spawn(Self::worker(rx, port)).await;
+        k.spawn(Self::worker(self, rx, port)).await;
         let dispatch = tracing_02::Dispatch::from_static(self);
         tracing_02::dispatch::set_global_default(dispatch)
             .expect("cannot set global default tracing dispatcher");
@@ -87,12 +91,44 @@ impl SerialCollector {
         len > 0
     }
 
-    async fn worker(rx: bbq::Consumer, port: serial_mux::PortHandle) {
+    async fn worker(&'static self, rx: bbq::Consumer, port: serial_mux::PortHandle) {
+        use futures::FutureExt;
+        use postcard::accumulator::{CobsAccumulator, FeedResult};
+        // we probably won't use 256 whole bytes of cobs yet since all the host
+        // -> target messages are quite small
+        let mut cobs_buf: CobsAccumulator<256> = CobsAccumulator::new();
+
         loop {
-            let rgr = rx.read_grant().await;
-            let len = rgr.len();
-            port.send(&rgr[..]).await;
-            rgr.release(len);
+            futures::select_biased! {
+                rgr = port.consumer().read_grant().fuse() => {
+                    let mut window = &rgr[..];
+
+                    'cobs: while !window.is_empty() {
+                        window = match cobs_buf.feed_ref::<HostRequest>(window) {
+                            FeedResult::Consumed => break 'cobs,
+                            FeedResult::OverFull(new_wind) => new_wind,
+                            FeedResult::DeserError(new_wind) => new_wind,
+                            FeedResult::Success { data, remaining } => {
+                                match data {
+                                    HostRequest::SetMaxLevel(lvl) => {
+                                        let lvl = lvl.map(|lvl| lvl as u8).unwrap_or(5);
+                                        info!("setting max level to {lvl}");
+                                        // self.max_level.store(lvl, Ordering::Relaxed);
+                                        // tracing_core_02::callsite::rebuild_interest_cache();
+                                    }
+                                }
+
+                                remaining
+                            }
+                        };
+                    }
+                },
+                rgr = rx.read_grant().fuse() => {
+                    let len = rgr.len();
+                    port.send(&rgr[..]).await;
+                    rgr.release(len)
+                },
+            }
         }
     }
 }
@@ -100,7 +136,7 @@ impl SerialCollector {
 impl Collect for SerialCollector {
     fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         // TODO(eliza): more sophisticated filtering
-        metadata.level() <= &self.max_level
+        metadata.level() <= &u8_to_level(self.max_level.load(Ordering::Relaxed))
     }
 
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> tracing_core_02::Interest {
@@ -126,7 +162,7 @@ impl Collect for SerialCollector {
     }
 
     fn max_level_hint(&self) -> Option<LevelFilter> {
-        Some(self.max_level)
+        Some(u8_to_level(self.max_level.load(Ordering::Relaxed)))
     }
 
     fn new_span(&self, span: &span::Attributes<'_>) -> span::Id {
@@ -193,5 +229,27 @@ impl Collect for SerialCollector {
     fn try_close(&self, span: span::Id) -> bool {
         self.send_event(16, || TraceEvent::DropSpan(span.as_serde()));
         false
+    }
+}
+
+const fn level_to_u8(level: LevelFilter) -> u8 {
+    match level {
+        LevelFilter::TRACE => 0,
+        LevelFilter::DEBUG => 1,
+        LevelFilter::INFO => 2,
+        LevelFilter::WARN => 3,
+        LevelFilter::ERROR => 4,
+        LevelFilter::OFF => 5,
+    }
+}
+
+const fn u8_to_level(level: u8) -> LevelFilter {
+    match level {
+        0 => LevelFilter::TRACE,
+        1 => LevelFilter::DEBUG,
+        2 => LevelFilter::INFO,
+        3 => LevelFilter::WARN,
+        4 => LevelFilter::ERROR,
+        _ => LevelFilter::OFF,
     }
 }

--- a/source/kernel/src/trace.rs
+++ b/source/kernel/src/trace.rs
@@ -129,7 +129,9 @@ impl SerialCollector {
                     FeedResult::Success { data, remaining } => {
                         match data {
                             HostRequest::SetMaxLevel(lvl) => {
-                                let level = lvl.map(|lvl| lvl as u8).unwrap_or(5);
+                                let level = lvl
+                                    .map(|lvl| lvl as u8)
+                                    .unwrap_or(level_to_u8(LevelFilter::OFF));
                                 let prev = self.max_level.swap(level, Ordering::AcqRel);
                                 if prev != level {
                                     tracing_core_02::callsite::rebuild_interest_cache();

--- a/source/kernel/src/trace.rs
+++ b/source/kernel/src/trace.rs
@@ -108,7 +108,6 @@ impl SerialCollector {
         // we probably won't use 256 whole bytes of cobs yet since all the host
         // -> target messages are quite small
         let mut cobs_buf: CobsAccumulator<16> = CobsAccumulator::new();
-        let mut needs_rebuild = false;
         let mut read_level = |rgr: bbq::GrantR| {
             let mut window = &rgr[..];
             let len = rgr.len();

--- a/source/trace-proto/src/lib.rs
+++ b/source/trace-proto/src/lib.rs
@@ -7,8 +7,9 @@ use tracing_serde_structured::{
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub enum TraceEvent<'a> {
-    /// Sent by the target periodically when not actively tracing, to indicate liveness.
-    Heartbeat,
+    /// Sent by the target periodically when not actively tracing, to indicate
+    /// liveness, or to ack a [`HostRequest::SetMaxLevel`].
+    Heartbeat(Option<SerializeLevel>),
     RegisterMeta {
         id: MetaId,
 

--- a/source/trace-proto/src/lib.rs
+++ b/source/trace-proto/src/lib.rs
@@ -2,7 +2,7 @@
 
 use core::{fmt, num::NonZeroU64};
 use tracing_serde_structured::{
-    SerializeId, SerializeMetadata, SerializeRecordFields, SerializeSpanFields,
+    SerializeId, SerializeMetadata, SerializeRecordFields, SerializeSpanFields, SerializeLevel,
 };
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -34,6 +34,19 @@ pub enum TraceEvent<'a> {
     Exit(SerializeId),
     CloneSpan(SerializeId),
     DropSpan(SerializeId),
+}
+
+
+/// Requests sent from a host to a trace target.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum HostRequest {
+    /// Sets the maximum tracing level. Traces above this verbosity level will
+    /// be discarded.
+    ///
+    /// This may cause the trace target to send new metadata to the host.
+    SetMaxLevel(Option<SerializeLevel>)
+
+    // TODO(eliza): add a keepalive?
 }
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/source/trace-proto/src/lib.rs
+++ b/source/trace-proto/src/lib.rs
@@ -2,11 +2,13 @@
 
 use core::{fmt, num::NonZeroU64};
 use tracing_serde_structured::{
-    SerializeId, SerializeMetadata, SerializeRecordFields, SerializeSpanFields, SerializeLevel,
+    SerializeId, SerializeLevel, SerializeMetadata, SerializeRecordFields, SerializeSpanFields,
 };
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub enum TraceEvent<'a> {
+    /// Sent by the target periodically when not actively tracing, to indicate liveness.
+    Heartbeat,
     RegisterMeta {
         id: MetaId,
 
@@ -36,7 +38,6 @@ pub enum TraceEvent<'a> {
     DropSpan(SerializeId),
 }
 
-
 /// Requests sent from a host to a trace target.
 #[derive(serde::Serialize, serde::Deserialize)]
 pub enum HostRequest {
@@ -44,9 +45,7 @@ pub enum HostRequest {
     /// be discarded.
     ///
     /// This may cause the trace target to send new metadata to the host.
-    SetMaxLevel(Option<SerializeLevel>)
-
-    // TODO(eliza): add a keepalive?
+    SetMaxLevel(Option<SerializeLevel>), // TODO(eliza): add a keepalive?
 }
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/tools/crowtty/Cargo.toml
+++ b/tools/crowtty/Cargo.toml
@@ -21,6 +21,7 @@ features = ["derive"]
 
 [dependencies.postcard]
 version = "1"
+features = ["alloc"]
 
 [dependencies.owo-colors]
 version = "3.5"
@@ -34,3 +35,9 @@ default-features = true
 [dependencies.mnemos-trace-proto]
 path = "../../source/trace-proto"
 features = ["std"]
+
+[dependencies.tracing-02]
+package = "tracing"
+git = "https://github.com/tokio-rs/tracing"
+# branch = "master"
+default-features = false

--- a/tools/crowtty/src/main.rs
+++ b/tools/crowtty/src/main.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread::{sleep, spawn, JoinHandle};
 use std::time::{Duration, Instant};
+use tracing_02::level_filters::LevelFilter;
 
 #[derive(Serialize, Deserialize)]
 pub struct Chunk {
@@ -40,6 +41,10 @@ struct Args {
     /// whether to include verbose logging of bytes in/out.
     #[arg(short, long, global = true)]
     verbose: bool,
+
+    /// maximum `tracing` level to request from the target.
+    #[arg(short, long, global = true, default_value_t = LevelFilter::INFO)]
+    trace_level: LevelFilter,
 }
 
 #[derive(Subcommand)]
@@ -213,11 +218,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let trace_handle = {
         let (inp_send, inp_recv) = channel();
         let (out_send, out_recv) = channel::<Vec<u8>>();
-        let thread_hdl = spawn(move || {
-            // don't drop this
-            let _inp_send = inp_send;
-            trace::decode(out_recv, tag.port(3), verbose)
-        });
+        let max_level = args.trace_level;
+        let thread_hdl =
+            spawn(move || trace::decode(max_level, inp_send, out_recv, tag.port(3), verbose));
         WorkerHandle {
             out: out_send,
             inp: inp_recv,

--- a/tools/crowtty/src/main.rs
+++ b/tools/crowtty/src/main.rs
@@ -123,14 +123,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         workers: HashMap::new(),
     };
 
-    let mut heartbeat = [1u8; 16];
-    let heartbeat = postcard::to_slice_cobs(
-        &mnemos_trace_proto::TraceEvent::Heartbeat,
-        &mut heartbeat[..],
-    )
-    .expect("failed to encode heartbeat msg");
-    println!("{:?}", heartbeat);
-
     // NOTE: You can connect to these ports using the following ncat/netcat/nc commands:
     // ```
     // # connect to port N - stdio

--- a/tools/crowtty/src/trace.rs
+++ b/tools/crowtty/src/trace.rs
@@ -64,7 +64,6 @@ impl TraceWorker {
         let mut cobs_buf: CobsAccumulator<1024> = CobsAccumulator::new();
 
         while let Ok(chunk) = self.rx.recv() {
-            println!("{:?}", chunk);
             let mut window = &chunk[..];
 
             'cobs: while !window.is_empty() {

--- a/tools/crowtty/src/trace.rs
+++ b/tools/crowtty/src/trace.rs
@@ -61,6 +61,17 @@ struct Span {
 
 impl TraceWorker {
     pub(crate) fn run(mut self) {
+        if self.max_level == LevelFilter::TRACE {
+            let warn = "WARN".if_supports_color(Stream::Stdout, |l| l.yellow());
+            let trace = "TRCE".if_supports_color(Stream::Stdout, |l| l.purple());
+            println!(
+                "{} {warn} Max level {trace} requested, this currently causes \
+                the board to hang for some reason.\n\
+                {} {warn} TODO eliza: fix this!",
+                self.tag, self.tag
+            );
+        }
+
         let mut cobs_buf: CobsAccumulator<1024> = CobsAccumulator::new();
 
         while let Ok(chunk) = self.rx.recv() {

--- a/tools/crowtty/src/trace.rs
+++ b/tools/crowtty/src/trace.rs
@@ -73,17 +73,6 @@ struct Span {
 
 impl TraceWorker {
     pub(crate) fn run(mut self) {
-        if self.max_level == LevelFilter::TRACE {
-            let warn = "WARN".if_supports_color(Stream::Stdout, |l| l.yellow());
-            let trace = "TRCE".if_supports_color(Stream::Stdout, |l| l.purple());
-            println!(
-                "{} {warn} Max level {trace} requested, this currently causes \
-                the board to hang for some reason.\n\
-                {} {warn} TODO eliza: fix this!",
-                self.tag, self.tag
-            );
-        }
-
         let mut cobs_buf: CobsAccumulator<1024> = CobsAccumulator::new();
 
         while let Ok(chunk) = self.rx.recv() {

--- a/tools/crowtty/src/trace.rs
+++ b/tools/crowtty/src/trace.rs
@@ -17,7 +17,6 @@ use crate::LogTag;
 use owo_colors::{OwoColorize, Stream};
 
 pub(crate) struct TraceWorker {
-    max_level: LevelFilter,
     tx: mpsc::Sender<Vec<u8>>,
     rx: mpsc::Receiver<Vec<u8>>,
     tag: LogTag,
@@ -51,7 +50,6 @@ impl TraceWorker {
             rx,
             tag,
             verbose,
-            max_level,
             spans: HashMap::new(),
             metas: HashMap::new(),
             stack: Vec::new(),


### PR DESCRIPTION
Currently, the `tracing` collector in the Allwinner D1 platform impl is
hardcoded to the DEBUG level. This is unfortunate, as it means that we
will always do the work of collecting and formatting DEBUG traces, even
when no one is listening on the UART tracing port. It would be more
efficient if we only formatted traces when a `crowtty` instance has
subscribed to the UART tracing port. Additionally, because trace
metadata is sent when the callsite is initially registered, a `crowtty`
instance that attaches after the board has started running may miss some
trace metadata. Finally, there is no way to change the trace level on
the fly, as it's hard-coded in the kernel.

This branch changes the `mnemos-trace-proto` wire protocol to include a
host to target message to select a `tracing` level. Now, the board can
start up with all tracing disabled, and `crowtty` can send the desired
tracing level once it connects. This way, we don't collect or format
traces at all when `crowtty` isn't connected. In order to ensure
`crowtty` waits to send the tracing level message only once the board's
tracing code has been initialized, we add a periodic "heartbeat" message
sent by the board on the tracing port while tracing is idle. This is
used by the host which is listening for traces to detect the presence of
the tracing collector on the debug target. The same message is used to
ack a successful request to select the tracing level.

When the tracing level is selected, the target rebuilds `tracing`'s
callsite cache, which means all metadata for callsites which have
previously been hit will be sent to the host. This ensures that
`crowtty` always has the metadata for all tracing spans and events that
are enabled, even if the target encountered them before `crowtty`
connected.

Making this work required fixing an upstream `tracing` bug,
https://github.com/tokio-rs/tracing/pull/2634, where calling into code
that includes `tracing` diagnostics from inside a
`Collect::register_callsite` method would cause a deadlock.
Additionally, I had to add code to the collector for tracking whether
it's inside its own `send` method, in order to temporarily disable `bbq`
tracing. This is because the collector's use of `bbq` creates an
infinite loop when the TRACE level is enabled.

Check this out:
![image](https://github.com/tosc-rs/mnemos/assets/2796466/9a527c27-a5c4-422f-b2b3-bd0a46ba4794)
