### PR TITLE
feat(melpo): trace improvement

### DIFF
--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -96,39 +96,58 @@ async fn kernel_entry(opts: MelpomeneOptions) {
             //
             // Create the buffer, and spawn the worker task, giving it one of the
             // queue handles
+            tracing::debug!("initializing simulated UART ({})", opts.serial_addr);
             TcpSerial::register(k, opts.serial_addr, 4096, 4096, irq)
                 .await
                 .unwrap();
+            tracing::info!("simulated UART ({}) initialized!", opts.serial_addr);
         }
     })
     .unwrap();
 
     // Initialize the SerialMuxServer
-    k.initialize(async {
-        // * Up to 16 virtual ports max
-        // * Framed messages up to 512 bytes max each
-        SerialMuxServer::register(k, 16, 512).await.unwrap();
-    })
+    k.initialize(
+        async {
+            // * Up to 16 virtual ports max
+            // * Framed messages up to 512 bytes max each
+            let ports = 16;
+            let frame_size = 512;
+            tracing::debug!(ports, frame_size, "initializing SerialMuxServer...");
+            SerialMuxServer::register(k, ports, frame_size)
+                .await
+                .unwrap();
+            tracing::info!(ports, frame_size, "SerialMuxServer initialized!");
+        }
+        .instrument(tracing::info_span!("SerialMuxServer")),
+    )
     .unwrap();
 
     // Spawn the graphics driver
     k.initialize(async {
+        tracing::debug!(
+            "initializing SimDisplay server ({DISPLAY_WIDTH_PX}x{DISPLAY_HEIGHT_PX})..."
+        );
         SimDisplay::register(k, 4, DISPLAY_WIDTH_PX, DISPLAY_HEIGHT_PX)
             .await
             .unwrap();
+        tracing::info!("SimDisplayServer initialized!");
     })
     .unwrap();
 
     // Spawn a loopback port
     k.initialize(
         async {
+            const PORT: u16 = 0;
+            tracing::debug!(port = PORT, "initializing SerMux loopback...");
             let mut mux_hdl = SerialMuxClient::from_registry(k).await;
-            let p0 = mux_hdl.open_port(0, 1024).await.unwrap();
+            let p0 = mux_hdl.open_port(PORT, 1024).await.unwrap();
             drop(mux_hdl);
+            tracing::info!("SerMux Loopback running!");
 
             loop {
                 let rgr = p0.consumer().read_grant().await;
                 let len = rgr.len();
+                tracing::trace!(PORT, "Loopback read {len}B");
                 p0.send(&rgr).await;
                 rgr.release(len);
             }
@@ -140,9 +159,12 @@ async fn kernel_entry(opts: MelpomeneOptions) {
     // Spawn a hello port
     k.initialize(
         async {
+            const PORT: u16 = 1;
+            tracing::debug!(port = PORT, "Starting SerMux 'hello world'...");
             let mut mux_hdl = SerialMuxClient::from_registry(k).await;
-            let p1 = mux_hdl.open_port(1, 1024).await.unwrap();
+            let p1 = mux_hdl.open_port(PORT, 1024).await.unwrap();
             drop(mux_hdl);
+            tracing::info!(port = PORT, "SerMux 'hello world' running!");
 
             loop {
                 k.sleep(Duration::from_secs(1)).await;
@@ -156,6 +178,7 @@ async fn kernel_entry(opts: MelpomeneOptions) {
     // Spawn a graphical shell
     k.initialize(
         async move {
+            tracing::debug!("Starting graphics console...");
             graphical_shell_mono(
                 k,   // disp_width_px
                 400, // disp_height_px
@@ -186,18 +209,18 @@ async fn kernel_entry(opts: MelpomeneOptions) {
             // if no timers have expired on this tick, we should sleep until the
             // next timer expires *or* something is woken by I/O, to simulate a
             // hardware platform waiting for an interrupt.
-            tracing::debug!("waiting for an interrupt...");
+            tracing::trace!("waiting for an interrupt...");
 
             // Cap out at 100ms, just in case sim services aren't using the IRQ
             let amount = turn.ticks_to_next_deadline().unwrap_or(100 * 1000); // 1 ticks per us, 1000 us per ms, 100ms sleep
-            tracing::debug!("next timer expires in {amount:?}us");
+            tracing::trace!("next timer expires in {amount:?}us");
             // wait for an "interrupt"
             futures::select! {
                 _ = irq.notified().fuse() => {
-                    tracing::debug!("...woken by I/O interrupt");
+                    tracing::trace!("...woken by I/O interrupt");
                },
                _ = tokio::time::sleep(Duration::from_micros(amount.into())).fuse() => {
-                    tracing::debug!("woken by timer");
+                    tracing::trace!("woken by timer");
                }
             }
 


### PR DESCRIPTION
This commit demotes the traces emitted by Melpomene on every iteration of the kernel run loop from DEBUG to TRACE, as these occur *extremely* frequently and spam the console when trying to get debugging output from other parts of the kernel. In addition, I've added new tracing messages when a kernel server is started in Melpomene so that we can easily trace the boot process.