### PR TITLE
feat(allwinner-d1): panic handling improvements

### DIFF
--- a/platforms/allwinner-d1/core/src/drivers/uart.rs
+++ b/platforms/allwinner-d1/core/src/drivers/uart.rs
@@ -259,11 +259,17 @@ pub unsafe fn kernel_uart(ccu: &mut CCU, gpio: &mut GPIO, uart0: UART0) -> Uart 
 pub struct Uart(d1_pac::UART0);
 impl core::fmt::Write for Uart {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl Uart {
+    pub fn write(&mut self, buf: &[u8]) {
         while self.0.usr.read().tfnf().bit_is_clear() {}
-        for byte in s.as_bytes() {
+        for byte in buf {
             self.0.thr().write(|w| unsafe { w.thr().bits(*byte) });
             while self.0.usr.read().tfnf().bit_is_clear() {}
         }
-        Ok(())
     }
 }

--- a/platforms/allwinner-d1/core/src/lib.rs
+++ b/platforms/allwinner-d1/core/src/lib.rs
@@ -281,12 +281,25 @@ impl D1 {
         // Ugly but works
         let mut uart: Uart = unsafe { core::mem::transmute(()) };
 
-        write!(&mut uart, "\r\n").ok();
-        write!(&mut uart, "{}\r\n", info).ok();
+        // end any existing SerMux frame on the UART
+        uart.write(&[0]);
+
+        // write out the panic message in plaintext
+        write!(&mut uart, "\r\n{info}\r\n").ok();
+        // end the SerMux frame so crowtty can decode the panic message as utf8
+        uart.write(&[0]);
+
+        write!(
+            &mut uart,
+            "you've met with a terrible fate, haven't you?\r\n"
+        )
+        .ok();
         uart.write(&[0]);
 
         die();
 
+        /// to sleep, perchance to dream; aye, there's the rub,
+        /// for in that sleep of death, what dreams may come?
         fn die() -> ! {
             loop {
                 // wait for an interrupt to pause the CPU. since we just

--- a/platforms/allwinner-d1/core/src/lib.rs
+++ b/platforms/allwinner-d1/core/src/lib.rs
@@ -289,7 +289,12 @@ impl D1 {
 
         fn die() -> ! {
             loop {
-                core::sync::atomic::fence(Ordering::SeqCst);
+                // wait for an interrupt to pause the CPU. since we just
+                // disabled interrupts above, this will keep the CPU in a low
+                // power state until it's reset.
+                unsafe {
+                    riscv::asm::wfi();
+                }
             }
         }
     }

--- a/platforms/allwinner-d1/core/src/lib.rs
+++ b/platforms/allwinner-d1/core/src/lib.rs
@@ -283,6 +283,7 @@ impl D1 {
 
         write!(&mut uart, "\r\n").ok();
         write!(&mut uart, "{}\r\n", info).ok();
+        uart.write(&[0]);
 
         die();
 

--- a/tools/crowtty/src/main.rs
+++ b/tools/crowtty/src/main.rs
@@ -237,6 +237,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mux = " MUX".if_supports_color(Stream::Stdout, |s| s.cyan());
     let dmux = "DMUX".if_supports_color(Stream::Stdout, |s| s.bright_purple());
     let err = "ERR!".if_supports_color(Stream::Stdout, |err| err.red());
+    let text = "TEXT".if_supports_color(Stream::Stdout, |s| s.bright_yellow());
     loop {
         let mut buf = [0u8; 256];
 
@@ -284,8 +285,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                     hdl.out.send(remain.to_vec()).ok();
                 }
+            } else if let Ok(s) = std::str::from_utf8(&carry[..]) {
+                for line in s.lines() {
+                    println!("{tag} {text} {line}");
+                }
             } else {
-                println!("{} {dmux} {err} Bad decode!", tag);
+                println!("{tag} {dmux} {err} Bad decode!");
             }
             // if let Ok(msg) = Message::decode_in_place(&mut carry) {
 


### PR DESCRIPTION
This branch contains two commits:

* feat(allwinner-d1): disable IRQs in panic

  This commit changes the panic handler for the D1 to disable
  interrupts, and adds a flag for tracking double panics. If we panic
  inside the panic handler, we now just die immediately instead of
  trying to print something.

* feat(crowtty): try to decode loose utf8

  This commit changes crowtty to attempt to decode any output that isn't
  in a SerMux frame as UTF-8 text. This lets us get panic output without
  having to do fancy COBS encoding in the panic handler. It also lets us
  see other stuff, like `xfel`'s bootloader output.
  
  For example: 
  ![image](https://github.com/tosc-rs/mnemos/assets/2796466/bcbdede6-86bb-4567-a650-46a7c9f6dc9a)
