### PR TITLE
feat(allwinner-d1): cancel in-flight DMA on panic

### DIFF
--- a/platforms/allwinner-d1/core/src/dmac/mod.rs
+++ b/platforms/allwinner-d1/core/src/dmac/mod.rs
@@ -15,10 +15,12 @@ pub mod descriptor;
 
 pub struct Dmac {
     pub dmac: DMAC, // TODO: not this
-    pub channels: [Channel; 16],
+    pub channels: [Channel; Self::CHANNEL_COUNT as usize],
 }
 
 impl Dmac {
+    pub const CHANNEL_COUNT: u8 = 16;
+
     pub fn new(dmac: DMAC, ccu: &mut CCU) -> Self {
         ccu.dma_bgr.write(|w| w.gating().pass().rst().deassert());
         Self {
@@ -51,7 +53,7 @@ pub struct Channel {
 
 impl Channel {
     pub unsafe fn summon_channel(idx: u8) -> Channel {
-        assert!(idx < 16);
+        assert!(idx < Dmac::CHANNEL_COUNT);
         Self { idx }
     }
 

--- a/platforms/allwinner-d1/core/src/lib.rs
+++ b/platforms/allwinner-d1/core/src/lib.rs
@@ -276,7 +276,16 @@ impl D1 {
             die();
         }
 
-        // TODO(eliza): abort any in-flight DMAs.
+        // Cancel any in-flight DMA requests. It's particularly important to
+        // cancel the UART TX DMA channel, because we're about to dump the panic
+        // message to the UART, but we may as well tear down any other in-flight
+        // DMAs.
+        for idx in 0..Dmac::CHANNEL_COUNT {
+            unsafe {
+                let mut ch = dmac::Channel::summon_channel(idx);
+                ch.stop_dma();
+            }
+        }
 
         // Ugly but works
         let mut uart: Uart = unsafe { core::mem::transmute(()) };


### PR DESCRIPTION
This commit updates the Allwinner D1 panic handler to cancel all in-flight DMA requests when panicking.