### PR TITLE
feat(trace): print some identifying information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "time",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -1530,6 +1530,7 @@ dependencies = [
  "tracing-core 0.2.0",
  "tracing-serde-structured",
  "uuid 1.3.4",
+ "vergen",
 ]
 
 [[package]]
@@ -2635,6 +2636,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+dependencies = [
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,6 +3017,18 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "8.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3c89c2c7e50f33e4d35527e5bf9c11d6d132226dbbd1753f0fbe9f19ef88c6"
+dependencies = [
+ "anyhow",
+ "rustc_version",
+ "rustversion",
+ "time 0.3.22",
+]
 
 [[package]]
 name = "version_check"

--- a/platforms/allwinner-d1/boards/Cargo.lock
+++ b/platforms/allwinner-d1/boards/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "atomic-polyfill"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +334,12 @@ version = "0.1.0"
 source = "git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033"
 
 [[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +444,7 @@ dependencies = [
  "tracing-core 0.2.0",
  "tracing-serde-structured",
  "uuid",
+ "vergen",
 ]
 
 [[package]]
@@ -896,6 +909,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+dependencies = [
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1065,18 @@ name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "vergen"
+version = "8.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3c89c2c7e50f33e4d35527e5bf9c11d6d132226dbbd1753f0fbe9f19ef88c6"
+dependencies = [
+ "anyhow",
+ "rustc_version",
+ "rustversion",
+ "time",
+]
 
 [[package]]
 name = "version_check"

--- a/platforms/allwinner-d1/core/src/lib.rs
+++ b/platforms/allwinner-d1/core/src/lib.rs
@@ -118,7 +118,6 @@ impl D1 {
         // initialize tracing
         k.initialize(async move {
             COLLECTOR.start(k).await;
-            trace::info!("started tracing");
         })
         .unwrap();
 

--- a/source/kernel/Cargo.toml
+++ b/source/kernel/Cargo.toml
@@ -13,6 +13,8 @@ categories = [
 ]
 license = "MIT OR Apache-2.0"
 
+build = "build.rs"
+
 [lib]
 name = "kernel"
 
@@ -117,6 +119,9 @@ rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033"
 
 [dependencies.profont]
 version = "0.6.1"
+
+[build-dependencies]
+vergen = { version = "8.0.0", features = ["cargo", "git", "gitcl", "rustc",] }
 
 [features]
 default = ["tracing-01"]

--- a/source/kernel/build.rs
+++ b/source/kernel/build.rs
@@ -1,0 +1,10 @@
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    vergen::EmitBuilder::builder()
+        .all_cargo()
+        .all_git()
+        .all_rustc()
+        .emit()?;
+    Ok(())
+}

--- a/source/kernel/src/trace.rs
+++ b/source/kernel/src/trace.rs
@@ -130,6 +130,17 @@ impl SerialCollector {
                                 let prev = self.max_level.swap(level, Ordering::AcqRel);
                                 if prev != level {
                                     tracing_core_02::callsite::rebuild_interest_cache();
+                                    info!(
+                                        message = %"hello from mnemOS",
+                                        version = %env!("CARGO_PKG_VERSION"),
+                                        git = %format_args!(
+                                            "{}@{}",
+                                            env!("VERGEN_GIT_BRANCH"),
+                                            env!("VERGEN_GIT_DESCRIBE")
+                                        ),
+                                        target = %env!("VERGEN_CARGO_TARGET_TRIPLE"),
+                                        profile = %if cfg!(debug_assertions) { "debug" } else { "release" },
+                                    );
                                 }
                             }
                         }


### PR DESCRIPTION
This commit changes the kernel's `tracing` subscriber so that when a host crowtty connects and selects a tracing level, the kernel immediately prints identifying information, including the version, Git commit the kernel was built from, target, and rustc profile.

This serves two purposes: one, it lets the user know that the desired trace level has been selected and the board isn't hung, and it allows the user to know what version of the kernel they're running. Knowing the version and Git SHA is useful in development in cases where, for example, you've previously flashed the board with a different dev branch than the one you're trying to test.

For example: 
![image](https://github.com/tosc-rs/mnemos/assets/2796466/83c13bcb-30ce-4d48-8646-ff4b347e6a79)
