### PR TITLE
feat(sermux + crowtty): Move sermux/crowtty protocol into separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,6 +557,7 @@ dependencies = [
  "serde",
  "serialport 4.0.1",
  "serialport 4.2.1",
+ "sermux-proto",
  "tracing 0.2.0",
  "tracing-serde-structured",
 ]
@@ -1524,6 +1525,7 @@ dependencies = [
  "profont",
  "ring-drawer",
  "serde",
+ "sermux-proto",
  "spitebuf",
  "tracing 0.1.37",
  "tracing 0.2.0",
@@ -2446,6 +2448,13 @@ dependencies = [
  "regex",
  "scopeguard",
  "winapi",
+]
+
+[[package]]
+name = "sermux-proto"
+version = "0.1.0"
+dependencies = [
+ "cobs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "source/melpomene",
     "source/alloc",
     "source/forth3",
+    "source/sermux-proto",
     "source/trace-proto",
 
     # tools

--- a/platforms/allwinner-d1/boards/Cargo.lock
+++ b/platforms/allwinner-d1/boards/Cargo.lock
@@ -439,6 +439,7 @@ dependencies = [
  "profont",
  "ring-drawer",
  "serde",
+ "sermux-proto",
  "spitebuf",
  "tracing 0.2.0",
  "tracing-core 0.2.0",
@@ -817,6 +818,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.18",
+]
+
+[[package]]
+name = "sermux-proto"
+version = "0.1.0"
+dependencies = [
+ "cobs",
 ]
 
 [[package]]

--- a/platforms/allwinner-d1/boards/src/bin/lichee-rv.rs
+++ b/platforms/allwinner-d1/boards/src/bin/lichee-rv.rs
@@ -47,6 +47,13 @@ fn main() -> ! {
         .initialize(SharpDisplay::register(d1.kernel, 4))
         .unwrap();
 
+    d1.kernel
+        .initialize(async move {
+            d1.kernel.sleep(Duration::from_secs(15)).await;
+            panic!("Whoopsie");
+        })
+        .unwrap();
+
     // Initialize LED loop
     d1.kernel
         .initialize(async move {

--- a/source/README.md
+++ b/source/README.md
@@ -22,7 +22,9 @@ Focus on userspace will resume after more progress has been made on the kernel.
 * [`melpomene/`] - Melpomene is the simulator for MnemOS development
 * [`mstd/`] - This is the userspace "standard library", which wraps mnemos-specific capabilities
 * [`notes/`] - Miscellaneous development notes
+* [`sermux-proto`] - Wire types used for the Serial Mux service, which allows for multiplexed "ports" over a serial link
 * [`spitebuf/`] - This is an async, mpsc library which powers the Kernel's `KChannel` data type
+* [`trace-proto`] - Wire types used for sending binary encoded `tracing` data from the target to a host
 
 [`abi/`]: ./abi/
 [`alloc/`]: ./alloc
@@ -31,7 +33,9 @@ Focus on userspace will resume after more progress has been made on the kernel.
 [`melpomene/`]: ./melpomene/
 [`mstd/`]: ./mstd/
 [`notes/`]: ./notes/
+[`sermux-proto`]: ./sermux-proto
 [`spitebuf/`]: ./spitebuf
+[`trace-proto`]: ./trace-proto
 
 [Forth]: https://forth-standard.org/
 

--- a/source/kernel/Cargo.toml
+++ b/source/kernel/Cargo.toml
@@ -117,6 +117,10 @@ rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033"
 git = "https://github.com/tosc-rs/teletype/"
 rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033"
 
+[dependencies.sermux-proto]
+path = "../sermux-proto"
+default-features = false
+
 [dependencies.profont]
 version = "0.6.1"
 

--- a/source/kernel/src/services/serial_mux.rs
+++ b/source/kernel/src/services/serial_mux.rs
@@ -21,26 +21,11 @@ use crate::{
 };
 use maitake::sync::Mutex;
 use mnemos_alloc::containers::{Arc, FixedVec};
+use sermux_proto::PortChunk;
 use uuid::Uuid;
 
-////////////////////////////////////////////////////////////////////////////////
-// Well Known Ports
-////////////////////////////////////////////////////////////////////////////////
-
-/// Well known [SerialMuxService] ports
-#[repr(u16)]
-#[non_exhaustive]
-pub enum WellKnown {
-    /// A bidirectional loopback channel - echos all characters back
-    Loopback = 0,
-    /// An output-only channel for sending periodic sign of life messages
-    HelloWorld = 1,
-    /// An input-only channel to act as a keyboard for a GUI application
-    /// such as a forth console, when there is no hardware keyboard available
-    PsuedoKeyboard = 2,
-    /// A bidirectional for binary encoded tracing messages
-    BinaryTracing = 3,
-}
+// Well known ports live in the sermux_proto crate
+pub use sermux_proto::WellKnown;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Service Definition
@@ -168,14 +153,14 @@ impl PortHandle {
         let msg_chunk = self.max_frame / 2;
 
         for chunk in data.chunks(msg_chunk) {
-            let enc_chunk = cobs::max_encoding_length(chunk.len() + 2);
-            let mut wgr = self.outgoing.send_grant_exact(enc_chunk + 1).await;
-            let mut encoder = cobs::CobsEncoder::new(&mut wgr);
-            encoder.push(&self.port.to_le_bytes()).unwrap();
-            encoder.push(chunk).unwrap();
-            let used = encoder.finalize().unwrap();
-            wgr[used] = 0;
-            wgr.commit(used + 1);
+            let pc = PortChunk::new(self.port, chunk);
+            let needed = pc.buffer_required();
+            let mut wgr = self.outgoing.send_grant_exact(needed).await;
+            let used = pc
+                .encode_to(&mut wgr)
+                .expect("sermux encoding should not fail")
+                .len();
+            wgr.commit(used);
         }
     }
 }

--- a/source/sermux-proto/Cargo.toml
+++ b/source/sermux-proto/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sermux-proto"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[dependencies.cobs]
+version = "0.2"
+default-features = false
+
+[features]
+use-std = []

--- a/source/sermux-proto/src/lib.rs
+++ b/source/sermux-proto/src/lib.rs
@@ -1,0 +1,263 @@
+//! # sermux-proto
+//!
+//! Wire types used by the `SerialMuxService` in the kernel. Extracted as a
+//! separate crate to allow external decoders (like `crowtty`) to share protocol
+//! definitions
+
+#![cfg_attr(not(any(test, feature = "use-std")), no_std)]
+
+use core::mem::size_of;
+
+////////////////////////////////////////////////////////////////////////////////
+// Well Known Ports
+////////////////////////////////////////////////////////////////////////////////
+
+/// Well known [SerialMuxService] ports
+#[repr(u16)]
+#[non_exhaustive]
+pub enum WellKnown {
+    /// A bidirectional loopback channel - echos all characters back
+    Loopback = 0,
+    /// An output-only channel for sending periodic sign of life messages
+    HelloWorld = 1,
+    /// An input-only channel to act as a keyboard for a GUI application
+    /// such as a forth console, when there is no hardware keyboard available
+    PsuedoKeyboard = 2,
+    /// A bidirectional for binary encoded tracing messages
+    BinaryTracing = 3,
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum Error {
+    /// The provided buffer is not suitable in size
+    InsufficientSize,
+    /// Ran out of room while filling a buffer, this is likely
+    /// an error in the `sermux-proto` library.
+    UnexpectedBufferFull,
+    /// The cobs decoding process failed. The message was likely
+    /// malformed or not a sermux-proto frame
+    CobsDecodeFailed,
+    /// Cobs decoding succeeded, but the resulting data was not
+    /// a valid sermux-proto frame
+    MalformedFrame,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct PortChunk<'a> {
+    pub port: u16,
+    pub chunk: &'a [u8],
+}
+
+impl<'a> PortChunk<'a> {
+    /// Create a new PortChunk from the given port and data
+    #[inline]
+    pub fn new(port: u16, chunk: &'a [u8]) -> Self {
+        Self { port, chunk }
+    }
+
+    /// Calculate the size required to encode the given data payload size
+    #[inline]
+    pub fn buffer_required(&self) -> usize {
+        // Room for COBS(port:u16 + data:[u8; len]) plus a terminating zero
+        cobs::max_encoding_length(self.chunk.len() + size_of::<u16>() + 1)
+    }
+
+    /// Encodes the current [PortChunk] into the given buffer
+    pub fn encode_to<'b>(&self, out_buf: &'b mut [u8]) -> Result<&'b mut [u8], Error> {
+        let PortChunk { port, chunk } = self;
+        if out_buf.len() < self.buffer_required() {
+            return Err(Error::InsufficientSize);
+        }
+
+        let mut encoder = cobs::CobsEncoder::new(out_buf);
+        encoder
+            .push(&port.to_le_bytes())
+            .map_err(|_| Error::UnexpectedBufferFull)?;
+        encoder
+            .push(chunk)
+            .map_err(|_| Error::UnexpectedBufferFull)?;
+        let used = encoder
+            .finalize()
+            .map_err(|_| Error::UnexpectedBufferFull)?;
+        // Get the encoded amount, with room for an extra zero terminator
+        let res = out_buf
+            .get_mut(..used + 1)
+            .ok_or(Error::UnexpectedBufferFull)?;
+        res[used] = 0;
+        Ok(res)
+    }
+
+    /// Decodes a [PortChunk] from the given buffer
+    ///
+    /// NOTE: This MAY mutate `data`, even if the decoding fails.
+    pub fn decode_from(data: &'a mut [u8]) -> Result<Self, Error> {
+        let dec_len = cobs::decode_in_place(data).map_err(|_| Error::CobsDecodeFailed)?;
+
+        // Messages must have a port and at least one data byte to be
+        // well formed
+        if dec_len < (size_of::<u16>() + 1) {
+            return Err(Error::MalformedFrame);
+        }
+
+        let frame = data.get(..dec_len).ok_or(Error::MalformedFrame)?;
+
+        let mut port_bytes = [0u8; size_of::<u16>()];
+        let (port_data, chunk) = frame.split_at(size_of::<u16>());
+        port_bytes.copy_from_slice(port_data);
+        let port = u16::from_le_bytes(port_bytes);
+
+        Ok(PortChunk { port, chunk })
+    }
+
+    /// Convert into an [OwnedPortChunk]
+    ///
+    /// Only available with the `use-std` feature active
+    #[cfg(feature = "use-std")]
+    pub fn into_owned(self) -> OwnedPortChunk {
+        OwnedPortChunk {
+            port: self.port,
+            chunk: self.chunk.to_vec(),
+        }
+    }
+}
+
+/// Like [PortChunk], but owns the storage instead
+///
+/// Only available with the `use-std` feature active
+#[cfg(feature = "use-std")]
+pub struct OwnedPortChunk {
+    pub port: u16,
+    pub chunk: Vec<u8>,
+}
+
+#[cfg(feature = "use-std")]
+impl OwnedPortChunk {
+    /// Create a new PortChunk from the given port and data
+    #[inline]
+    pub fn new(port: u16, chunk: Vec<u8>) -> Self {
+        Self { port, chunk }
+    }
+
+    /// Calculate the size required to encode the given data payload size
+    #[inline]
+    pub fn buffer_required(&self) -> usize {
+        // Room for COBS(port:u16 + data:[u8; len]) plus a terminating zero
+        cobs::max_encoding_length(self.chunk.len() + size_of::<u16>() + 1)
+    }
+
+    /// Encodes the current [PortChunk] into the given buffer
+    pub fn encode_to<'b>(&self, out_buf: &'b mut [u8]) -> Result<&'b mut [u8], Error> {
+        let pc = self.as_port_chunk();
+        pc.encode_to(out_buf)
+    }
+
+    /// Decodes an [OwnedPortChunk] from the given buffer
+    ///
+    /// Unlike [PortChunk::decode_from], this will not mutate the given buffer.
+    pub fn decode(data: &[u8]) -> Result<Self, Error> {
+        let mut data = data.to_vec();
+        let pc = PortChunk::decode_from(&mut data)?;
+        let port = pc.port;
+        let len = pc.chunk.len();
+        data.shrink_to(len);
+        Ok(OwnedPortChunk { port, chunk: data })
+    }
+
+    /// Borrows self as a [PortChunk]
+    pub fn as_port_chunk(&self) -> PortChunk<'_> {
+        PortChunk {
+            port: self.port,
+            chunk: &self.chunk,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn len_calc_right() {
+        let data = [1, 2, 3, 4];
+        let pc = PortChunk::new(0x4269, &data);
+        let reqd = pc.buffer_required();
+        assert_eq!(8, reqd);
+        let mut buf = [0u8; 8];
+        let res = pc.encode_to(&mut buf).unwrap();
+        assert_eq!(&[7, 0x69, 0x42, 1, 2, 3, 4, 0], res);
+
+        let data = [1u8; 256];
+        let pc = PortChunk::new(0x4269, &data);
+        let reqd = pc.buffer_required();
+        assert_eq!(261, reqd);
+        let mut buf = [0u8; 261];
+        let res = pc.encode_to(&mut buf).unwrap();
+        assert_eq!(res.len(), 261);
+    }
+
+    #[test]
+    fn round_trip() {
+        let pc = PortChunk {
+            port: 1234,
+            chunk: &[1, 2, 3, 4],
+        };
+        assert_eq!(pc.buffer_required(), 8);
+        let mut buf = [0u8; 8];
+        let enc = pc.encode_to(&mut buf).unwrap();
+
+        let dec = PortChunk::decode_from(enc).unwrap();
+        assert_eq!(dec.port, 1234);
+        assert_eq!(dec.chunk, &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn too_short() {
+        // ONLY cobs delim (zero size)
+        let mut data = [0];
+        assert_eq!(
+            PortChunk::decode_from(&mut data),
+            Err(Error::MalformedFrame)
+        );
+
+        // cobs header + delim (zero size)
+        let mut data = [1, 0];
+        assert_eq!(
+            PortChunk::decode_from(&mut data),
+            Err(Error::MalformedFrame)
+        );
+
+        // cobs header + 1 data byte
+        let mut data = [1, 1, 0];
+        assert_eq!(
+            PortChunk::decode_from(&mut data),
+            Err(Error::MalformedFrame)
+        );
+
+        // cobs header + 2 data byte
+        let mut data = [1, 1, 1, 0];
+        assert_eq!(
+            PortChunk::decode_from(&mut data),
+            Err(Error::MalformedFrame)
+        );
+
+        // cobs header + 3 data byte (2 byte port, 1 byte chunk)
+        let mut data = [1, 1, 1, 1, 0];
+        let _ = PortChunk::decode_from(&mut data).unwrap();
+    }
+
+    #[test]
+    fn bad_cobs() {
+        // cobs pointer goes past the end
+        let mut data = [100, 2, 3, 0];
+        assert_eq!(
+            PortChunk::decode_from(&mut data),
+            Err(Error::CobsDecodeFailed)
+        );
+
+        // secondary cobs pointer goes past the end
+        let mut data = [2, 2, 2, 0];
+        assert_eq!(
+            PortChunk::decode_from(&mut data),
+            Err(Error::CobsDecodeFailed)
+        );
+    }
+}

--- a/source/sermux-proto/src/lib.rs
+++ b/source/sermux-proto/src/lib.rs
@@ -12,7 +12,7 @@ use core::mem::size_of;
 // Well Known Ports
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Well known [SerialMuxService] ports
+/// Well known `SerialMuxService` ports
 #[repr(u16)]
 #[non_exhaustive]
 pub enum WellKnown {

--- a/source/sermux-proto/src/lib.rs
+++ b/source/sermux-proto/src/lib.rs
@@ -70,12 +70,13 @@ pub struct PortChunk<'a> {
 impl<'a> PortChunk<'a> {
     /// Create a new PortChunk from the given port and data
     #[inline]
-    pub fn new(port: u16, chunk: &'a [u8]) -> Self {
+    pub fn new(port: impl Into<u16>, chunk: &'a [u8]) -> Self {
         Self { port, chunk }
     }
 
     /// Calculate the size required to encode the given data payload size
     #[inline]
+    #[must_use]
     pub fn buffer_required(&self) -> usize {
         // Room for COBS(port:u16 + data:[u8; len]) plus a terminating zero
         cobs::max_encoding_length(self.chunk.len() + size_of::<u16>() + 1)
@@ -151,14 +152,16 @@ pub struct OwnedPortChunk {
 
 #[cfg(feature = "use-std")]
 impl OwnedPortChunk {
-    /// Create a new PortChunk from the given port and data
+    /// Create a new OwnedPortChunk from the given port and data
     #[inline]
+    #[must_use]
     pub fn new(port: u16, chunk: Vec<u8>) -> Self {
         Self { port, chunk }
     }
 
     /// Calculate the size required to encode the given data payload size
     #[inline]
+    #[must_use]
     pub fn buffer_required(&self) -> usize {
         // Room for COBS(port:u16 + data:[u8; len]) plus a terminating zero
         cobs::max_encoding_length(self.chunk.len() + size_of::<u16>() + 1)

--- a/tools/crowtty/Cargo.toml
+++ b/tools/crowtty/Cargo.toml
@@ -41,6 +41,10 @@ git = "https://github.com/hawkw/tracing-serde-structured"
 branch = "eliza/tracing-02"
 default-features = true
 
+[dependencies.sermux-proto]
+path = "../../source/sermux-proto"
+features = ["use-std"]
+
 [dependencies.mnemos-trace-proto]
 path = "../../source/trace-proto"
 features = ["std"]

--- a/tools/crowtty/src/main.rs
+++ b/tools/crowtty/src/main.rs
@@ -1,6 +1,6 @@
 use owo_colors::{OwoColorize, Stream};
 use serde::{Deserialize, Serialize};
-use sermux_proto::{Error as SPError, OwnedPortChunk, WellKnown};
+use sermux_proto::{DecodeError, OwnedPortChunk, WellKnown};
 use std::{
     collections::HashMap,
     fmt,
@@ -155,7 +155,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         WellKnown::PsuedoKeyboard,
     ]
     .into_iter()
-    .map(|p| p as u16)
+    .map(Into::into)
     {
         let (inp_send, inp_recv) = channel();
         let (out_send, out_recv) = channel();
@@ -318,7 +318,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         hdl.out.send(chunk.to_vec()).ok();
                     }
                 }
-                Err(SPError::CobsDecodeFailed) => {
+                Err(DecodeError::CobsDecodeFailed) => {
                     if let Ok(s) = std::str::from_utf8(&carry[..]) {
                         success = true;
                         for line in s.lines() {
@@ -326,7 +326,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }
                     }
                 }
-                Err(SPError::MalformedFrame) => {
+                Err(DecodeError::MalformedFrame) => {
                     success = true;
 
                     // If the malformed frame is JUST a null terminator, this is probably
@@ -335,7 +335,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         println!("{tag} {dmux} {err} bonus data? {carry:#02x?}");
                     }
                 }
-                Err(_) => {}
             }
 
             if !success {

--- a/tools/crowtty/src/main.rs
+++ b/tools/crowtty/src/main.rs
@@ -1,13 +1,16 @@
 use owo_colors::{OwoColorize, Stream};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::fmt;
-use std::io::{ErrorKind, Read, Write};
-use std::net::{TcpListener, TcpStream};
-use std::path::PathBuf;
-use std::sync::mpsc::{channel, Receiver, Sender};
-use std::thread::{sleep, spawn, JoinHandle};
-use std::time::{Duration, Instant};
+use sermux_proto::{Error as SPError, OwnedPortChunk, WellKnown};
+use std::{
+    collections::HashMap,
+    fmt,
+    io::{ErrorKind, Read, Write},
+    net::{TcpListener, TcpStream},
+    path::PathBuf,
+    sync::mpsc::{channel, Receiver, Sender},
+    thread::{sleep, spawn, JoinHandle},
+    time::{Duration, Instant},
+};
 use tracing_02::level_filters::LevelFilter;
 
 /// Unfortunately, the `serialport` crate seems to have some issues on M-series Macs.
@@ -146,7 +149,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // # connect to port N - stdio
     // stty -icanon -echo && ncat 127.0.0.1 $PORT
     // ```
-    for i in [0, 1, 2].into_iter() {
+    for i in [
+        WellKnown::Loopback,
+        WellKnown::HelloWorld,
+        WellKnown::PsuedoKeyboard,
+    ]
+    .into_iter()
+    .map(|p| p as u16)
+    {
         let (inp_send, inp_recv) = channel();
         let (out_send, out_recv) = channel();
 
@@ -232,13 +242,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         manager.workers.insert(i, handle);
     }
 
-    // spawn tracing on port 3
+    // spawn tracing listener
+    let trace_port = WellKnown::BinaryTracing as u16;
     let trace_handle = {
         let (inp_send, inp_recv) = channel();
         let (out_send, out_recv) = channel::<Vec<u8>>();
         let max_level = args.trace_level;
         let thread_hdl = spawn(move || {
-            trace::TraceWorker::new(max_level, inp_send, out_recv, tag.port(3), verbose).run()
+            trace::TraceWorker::new(max_level, inp_send, out_recv, tag.port(trace_port), verbose)
+                .run()
         });
         WorkerHandle {
             out: out_send,
@@ -247,7 +259,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    manager.workers.insert(3, trace_handle);
+    manager.workers.insert(trace_port, trace_handle);
 
     let mux = " MUX".if_supports_color(Stream::Stdout, |s| s.cyan());
     let dmux = "DMUX".if_supports_color(Stream::Stdout, |s| s.bright_purple());
@@ -286,50 +298,51 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         carry.extend_from_slice(&buf[..used]);
 
+        // TODO: We probably want some kind of timeout here to force a flush
+        // of the data even if we never get a null, like for example if we aren't
+        // getting serial-mux data at all, and just getting plaintext with no nulls
+        // at all.
         while let Some(pos) = carry.iter().position(|b| *b == 0) {
-            let new_chunk = carry.split_off(pos + 1);
-            if let Ok(used) = cobs::decode_in_place(&mut carry) {
-                const PORT_LEN: usize = 2;
-                if carry.len() >= PORT_LEN {
-                    let mut bytes = [0u8; PORT_LEN];
-                    let (port, remain) = carry[..used].split_at(2);
-                    bytes.copy_from_slice(port);
-                    let port = u16::from_le_bytes(bytes);
+            let remainder = carry.split_off(pos + 1);
 
+            // Success means we printed something more useful than "bad decode",
+            // even if the actual decoding failed
+            let mut success = false;
+            match OwnedPortChunk::decode(&carry) {
+                Ok(OwnedPortChunk { port, chunk }) => {
+                    success = true;
                     if let Some(hdl) = manager.workers.get_mut(&port) {
                         if verbose {
-                            println!("{} {dmux} {}B -> :{port}", tag.port(port), remain.len());
+                            println!("{} {dmux} {}B -> :{port}", tag.port(port), chunk.len());
                         }
-                        hdl.out.send(remain.to_vec()).ok();
+                        hdl.out.send(chunk.to_vec()).ok();
                     }
-                } else {
-                    // we decoded a single byte, which we can't demux (as
-                    // there's no port number).
-                    let byte = carry[0];
+                }
+                Err(SPError::CobsDecodeFailed) => {
+                    if let Ok(s) = std::str::from_utf8(&carry[..]) {
+                        success = true;
+                        for line in s.lines() {
+                            println!("{tag} {text} {line}");
+                        }
+                    }
+                }
+                Err(SPError::MalformedFrame) => {
+                    success = true;
 
-                    // if the byte was 0, it was probably sent to terminate any
-                    // existing frame, but there was no frame; in that case, we
-                    // can just ignore it. if it wasn't a zero, print it,
-                    // because that's weird.
-                    if byte != 0 {
-                        println!(
-                            "{tag} {dmux} {err} a {byte:#02x} is loose in the cat room! (no port)"
-                        );
+                    // If the malformed frame is JUST a null terminator, this is probably
+                    // a "frame flush" event, like we are just about to panic.
+                    if carry != &[0x00] {
+                        println!("{tag} {dmux} {err} bonus data? {carry:#02x?}");
                     }
                 }
-            } else if let Ok(s) = std::str::from_utf8(&carry[..]) {
-                for line in s.lines() {
-                    println!("{tag} {text} {line}");
-                }
-            } else {
+                Err(_) => {}
+            }
+
+            if !success {
                 println!("{tag} {dmux} {err} Bad decode!");
             }
-            // if let Ok(msg) = Message::decode_in_place(&mut carry) {
 
-            // } else {
-            //     println!("Bad decode!");
-            // }
-            carry = new_chunk;
+            carry = remainder;
         }
 
         sleep(Duration::from_millis(10));


### PR DESCRIPTION
This PR moves the sermux protocol format and definitions into a separate crate, removing the magic values from the crowtty crate