### PR TITLE
feat(trace): track dropped data

### DIFF
--- a/source/trace-proto/src/lib.rs
+++ b/source/trace-proto/src/lib.rs
@@ -5,7 +5,7 @@ use tracing_serde_structured::{
     SerializeId, SerializeLevel, SerializeMetadata, SerializeRecordFields, SerializeSpanFields,
 };
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum TraceEvent<'a> {
     /// Sent by the target periodically when not actively tracing, to indicate
     /// liveness, or to ack a [`HostRequest::SetMaxLevel`].
@@ -37,6 +37,15 @@ pub enum TraceEvent<'a> {
     Exit(SerializeId),
     CloneSpan(SerializeId),
     DropSpan(SerializeId),
+
+    /// The target put some data on the ground. Probably because a buffer was
+    /// full.
+    Discarded {
+        new_spans: usize,
+        span_activity: usize,
+        events: usize,
+        metas: usize,
+    },
 }
 
 /// Requests sent from a host to a trace target.

--- a/tools/crowtty/src/trace.rs
+++ b/tools/crowtty/src/trace.rs
@@ -296,6 +296,9 @@ impl TraceWorker {
                     self.textbuf.clear();
                 }
             }
+            dropped @ TraceEvent::Discarded { .. } => {
+                println!("{} {dropped:?}", self.tag);
+            }
         }
     }
 }


### PR DESCRIPTION
The kernel's `tracing` subscriber may sometimes drop data, if the internal trace buffer is full. I hate dropping data. What I hate even more than dropping data, though, is *silently* dropping data. Sometimes you gotta drop stuff, but not letting the user know that they are getting an incomplete picture is unexcusable, especially in a debugging tool.

So, this branch updates the `trace-proto` crate to include a message for discarded data. The kernel's collector counts when it discards something, and the worker task periodically checks if we've lost data, and sends the new `Discarded` message to let the host know that it hasn't gotten the whole trace.

I tested this by artificially setting the buffer size to 8 bytes, and it definitely works:

```
[3 +0282.589088566s] UART BEAT Max level set to Some(DBUG)
[3 +0285.593108198s] UART Discarded { new_spans: 0, span_activity: 0, events: 0, metas: 4 }
```