### PR TITLE
fix(sermux): `OwnedPortChunk` leaving port in chunk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
 name = "libudev"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,6 +1767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg 1.1.0",
+ "libm",
 ]
 
 [[package]]
@@ -1981,6 +2003,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift 0.3.0",
+ "regex-syntax 0.6.29",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,6 +2055,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,7 +2084,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi",
 ]
 
@@ -2155,6 +2203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2298,6 +2355,18 @@ name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2455,6 +2524,7 @@ name = "sermux-proto"
 version = "0.1.0"
 dependencies = [
  "cobs",
+ "proptest",
 ]
 
 [[package]]
@@ -2947,6 +3017,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,6 +3126,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/source/sermux-proto/Cargo.toml
+++ b/source/sermux-proto/Cargo.toml
@@ -13,3 +13,6 @@ default-features = false
 
 [features]
 use-std = []
+
+[dev-dependencies.proptest]
+version = "1.2"

--- a/source/sermux-proto/proptest-regressions/lib.txt
+++ b/source/sermux-proto/proptest-regressions/lib.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 648495c54fabc13db4dbdc0be6005cfa9d47272cbefef614de069c163969ccad # shrinks to port = 0, ref chunk = [0]

--- a/source/sermux-proto/src/lib.rs
+++ b/source/sermux-proto/src/lib.rs
@@ -207,9 +207,10 @@ impl OwnedPortChunk {
         let mut data = data.to_vec();
         let pc = PortChunk::decode_from(&mut data)?;
         let port = pc.port;
-        let len = pc.chunk.len();
-        data.shrink_to(len);
-        Ok(OwnedPortChunk { port, chunk: data })
+        Ok(OwnedPortChunk {
+            port,
+            chunk: pc.chunk.to_vec(),
+        })
     }
 
     /// Borrows self as a [PortChunk]

--- a/source/sermux-proto/src/lib.rs
+++ b/source/sermux-proto/src/lib.rs
@@ -171,13 +171,13 @@ impl<'a> PortChunk<'a> {
 /// Like [PortChunk], but owns the storage instead
 ///
 /// Only available with the `use-std` feature active
-#[cfg(feature = "use-std")]
+#[cfg(any(feature = "use-std", test))]
 pub struct OwnedPortChunk {
     pub port: u16,
     pub chunk: Vec<u8>,
 }
 
-#[cfg(feature = "use-std")]
+#[cfg(any(feature = "use-std", test))]
 impl OwnedPortChunk {
     /// Create a new OwnedPortChunk from the given port and data
     #[inline]
@@ -254,6 +254,21 @@ mod test {
         let enc = pc.encode_to(&mut buf).unwrap();
 
         let dec = PortChunk::decode_from(enc).unwrap();
+        assert_eq!(dec.port, 1234);
+        assert_eq!(dec.chunk, &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn owned_round_trip() {
+        let pc = PortChunk {
+            port: 1234,
+            chunk: &[1, 2, 3, 4],
+        };
+        assert_eq!(pc.buffer_required(), 8);
+        let mut buf = [0u8; 8];
+        let enc = pc.encode_to(&mut buf).unwrap();
+
+        let dec = OwnedPortChunk::decode(enc).unwrap();
         assert_eq!(dec.port, 1234);
         assert_eq!(dec.chunk, &[1, 2, 3, 4]);
     }


### PR DESCRIPTION
Currently, the behavior of the `OwnedPortChunk::decode` function is
incorrect. The returned `chunk` in the `OwnedPortChunk` is constructed
by allocating a new `Vec` from the input, decoding a `PortChunk` from
it, and then shrinking the `Vec` to the size of the `chunk` component of
the returned borrowed `PortChunk`.

This does the wrong thing. `Vec::shrink_to` shrinks the `Vec` from the
*end*, so we are shrinking it down to the *first* `chunk.len()` bytes.
The port number is at the beginning of the `Vec`, rather than the end,
so instead of dropping the port number and keeping the data, we are
dropping the last two bytes of the data and producing a buffer that
contains `[port[0], port[1], data[0], ... data[len(data) - 2]]`. This
means the data is silently corrupted.

This branch fixes this behavior by instead constructing the owned chunk
using `pc.chunk.to_vec()`. This has the unfortunate consequence of
meaning that we allocate twice, rather than once, but it means that we
now return the correct data when using `OwnedPortChunk`. Alternatively,
we could use `Vec::remove` twice to remove the first two bytes of the
`Vec`, but that's two _O_(_n_) operations, which is probably at least as
bad as allocating. We could, potentially, change the
`OwnedPortChunk::decode` operation to not just call `PortChunk::decode`,
but that would be more complicated.

Adding a failing test for this is as simple as adding a round-tripping
test for `OwnedPortChunk` as well as `PortChunk`, which we didn't have
previously. I've also changed the round-tripping tests to use `proptest`
to generate arbitrary port numbers and chunks to round trip,
because...why not?