### PR TITLE
feat: janky way of having tracing in ISRs

### DIFF
--- a/platforms/allwinner-d1/core/src/drivers/uart.rs
+++ b/platforms/allwinner-d1/core/src/drivers/uart.rs
@@ -56,6 +56,7 @@ impl D1Uart {
     }
 
     pub fn handle_uart0_int() {
+        let _isr = kernel::isr::Isr::enter();
         let uart0 = unsafe { &*UART0::PTR };
         let prod = UART_RX.load(Ordering::Acquire);
         let mut handled_all = false;

--- a/platforms/allwinner-d1/core/src/drivers/uart.rs
+++ b/platforms/allwinner-d1/core/src/drivers/uart.rs
@@ -56,7 +56,6 @@ impl D1Uart {
     }
 
     pub fn handle_uart0_int() {
-        let _isr = kernel::isr::Isr::enter();
         let uart0 = unsafe { &*UART0::PTR };
         let prod = UART_RX.load(Ordering::Acquire);
         let mut handled_all = false;

--- a/platforms/allwinner-d1/core/src/lib.rs
+++ b/platforms/allwinner-d1/core/src/lib.rs
@@ -234,7 +234,6 @@ impl D1 {
     /// At the moment, we only service the Channel 0 interrupt,
     /// which indicates that the serial transmission is complete.
     fn handle_dmac() {
-        let _isr = kernel::isr::Isr::enter();
         let dmac = unsafe { &*DMAC::PTR };
         dmac.dmac_irq_pend0.modify(|r, w| {
             tracing::trace!(dmac_irq_pend0 = ?format_args!("{:#b}", r.bits()), "DMAC interrupt");
@@ -256,7 +255,6 @@ impl D1 {
     /// We don't actually do anything in the TIMER1 interrupt. It is only here to
     /// knock us out of WFI. Just disable the IRQ to prevent refires
     fn timer1_int() {
-        let _isr = kernel::isr::Isr::enter();
         let timer = unsafe { &*TIMER::PTR };
         timer
             .tmr_irq_sta

--- a/platforms/allwinner-d1/core/src/lib.rs
+++ b/platforms/allwinner-d1/core/src/lib.rs
@@ -234,8 +234,10 @@ impl D1 {
     /// At the moment, we only service the Channel 0 interrupt,
     /// which indicates that the serial transmission is complete.
     fn handle_dmac() {
+        let _isr = kernel::isr::Isr::enter();
         let dmac = unsafe { &*DMAC::PTR };
         dmac.dmac_irq_pend0.modify(|r, w| {
+            tracing::trace!(dmac_irq_pend0 = ?format_args!("{:#b}", r.bits()), "DMAC interrupt");
             if r.dma0_queue_irq_pend().bit_is_set() {
                 D1Uart::tx_done_waker().wake();
             }
@@ -254,6 +256,7 @@ impl D1 {
     /// We don't actually do anything in the TIMER1 interrupt. It is only here to
     /// knock us out of WFI. Just disable the IRQ to prevent refires
     fn timer1_int() {
+        let _isr = kernel::isr::Isr::enter();
         let timer = unsafe { &*TIMER::PTR };
         timer
             .tmr_irq_sta

--- a/platforms/allwinner-d1/core/src/plic.rs
+++ b/platforms/allwinner-d1/core/src/plic.rs
@@ -268,6 +268,10 @@ static INTERRUPT_ARRAY: [Vectored; INTERRUPT_LIST.len()] = lister();
 // do at a hardware level. For now, it's probably fine
 #[export_name = "MachineExternal"]
 fn im_an_interrupt() {
+    // tell the kernel that we are inside an ISR. currently, this just results
+    // in switching tracing buffers to use a special ISR tracebuf, in case the
+    // interrupt fired while someone was holding a tracebuf WGR.
+    let _in_isr = kernel::isr::Isr::enter();
     let plic = unsafe { Plic::summon() };
     let claim = plic.claim();
     let claim_u16 = claim as u16;

--- a/source/kernel/src/isr.rs
+++ b/source/kernel/src/isr.rs
@@ -1,0 +1,36 @@
+use portable_atomic::{AtomicU8, Ordering};
+
+static IN_ISR: AtomicU8 = AtomicU8::new(0);
+
+pub struct Isr(());
+
+impl Drop for Isr {
+    fn drop(&mut self) {
+        IN_ISR.fetch_sub(1, Ordering::Release);
+    }
+}
+
+impl Isr {
+    /// Enter an interrupt service routine (ISR) context.
+    ///
+    /// When the returned guard is dropped, the system is no longer considered
+    /// to be inside an ISR.
+    #[must_use]
+    #[inline]
+    pub fn enter() -> Self {
+        IN_ISR.fetch_add(1, Ordering::Release);
+        Self(())
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn is_in_isr() -> bool {
+        Self::level() > 0
+    }
+
+    #[must_use]
+    #[inline]
+    pub(crate) fn level() -> u8 {
+        IN_ISR.load(Ordering::Acquire)
+    }
+}

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -77,6 +77,7 @@ pub mod comms;
 pub mod daemons;
 pub(crate) mod fmt;
 pub mod forth;
+pub mod isr;
 pub mod registry;
 pub mod services;
 #[cfg(feature = "tracing-02")]


### PR DESCRIPTION
This is not *that* good but it allows at least one ISR to trace even if
the interrupt fired while normal code was holding the trace WGR. We can
probably figure out a nicer version of this, with different tracebufs
for each ISR priority level, later.

Cherry-picked out of #103 