### PR TITLE
feat(d1): run the graphical Forth shell

### DIFF
--- a/platforms/allwinner-d1/boards/src/bin/lichee-rv.rs
+++ b/platforms/allwinner-d1/boards/src/bin/lichee-rv.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use core::time::Duration;
 use mnemos_d1_core::{
     dmac::Dmac,
-    drivers::{sharp_display::SharpDisplay, spim::kernel_spim1, uart::kernel_uart},
+    drivers::{spim::kernel_spim1, uart::kernel_uart},
     plic::Plic,
     timer::Timers,
     Ram, D1,
@@ -43,9 +43,7 @@ fn main() -> ! {
         w
     });
 
-    d1.kernel
-        .initialize(SharpDisplay::register(d1.kernel, 4))
-        .unwrap();
+    d1.initialize_sharp_display();
 
     // Initialize LED loop
     d1.kernel

--- a/platforms/allwinner-d1/boards/src/bin/mq-pro.rs
+++ b/platforms/allwinner-d1/boards/src/bin/mq-pro.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use core::time::Duration;
 use mnemos_d1_core::{
     dmac::Dmac,
-    drivers::{sharp_display::SharpDisplay, spim::kernel_spim1, uart::kernel_uart},
+    drivers::{spim::kernel_spim1, uart::kernel_uart},
     plic::Plic,
     timer::Timers,
     Ram, D1,
@@ -43,9 +43,7 @@ fn main() -> ! {
         w
     });
 
-    d1.kernel
-        .initialize(SharpDisplay::register(d1.kernel, 4))
-        .unwrap();
+    d1.initialize_sharp_display();
 
     // Initialize LED loop
     d1.kernel

--- a/platforms/allwinner-d1/core/src/drivers/sharp_display.rs
+++ b/platforms/allwinner-d1/core/src/drivers/sharp_display.rs
@@ -75,6 +75,9 @@ mod commands {
 pub struct SharpDisplay;
 
 impl SharpDisplay {
+    pub const WIDTH: usize = WIDTH;
+    pub const HEIGHT: usize = HEIGHT;
+
     /// Register the driver instance
     ///
     /// Registration will also start the simulated display, meaning that the display

--- a/platforms/allwinner-d1/core/src/lib.rs
+++ b/platforms/allwinner-d1/core/src/lib.rs
@@ -18,7 +18,7 @@ use d1_pac::{Interrupt, DMAC, TIMER};
 use kernel::{
     daemons::sermux::{hello, loopback, HelloSettings, LoopbackSettings},
     mnemos_alloc::containers::Box,
-    services::serial_mux::SerialMuxServer,
+    services::{forth_spawnulator::SpawnulatorServer, serial_mux::SerialMuxServer},
     trace::{self, Instrument},
     Kernel, KernelSettings,
 };
@@ -129,6 +129,9 @@ impl D1 {
         let hello_settings = HelloSettings::default();
         k.initialize(hello(k, hello_settings)).unwrap();
 
+        // Spawn the spawnulator
+        k.initialize(SpawnulatorServer::register(k, 16)).unwrap();
+
         Ok(Self {
             kernel: k,
             _uart: uart,
@@ -136,6 +139,50 @@ impl D1 {
             timers,
             plic,
         })
+    }
+
+    /// Spawns a SHARP Memory Display driver and a graphical Forth REPL on the Sharp
+    /// Memory Display.
+    ///
+    /// This function requires a SHARP memory display to be connected to the D1's
+    /// SPI_DBI pins (SPI1).
+    ///
+    /// # Panics
+    ///
+    /// If the SHARP Memory Display driver or the graphical Forth REPL tasks
+    /// could not be spawned.
+    pub fn initialize_sharp_display(&self) {
+        use drivers::sharp_display::SharpDisplay;
+        use kernel::daemons::shells;
+
+        const MAX_FRAMES: usize = 4;
+
+        // the `'static` kernel reference is the only thing from `self` that
+        // must be moved into the spawned tasks.
+        let k = self.kernel;
+
+        let sharp_display = self
+            .kernel
+            .initialize(SharpDisplay::register(k, MAX_FRAMES))
+            .expect("failed to spawn SHARP display driver");
+
+        // spawn Forth shell
+        self.kernel
+            .initialize(async move {
+                trace::debug!("waiting for SHARP display driver...");
+                sharp_display
+                    .await
+                    .expect("display driver task isn't cancelled")
+                    .expect("display driver must come up");
+                trace::debug!("display driver ready!");
+                let settings = shells::GraphicalShellSettings::with_display_size(
+                    SharpDisplay::WIDTH as u32,
+                    SharpDisplay::HEIGHT as u32,
+                );
+                k.spawn(shells::graphical_shell_mono(k, settings)).await;
+                trace::info!("graphical shell running.");
+            })
+            .expect("failed to spawn graphical forth shell");
     }
 
     pub fn run(self) -> ! {


### PR DESCRIPTION
This branch changes the `boards/mq-pro` and `boards/lichee-rv` binary targets to run the graphical Forth shell on its SHARP Memory Display. I added a utility function in the `d1-core` crate for spawning both the display driver and the graphical Forth shell, but I decided that the individual board targets should be responsible for actually calling that function. My thinking was that the `d1-core` crate is SOC-specific but not hardware specific, so (theoretically) it knows that it's running on a D1 but it doesn't know what hardware is connected to that D1.

I also changed `d1-core`'s `D1::initialize` function to spawn the Forth spawnulator, because...we need to ensure that it's spawnulated so that we can spawnulate. :)

```
<| ok
```
![ok](https://github.com/tosc-rs/mnemos/assets/2796466/cb6ef3ae-afa5-4c46-a40a-bf697b25f323)
