### PR TITLE
feat(crowtty): basic built-in pseudo-keyboard

### DIFF
--- a/source/kernel/src/daemons/shells.rs
+++ b/source/kernel/src/daemons/shells.rs
@@ -108,9 +108,9 @@ pub async fn sermux_shell(k: &'static Kernel, settings: SermuxShellSettings) {
 /// ```
 #[derive(Debug)]
 pub struct GraphicalShellSettings {
-    /// Sermux port to use as a PsuedoKeyboard.
+    /// Sermux port to use as a PseudoKeyboard.
     ///
-    /// Defaults to [WellKnown::PsuedoKeyboard]
+    /// Defaults to [WellKnown::PseudoKeyboard]
     pub port: u16,
     /// Number of bytes used for the sermux buffer
     ///
@@ -135,7 +135,7 @@ pub struct GraphicalShellSettings {
 impl GraphicalShellSettings {
     pub fn with_display_size(width_px: u32, height_px: u32) -> Self {
         Self {
-            port: WellKnown::PsuedoKeyboard.into(),
+            port: WellKnown::PseudoKeyboard.into(),
             capacity: 256,
             forth_settings: Default::default(),
             disp_width_px: width_px,

--- a/source/sermux-proto/src/lib.rs
+++ b/source/sermux-proto/src/lib.rs
@@ -24,9 +24,9 @@ pub enum WellKnown {
     /// such as a forth console, when there is no hardware keyboard available.
     ///
     /// Unlike the ForthShell ports, which serve as ssh/telnet like bidirectional
-    /// items, PsuedoKeyboard is only used to receive the input, as the output is
+    /// items, PseudoKeyboard is only used to receive the input, as the output is
     /// shown on a graphical terminal
-    PsuedoKeyboard = 2,
+    PseudoKeyboard = 2,
     /// A bidirectional for binary encoded tracing messages
     BinaryTracing = 3,
 

--- a/tools/crowtty/src/keyboard.rs
+++ b/tools/crowtty/src/keyboard.rs
@@ -1,0 +1,53 @@
+use owo_colors::{OwoColorize, Stream};
+use std::{
+    io::{self, BufRead},
+    sync::mpsc,
+    thread,
+};
+
+use crate::{LogTag, WorkerHandle};
+
+pub(crate) struct KeyboardWorker {
+    tx: mpsc::Sender<Vec<u8>>,
+    _rx: mpsc::Receiver<Vec<u8>>,
+    tag: LogTag,
+}
+
+impl KeyboardWorker {
+    pub fn spawn(tag: LogTag) -> WorkerHandle {
+        let (inp_send, inp_recv) = mpsc::channel();
+        let (out_send, out_recv) = mpsc::channel::<Vec<u8>>();
+        let worker = Self {
+            tx: inp_send,
+            _rx: out_recv,
+            tag,
+        };
+        let thread_hdl = thread::spawn(|| worker.run());
+        WorkerHandle {
+            out: out_send,
+            inp: inp_recv,
+            _thread_hdl: thread_hdl,
+        }
+    }
+
+    fn run(self) {
+        let mut stdin = io::stdin().lock();
+        let keyb = "KEYB".if_supports_color(Stream::Stdout, |x| x.bright_yellow());
+        loop {
+            let mut buf = String::new();
+            match stdin.read_line(&mut buf) {
+                Ok(n) => {
+                    self.tag.if_verbose(format_args!("{keyb} {n}B <- {buf:?}"));
+                    self.tx.send(buf.into_bytes()).unwrap();
+                }
+                Err(error) => {
+                    println!(
+                        "{} {keyb} {} {error}",
+                        self.tag,
+                        "ERR!".if_supports_color(Stream::Stdout, |x| x.red())
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently, the SerMux pseudo-keyboard port is handled like any other SerMux port by crowtty --- so, if we want to send keyboard input to the target device, we must open a separate `stty`/`netcat` session to write to the pseudo-keyboard. This is a bit annyoing and requires opening an additional terminal window.

To improve developer quality of life, I've added a very basic built-in pseudo-keyboard to crowtty. Now, input from stdin is written to the pseudo-keyboard port by default. A command-line argument allows disabling this behavior and treating the pseudo-keyboard port as a normal SerMux port, so the old behavior is still available.

The current pseudo-keyboard is pretty basic. It sends input to the target line-by-line rather than character-by-character, so we can't see typing on the target's display. Also, everything written to the port is displayed on the terminal on the host, which is a bit ugly when it gets interrupted by a log line. In the future, we may want to use a terminal UI library to change the behavior for stdin to read character-by-character and not echo the input, so that the input is instead echoed on the target's display as the user types it in. But this works for now.

Also, I fixed a typo in the `sermux_proto::WellKnown` enum --- it's spelt "pseudo", not "psuedo". :)

For example: 
![image](https://github.com/tosc-rs/mnemos/assets/2796466/466dfe45-ec8c-4b74-ae66-4949be942702)

And on the target:
![image](https://github.com/tosc-rs/mnemos/assets/2796466/818701ef-a71a-4de4-9daa-ffa25f42a725)