### PR TITLE
fix(sermux): Rework serial mux to avoid edge cases and make it more testable

### DIFF
--- a/source/kernel/Cargo.toml
+++ b/source/kernel/Cargo.toml
@@ -130,6 +130,11 @@ version = "0.6.1"
 [build-dependencies]
 vergen = { version = "8.0.0", features = ["cargo", "git", "gitcl", "rustc",] }
 
+[dev-dependencies.futures]
+version = "0.3.21"
+features = ["async-await", "executor"]
+default-features = false
+
 [features]
 default = ["tracing-01"]
 tracing-02 = ["dep:tracing-02", "tracing-core-02", "tracing-serde-structured", "mnemos-trace-proto"]

--- a/source/kernel/src/daemons/shells.rs
+++ b/source/kernel/src/daemons/shells.rs
@@ -97,12 +97,12 @@ pub async fn sermux_shell(k: &'static Kernel, settings: SermuxShellSettings) {
 /// This does NOT implement [Default]. Instead use [GraphicalShellSettings::with_display_size].
 ///
 /// For example:
-/// ```
+/// ```skip
 /// use kernel::daemons::shells::GraphicalShellSettings;
 /// let shell = GraphicalShellSettings {
 ///     // override the capacity with a larger value:
 ///     capacity: 512,
-///    ..GraphicalShellSettings::with_display_size(420, 69), // nice!
+///    ..GraphicalShellSettings::with_display_size(420, 69) // nice!
 /// };
 /// # drop(shell);
 /// ```

--- a/source/kernel/src/services/i2c.rs
+++ b/source/kernel/src/services/i2c.rs
@@ -384,7 +384,6 @@ impl i2c::I2c<i2c::SevenBitAddress> for I2cClient {
                     buf = read;
                 }
                 i2c::Operation::Write(src) => {
-                    let len = src.len();
                     buf.try_extend_from_slice(src)
                         .expect("we should have pre-allocated a large enough buffer!");
                     let write = txn.write(buf, end).await?;

--- a/source/kernel/src/services/serial_mux.rs
+++ b/source/kernel/src/services/serial_mux.rs
@@ -8,6 +8,7 @@
 
 use core::time::Duration;
 
+use crate::comms::bbq::GrantR;
 use crate::tracing::{debug, warn};
 use crate::{
     comms::{
@@ -338,75 +339,127 @@ impl CommanderTask {
 
 // impl IncomingMuxerTask
 
+/// Takes data from the grant
+///
+/// Returns true if the buffer is now ready for decoding
+/// Returns false if more data is needed
+///
+/// If the grant has been overfilled, the buffer will be cleared.
+fn take_from_grant(buffer: &mut FixedVec<u8>, grant: GrantR) -> bool {
+    let mut try_decode = false;
+
+    // How many bytes should we try to take?
+    let to_use = match grant.iter().position(|&v| v == 0) {
+        Some(idx) => {
+            try_decode = true;
+            &grant[..idx + 1]
+        }
+        None => &grant,
+    };
+
+    // Okay, add those to the buffer
+    if buffer.try_extend_from_slice(to_use).is_err() {
+        warn!("Overfilled accumulator");
+        buffer.clear();
+        try_decode = false;
+    }
+
+    // Now we can release the grant
+    let used = to_use.len();
+    grant.release(used);
+    debug!(used, "consumed incoming bytes");
+
+    try_decode
+}
+
+/// Tries to decode a port and message from the given buffer
+///
+/// Either way, you should probably clear the buffer when you are done.
+fn try_decode<'a>(buffer: &'a mut [u8]) -> Option<(u16, &'a [u8])> {
+    let used = match cobs::decode_in_place(buffer) {
+        Ok(u) if u < 3 => {
+            warn!("Cobs decode too short!");
+            return None;
+        }
+        Ok(u) => u,
+        Err(_) => {
+            warn!("Cobs decode failed!");
+            return None;
+        }
+    };
+
+    let total = buffer.get(..used)?;
+
+    let mut port = [0u8; 2];
+    let (portb, datab) = total.split_at(2);
+    port.copy_from_slice(portb);
+    let port_id = u16::from_le_bytes(port);
+
+    Some((port_id, datab))
+}
+
 impl IncomingMuxerTask {
     async fn run(mut self) {
         loop {
-            let mut rgr = self.incoming.read_grant().await;
-            let mut used = 0;
-            for ch in rgr.split_inclusive_mut(|&num| num == 0) {
-                used += ch.len();
+            let rgr = self.incoming.read_grant().await;
 
-                if ch.last() != Some(&0) {
-                    // This is the last chunk, and it doesn't end with a zero.
-                    // just add it to the accumulator, if we can.
-                    if self.buf.try_extend_from_slice(ch).is_err() {
-                        warn!("Overfilled accumulator");
-                        self.buf.clear();
-                    }
+            // No data, no worries
+            if !take_from_grant(&mut self.buf, rgr) {
+                continue;
+            }
 
-                    // Either we overfilled, or this was the last data. Move on.
+            //////////////////////////////////////////////////////////////////
+            // No early returns/continues until the jerb is done unless you
+            // clear the buffer!
+            //
+            let (port_id, datab) = match try_decode(self.buf.as_slice_mut()) {
+                Some(a) => a,
+                None => {
+                    // Nothing decoded, which means decoding has failed.
+                    self.buf.clear();
                     continue;
                 }
+            };
 
-                // Okay, we know that we have a zero terminated item. Do we have anything residual?
-                let buf = if self.buf.as_slice().is_empty() {
-                    // Yes, no pending data, just use the current chunk
-                    ch
+            // Great, now we have a message! Let's see if we have someone listening to this port
+            let mux = self.mux.lock().await;
+            if let Some(port) = mux.ports.as_slice().iter().find(|p| p.port == port_id) {
+                if let Some(mut wgr) = port.upstream.send_grant_exact_sync(datab.len()) {
+                    wgr.copy_from_slice(datab);
+                    wgr.commit(datab.len());
+                    debug!(port_id, len = datab.len(), "Sent bytes to port");
                 } else {
-                    // We have residual data, we need to copy the chunk to the end of the buffer
-                    if self.buf.try_extend_from_slice(ch).is_err() {
-                        warn!("Overfilled accumulator");
-                        self.buf.clear();
-                        continue;
-                    }
-
-                    self.buf.as_slice_mut()
-                };
-
-                // Great! Now decode the cobs message in place.
-                let used = match cobs::decode_in_place(buf) {
-                    Ok(u) if u < 3 => {
-                        warn!("Cobs decode too short!");
-                        continue;
-                    }
-                    Ok(u) => u,
-                    Err(_) => {
-                        warn!("Cobs decode failed!");
-                        continue;
-                    }
-                };
-
-                let mut port = [0u8; 2];
-                let (portb, datab) = buf[..used].split_at(2);
-                port.copy_from_slice(portb);
-                let port_id = u16::from_le_bytes(port);
-
-                // Great, now we have a message! Let's see if we have someone listening to this port
-                let mux = self.mux.lock().await;
-                if let Some(port) = mux.ports.as_slice().iter().find(|p| p.port == port_id) {
-                    if let Some(mut wgr) = port.upstream.send_grant_exact_sync(datab.len()) {
-                        wgr.copy_from_slice(datab);
-                        wgr.commit(datab.len());
-                        debug!(port_id, len = datab.len(), "Sent bytes to port");
-                    } else {
-                        warn!(port_id, len = datab.len(), "Discarded bytes, full buffer");
-                    }
-                } else {
-                    warn!(port_id, len = datab.len(), "Discarded bytes, no consumer");
+                    warn!(port_id, len = datab.len(), "Discarded bytes, full buffer");
                 }
+            } else {
+                warn!(port_id, len = datab.len(), "Discarded bytes, no consumer");
             }
-            rgr.release(used);
-            debug!(used, "processed incoming bytes");
+
+            // Now we clear the buffer
+            self.buf.clear();
+            //
+            // jerb done!
+            //////////////////////////////////////////////////////////////////
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn simple_decode() {
+        let (prod, cons) = futures::executor::block_on(async { bbq::new_spsc_channel(128).await });
+        let mut fixie = futures::executor::block_on(async { FixedVec::<u8>::new(64).await });
+        let mut wgr = prod.send_grant_exact_sync(5).unwrap();
+        wgr.copy_from_slice(&[0x01, 0x01, 0x02, b'!', 0x00]);
+        wgr.commit(5);
+        let rgr = cons.read_grant_sync().unwrap();
+
+        assert!(take_from_grant(&mut fixie, rgr));
+        assert_eq!(fixie.as_slice(), &[0x01, 0x01, 0x02, b'!', 0x00]);
+        let (port_id, data) = try_decode(fixie.as_slice_mut()).unwrap();
+        assert_eq!(port_id, 0);
+        assert_eq!(data, b"!");
     }
 }


### PR DESCRIPTION
This PR reworks and simplifies some of the logic in serial mux, and addresses an issue
that could cause the decoder to lock up when empty messages (and potentially others)
are received.

This also breaks out some of the steps to make them easier to test, and tests them.