### PR TITLE
fix(d1): remove bonus I2C write

### DIFF
--- a/platforms/allwinner-d1/core/src/drivers/twi.rs
+++ b/platforms/allwinner-d1/core/src/drivers/twi.rs
@@ -352,7 +352,6 @@ impl I2c0 {
         // reset the TWI engine.
         guard.twi.twi_srst.write(|w| w.soft_rst().set_bit());
         guard.twi.twi_efr.reset();
-        guard.twi.twi_data.reset();
 
         let mut started = false;
         while let Ok(Transfer {


### PR DESCRIPTION
The TWI driver contained some code that would attempt to zero the
TWI_DATA register at the beginning of every transaction. This may result
in the TWI sending the address 0x00 (read) on the bus, which is super
wrong lol.