### PR TITLE
feat(crowtty): add host-side trace filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
  "tonic",
  "tracing 0.1.37",
  "tracing-core 0.1.31",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.17",
 ]
 
 [[package]]
@@ -575,6 +575,7 @@ dependencies = [
  "sermux-proto",
  "tracing 0.2.0",
  "tracing-serde-structured",
+ "tracing-subscriber 0.3.0",
 ]
 
 [[package]]
@@ -1356,7 +1357,7 @@ dependencies = [
  "generator",
  "scoped-tls",
  "tracing 0.1.37",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.17",
 ]
 
 [[package]]
@@ -1436,7 +1437,7 @@ dependencies = [
  "tokio",
  "tracing 0.1.37",
  "tracing-modality",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.17",
  "uuid 1.3.4",
 ]
 
@@ -2994,7 +2995,7 @@ dependencies = [
  "tokio",
  "tracing 0.1.37",
  "tracing-core 0.1.31",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.17",
  "url",
  "uuid 1.3.4",
 ]
@@ -3007,6 +3008,14 @@ dependencies = [
  "hash32 0.2.1",
  "heapless",
  "serde",
+ "tracing-core 0.2.0",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.0"
+source = "git+https://github.com/tokio-rs/tracing#27f688efb72316a26f3ec1f952c82626692c08ff"
+dependencies = [
  "tracing-core 0.2.0",
 ]
 

--- a/tools/crowtty/Cargo.toml
+++ b/tools/crowtty/Cargo.toml
@@ -22,7 +22,7 @@ version = "0.2"
 
 [dependencies.clap]
 version = "4.0"
-features = ["derive"]
+features = ["derive", "env"]
 
 [dependencies.serde]
 version = "1.0"
@@ -54,3 +54,10 @@ package = "tracing"
 git = "https://github.com/tokio-rs/tracing"
 # branch = "master"
 default-features = false
+
+[dependencies.tracing-subscriber]
+package = "tracing-subscriber"
+git = "https://github.com/tokio-rs/tracing"
+# branch = "master"
+default-features = false
+features = ["std"]

--- a/tools/crowtty/src/main.rs
+++ b/tools/crowtty/src/main.rs
@@ -70,12 +70,12 @@ struct Args {
     /// - the `INFO` level globally (regardless of module path),
     /// - the `DEBUG` level for all modules in the `kernel` crate,
     /// - and the `TRACE` level for the `comms::bbq` submodule in `kernel`.
-    /// 
+    ///
     /// enabling a more verbose level enables all levels less verbose than that
     /// level. for example, enabling the `INFO` level for a given target will also
-    /// enable the `WARN` and `ERROR` levels for that target. 
+    /// enable the `WARN` and `ERROR` levels for that target.
     ///
-    /// see <https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/targets/struct.Targets.html#filtering-with-targets> 
+    /// see <https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/targets/struct.Targets.html#filtering-with-targets>
     /// for more details on this syntax.
     #[arg(
         short,

--- a/tools/crowtty/src/main.rs
+++ b/tools/crowtty/src/main.rs
@@ -63,9 +63,15 @@ struct Args {
     #[arg(short, long, global = true)]
     verbose: bool,
 
-    /// maximum `tracing` level to request from the target.
-    #[arg(short, long, global = true, default_value_t = LevelFilter::INFO)]
-    trace_level: LevelFilter,
+    /// a comma-separated list of `tracing` targets and levels to enable.
+    #[arg(
+        short,
+        long = "trace",
+        global = true,
+        env = "MNEMOS_TRACE",
+        default_value_t = tracing_subscriber::filter::Targets::new().with_default(LevelFilter::INFO),
+    )]
+    trace_filter: tracing_subscriber::filter::Targets,
 
     /// SerMux port for a pseudo-keyboard for the graphical Forth shell on the target.
     #[arg(short, long, global = true, default_value_t = sermux_proto::WellKnown::PseudoKeyboard as u16)]
@@ -153,7 +159,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         no_keyboard,
         keyboard_port,
         verbose,
-        trace_level,
+        trace_filter,
     } = Args::parse();
     let (mut port, mut tag) = match command {
         Command::Tcp { port } => (Connect::new_from_tcp(port), LogTag::new(true)),
@@ -289,7 +295,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let (inp_send, inp_recv) = channel();
         let (out_send, out_recv) = channel::<Vec<u8>>();
         let thread_hdl = spawn(move || {
-            trace::TraceWorker::new(trace_level, inp_send, out_recv, tag.port(trace_port)).run()
+            trace::TraceWorker::new(trace_filter, inp_send, out_recv, tag.port(trace_port)).run()
         });
         WorkerHandle {
             out: out_send,

--- a/tools/crowtty/src/main.rs
+++ b/tools/crowtty/src/main.rs
@@ -64,6 +64,19 @@ struct Args {
     verbose: bool,
 
     /// a comma-separated list of `tracing` targets and levels to enable.
+    ///
+    /// for example, `info,kernel=debug,kernel::comms::bbq=trace` will enable:
+    ///
+    /// - the `INFO` level globally (regardless of module path),
+    /// - the `DEBUG` level for all modules in the `kernel` crate,
+    /// - and the `TRACE` level for the `comms::bbq` submodule in `kernel`.
+    /// 
+    /// enabling a more verbose level enables all levels less verbose than that
+    /// level. for example, enabling the `INFO` level for a given target will also
+    /// enable the `WARN` and `ERROR` levels for that target. 
+    ///
+    /// see <https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/targets/struct.Targets.html#filtering-with-targets> 
+    /// for more details on this syntax.
     #[arg(
         short,
         long = "trace",


### PR DESCRIPTION
Currently, our ability to filter traces is limited to setting a max
level on the target. This is not ideal --- sometimes, we may want
`TRACE` events from one module, but enabling `TRACE` globally results in
an unreadably verbose firehose log.

In the rest of the `tracing` ecosystem, this is generally solved by
using *filters*, typically setting a separate maximum level based on
trace targets (module paths). We can't easily implement dynamic target
filtering in the kernel itself, because `mnemos_alloc` doesn't currently
provide us a nice way of working with owned strings for mudle paths.

However, we *can* easily implement this kind of filtering on the host
side, in `crowtty`. This branch adds support for module-path-based
filtering in `crowtty`, controlled by a `--trace` flag, which replaces
the previous `--trace-level`. I felt like breaking the CLI arguments was
probably fine but if someone really cares about backwards compatibility,
we could make the `--trace-level` flag an alias for `--trace <LEVEL>`.

In the future, when we have the capacity to do nice string handling in
the kernel, it would be preferable to have these trace filter
configurations be sent to the target device, and have it perform
filtering. That would allow us to actually skip recording unwanted
traces, reducing the performance impact of turning on more verbose
traces. However, with the current design, we will still send the max
level to the target, so if we enable `INFO` globally and `DEBUG` in some
specific module, we will, at least, still disable the `TRACE` level on
the target.

When the capacity to perform filtering in the target is added, the
existing flag can be kept, and the behavior modified to send a
traceproto message that selects that filter configuration.

For example, here's a `crowtty` session where I enable the `TRACE` level
for the TWI driver, but `INFO` for all other modules. Note that none of
the traces from other parts of mnemOS, such as `comms::bbq` or the SHARP
display driver, are displayed, so we only see the very verbose
diagnostics from the TWI driver.
![image](https://github.com/tosc-rs/mnemos/assets/2796466/fd22347b-820e-4d74-80a4-639050dc2758)

Fixes #153