### PR TITLE
qol(workspace): Remove alloc patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,3 @@ rev = "cbcfc62a6ea3646fb43f2c159cfdc19b3d932004"
 [patch.crates-io.cordyceps]
 git = "https://github.com/hawkw/mycelium.git"
 rev = "cbcfc62a6ea3646fb43f2c159cfdc19b3d932004"
-
-[patch.crates-io.mnemos-alloc]
-path = "./source/alloc"

--- a/source/melpomene/Cargo.toml
+++ b/source/melpomene/Cargo.toml
@@ -31,6 +31,7 @@ path = "../kernel"
 [dependencies.mnemos-alloc]
 version = "0.1.0"
 features = ["use-std"]
+path = "../alloc"
 
 [dependencies.mnemos-abi]
 path = "../abi"

--- a/source/mstd/Cargo.toml
+++ b/source/mstd/Cargo.toml
@@ -35,6 +35,7 @@ path = "../abi"
 
 [dependencies.mnemos-alloc]
 version = "0.1.0"
+path = "../alloc"
 
 [dependencies.heapless]
 version = "0.7.10"


### PR DESCRIPTION
This PR removes the workspace level patch for mnemos-alloc. This is no longer needed as the crate is now vendored into the monorepo.

The kernel was already indirectly updated to use a path dep in #148 due to workspace issues, this change furthers that process and updates `melpo` and `mstd` to do the same.