### PR TITLE
feat(kernel): add generic `KeyboardService` abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,7 @@ dependencies = [
  "bbq10kbd",
  "futures",
  "mnemos",
+ "mycelium-bitfield",
  "tracing 0.2.0",
  "uuid 1.3.4",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,6 +1566,7 @@ dependencies = [
  "mnemos-abi",
  "mnemos-alloc",
  "mnemos-trace-proto",
+ "mycelium-bitfield",
  "mycelium-util",
  "portable-atomic",
  "postcard 1.0.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,17 @@ rev = "cbcfc62a6ea3646fb43f2c159cfdc19b3d932004"
 git = "https://github.com/hawkw/mycelium.git"
 rev = "cbcfc62a6ea3646fb43f2c159cfdc19b3d932004"
 
+# Use the `mycelium-bitfield` crate from the Mycelium monorepo rather than
+# crates.io.
+# NOTE: this patch, unlike the patches for `maitake` and `mycelium-util`, (which
+# are unpublished), is not *strictly* necessary, as `mycelium-bitfield` *is*
+# published to crates.io. However, we may as well depend on the git version,
+# since it's already in our dependency tree as a transitive dep of `maitake` ---
+# having both a Git dep and a crates.io dep seems unfortunate.
+[patch.crates-io.mycelium-bitfield]
+git = "https://github.com/hawkw/mycelium.git"
+rev = "cbcfc62a6ea3646fb43f2c159cfdc19b3d932004"
+
 [patch.crates-io.cordyceps]
 git = "https://github.com/hawkw/mycelium.git"
 rev = "cbcfc62a6ea3646fb43f2c159cfdc19b3d932004"

--- a/platforms/allwinner-d1/boards/Cargo.lock
+++ b/platforms/allwinner-d1/boards/Cargo.lock
@@ -458,6 +458,7 @@ dependencies = [
  "mnemos-abi",
  "mnemos-alloc",
  "mnemos-trace-proto",
+ "mycelium-bitfield",
  "mycelium-util",
  "portable-atomic",
  "postcard",

--- a/platforms/allwinner-d1/boards/Cargo.lock
+++ b/platforms/allwinner-d1/boards/Cargo.lock
@@ -500,6 +500,7 @@ dependencies = [
  "bbq10kbd",
  "futures",
  "mnemos",
+ "mycelium-bitfield",
  "tracing 0.2.0",
  "uuid",
 ]

--- a/platforms/allwinner-d1/boards/Cargo.toml
+++ b/platforms/allwinner-d1/boards/Cargo.toml
@@ -69,6 +69,17 @@ rev = "cbcfc62a6ea3646fb43f2c159cfdc19b3d932004"
 git = "https://github.com/hawkw/mycelium.git"
 rev = "cbcfc62a6ea3646fb43f2c159cfdc19b3d932004"
 
+# Use the `mycelium-bitfield` crate from the Mycelium monorepo rather than
+# crates.io.
+# NOTE: this patch, unlike the patches for `maitake` and `mycelium-util`, (which
+# are unpublished), is not *strictly* necessary, as `mycelium-bitfield` *is*
+# published to crates.io. However, we may as well depend on the git version,
+# since it's already in our dependency tree as a transitive dep of `maitake` ---
+# having both a Git dep and a crates.io dep seems unfortunate.
+[patch.crates-io.mycelium-bitfield]
+git = "https://github.com/hawkw/mycelium.git"
+rev = "cbcfc62a6ea3646fb43f2c159cfdc19b3d932004"
+
 [patch.crates-io.cordyceps]
 git = "https://github.com/hawkw/mycelium.git"
 rev = "cbcfc62a6ea3646fb43f2c159cfdc19b3d932004"

--- a/platforms/allwinner-d1/boards/src/bin/lichee-rv.rs
+++ b/platforms/allwinner-d1/boards/src/bin/lichee-rv.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use core::time::Duration;
 use mnemos_d1_core::{
     dmac::Dmac,
-    drivers::{spim::kernel_spim1, uart::kernel_uart, twi},
+    drivers::{spim::kernel_spim1, twi, uart::kernel_uart},
     plic::Plic,
     timer::Timers,
     Ram, D1,

--- a/platforms/allwinner-d1/boards/src/bin/mq-pro.rs
+++ b/platforms/allwinner-d1/boards/src/bin/mq-pro.rs
@@ -85,20 +85,20 @@ fn main() -> ! {
         }
     ).unwrap();
 
-    // d1.kernel.initialize(async move {
-    //     // walk through the HSV color space. maybe eventually we'll use the RGB
-    //     // LED to display useful information, but this is fun for now.
-    //     let mut hue = 0;
+    d1.kernel.initialize(async move {
+        // walk through the HSV color space. maybe eventually we'll use the RGB
+        // LED to display useful information, but this is fun for now.
+        let mut hue = 0;
 
-    //     let mut i2c_puppet = I2cPuppetClient::from_registry(d1.kernel).await;
+        let mut i2c_puppet = I2cPuppetClient::from_registry(d1.kernel).await;
 
-    //     i2c_puppet.toggle_led(true).await.expect("can't turn on LED");
-    //     loop {
-    //         i2c_puppet.set_led_color(HsvColor::from_hue(hue)).await.expect("can't set color");
-    //         hue = hue.wrapping_add(1);
-    //         d1.kernel.sleep(Duration::from_millis(50)).await;
-    //     }
-    // }).unwrap();
+        i2c_puppet.toggle_led(true).await.expect("can't turn on LED");
+        loop {
+            i2c_puppet.set_led_color(HsvColor::from_hue(hue)).await.expect("can't set color");
+            hue = hue.wrapping_add(1);
+            d1.kernel.sleep(Duration::from_millis(50)).await;
+        }
+    }).unwrap();
 
     d1.run()
 }

--- a/platforms/allwinner-d1/boards/src/bin/mq-pro.rs
+++ b/platforms/allwinner-d1/boards/src/bin/mq-pro.rs
@@ -77,7 +77,7 @@ fn main() -> ! {
             let mut i2c_puppet = I2cPuppetClient::from_registry(d1.kernel).await;
             tracing::info!("got i2c puppet client");
 
-            let mut keys = i2c_puppet.subscribe_to_keys().await.expect("can't get keys");
+            let mut keys = i2c_puppet.subscribe_to_raw_keys().await.expect("can't get keys");
             tracing::info!("got key subscription");
             while let Ok(key) = keys.next_char().await {
                 tracing::info!(?key, "got keypress");

--- a/platforms/allwinner-d1/boards/src/bin/mq-pro.rs
+++ b/platforms/allwinner-d1/boards/src/bin/mq-pro.rs
@@ -4,6 +4,7 @@
 extern crate alloc;
 
 use core::time::Duration;
+use mnemos_beepy::i2c_puppet::{HsvColor, I2cPuppetClient, I2cPuppetServer};
 use mnemos_d1_core::{
     dmac::Dmac,
     drivers::{spim::kernel_spim1, twi, uart::kernel_uart},
@@ -11,7 +12,6 @@ use mnemos_d1_core::{
     timer::Timers,
     Ram, D1,
 };
-use mnemos_beepy::i2c_puppet::{I2cPuppetClient, I2cPuppetServer, HsvColor};
 
 const HEAP_SIZE: usize = 384 * 1024 * 1024;
 
@@ -65,40 +65,56 @@ fn main() -> ! {
 
     d1.initialize_sharp_display();
 
-    let i2c_puppet_up = d1.kernel.initialize(async move {
-        d1.kernel.sleep(Duration::from_secs(2)).await;
-        I2cPuppetServer::register(d1.kernel, Default::default()).await.expect("failed to register i2c_puppet driver!");
-    }).unwrap();
+    let i2c_puppet_up = d1
+        .kernel
+        .initialize(async move {
+            d1.kernel.sleep(Duration::from_secs(2)).await;
+            I2cPuppetServer::register(d1.kernel, Default::default())
+                .await
+                .expect("failed to register i2c_puppet driver!");
+        })
+        .unwrap();
 
-    d1.kernel.initialize(
-        async move {
+    d1.kernel
+        .initialize(async move {
             // i2c_puppet demo: print each keypress to the console.
             i2c_puppet_up.await.unwrap();
             let mut i2c_puppet = I2cPuppetClient::from_registry(d1.kernel).await;
             tracing::info!("got i2c puppet client");
 
-            let mut keys = i2c_puppet.subscribe_to_raw_keys().await.expect("can't get keys");
+            let mut keys = i2c_puppet
+                .subscribe_to_raw_keys()
+                .await
+                .expect("can't get keys");
             tracing::info!("got key subscription");
             while let Ok(key) = keys.next_char().await {
                 tracing::info!(?key, "got keypress");
             }
-        }
-    ).unwrap();
+        })
+        .unwrap();
 
-    d1.kernel.initialize(async move {
-        // walk through the HSV color space. maybe eventually we'll use the RGB
-        // LED to display useful information, but this is fun for now.
-        let mut hue = 0;
+    d1.kernel
+        .initialize(async move {
+            // walk through the HSV color space. maybe eventually we'll use the RGB
+            // LED to display useful information, but this is fun for now.
+            let mut hue = 0;
 
-        let mut i2c_puppet = I2cPuppetClient::from_registry(d1.kernel).await;
+            let mut i2c_puppet = I2cPuppetClient::from_registry(d1.kernel).await;
 
-        i2c_puppet.toggle_led(true).await.expect("can't turn on LED");
-        loop {
-            i2c_puppet.set_led_color(HsvColor::from_hue(hue)).await.expect("can't set color");
-            hue = hue.wrapping_add(1);
-            d1.kernel.sleep(Duration::from_millis(50)).await;
-        }
-    }).unwrap();
+            i2c_puppet
+                .toggle_led(true)
+                .await
+                .expect("can't turn on LED");
+            loop {
+                i2c_puppet
+                    .set_led_color(HsvColor::from_hue(hue))
+                    .await
+                    .expect("can't set color");
+                hue = hue.wrapping_add(1);
+                d1.kernel.sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .unwrap();
 
     d1.run()
 }

--- a/platforms/allwinner-d1/boards/src/bin/mq-pro.rs
+++ b/platforms/allwinner-d1/boards/src/bin/mq-pro.rs
@@ -85,20 +85,20 @@ fn main() -> ! {
         }
     ).unwrap();
 
-    d1.kernel.initialize(async move {
-        // walk through the HSV color space. maybe eventually we'll use the RGB
-        // LED to display useful information, but this is fun for now.
-        let mut hue = 0;
+    // d1.kernel.initialize(async move {
+    //     // walk through the HSV color space. maybe eventually we'll use the RGB
+    //     // LED to display useful information, but this is fun for now.
+    //     let mut hue = 0;
 
-        let mut i2c_puppet = I2cPuppetClient::from_registry(d1.kernel).await;
+    //     let mut i2c_puppet = I2cPuppetClient::from_registry(d1.kernel).await;
 
-        i2c_puppet.toggle_led(true).await.expect("can't turn on LED");
-        loop {
-            i2c_puppet.set_led_color(HsvColor::from_hue(hue)).await.expect("can't set color");
-            hue = hue.wrapping_add(1);
-            d1.kernel.sleep(Duration::from_millis(50)).await;
-        }
-    }).unwrap();
+    //     i2c_puppet.toggle_led(true).await.expect("can't turn on LED");
+    //     loop {
+    //         i2c_puppet.set_led_color(HsvColor::from_hue(hue)).await.expect("can't set color");
+    //         hue = hue.wrapping_add(1);
+    //         d1.kernel.sleep(Duration::from_millis(50)).await;
+    //     }
+    // }).unwrap();
 
     d1.run()
 }

--- a/platforms/beepy/Cargo.toml
+++ b/platforms/beepy/Cargo.toml
@@ -30,3 +30,6 @@ default-features = false
 version = "0.3.21"
 features = ["async-await"]
 default-features = false
+
+[dependencies.mycelium-bitfield]
+version = "0.1.2"

--- a/platforms/beepy/src/i2c_puppet.rs
+++ b/platforms/beepy/src/i2c_puppet.rs
@@ -552,7 +552,7 @@ pub struct I2cPuppetSettings {
     pub max_subscriptions: usize,
     pub poll_interval: Duration,
     /// If set, the `i2c_puppet` service will also forward keypresses to the kernel's
-    /// [`KeyboardMuxService`].
+    /// [`KeyboardMuxService`](kernel::services::keyboard::mux::KeyboardMuxService).
     pub keymux: bool,
 }
 

--- a/platforms/beepy/src/i2c_puppet.rs
+++ b/platforms/beepy/src/i2c_puppet.rs
@@ -313,7 +313,12 @@ impl I2cPuppetServer {
         let cfg = reg::Cfg::new()
             .with(reg::Cfg::KEY_INT, true)
             .with(reg::Cfg::USE_MODS, true)
-            .with(reg::Cfg::OVERFLOW_INT, true);
+            .with(reg::Cfg::OVERFLOW_INT, true)
+            // overwrite older keypresses when the FIFO is full. 
+            // since we only poll the keyboard when there are active 
+            // subscriptions, enable this setting so that the
+            // FIFO doesn't fill up with ancient keypresses. 
+            .with(reg::Cfg::OVERFLOW_ON, true);
         tracing::info!("setting i2c_puppet config:\n{cfg}");
         i2c.write(ADDR, &[reg::CFG | reg::WRITE, cfg.bits()])
             .await

--- a/platforms/beepy/src/i2c_puppet.rs
+++ b/platforms/beepy/src/i2c_puppet.rs
@@ -562,7 +562,7 @@ impl Default for I2cPuppetSettings {
             channel_capacity: 8,
             subscription_capacity: 32,
             max_subscriptions: 8,
-            poll_interval: Duration::from_secs(1),
+            poll_interval: Duration::from_millis(50),
             keymux: true,
         }
     }

--- a/platforms/beepy/src/i2c_puppet.rs
+++ b/platforms/beepy/src/i2c_puppet.rs
@@ -1,3 +1,5 @@
+//! Driver for the [`i2c_puppet`](https://github.com/solderparty/i2c_puppet)
+//! keyboard firmware.
 use bbq10kbd::{AsyncBbq10Kbd, CapsLockState, FifoCount, NumLockState};
 pub use bbq10kbd::{KeyRaw, KeyStatus, Version};
 use core::{fmt, time::Duration};
@@ -136,8 +138,8 @@ impl I2cPuppetClient {
     ///
     /// The returned [`RawKeySubscription`] provides access to keyboard events
     /// in the [`bbq10kbd`] crate's representation, which is specific to the
-    /// Blackberry Q10 keyboard. In general, it's preferable to implement code
-    /// that requires keyboard input against the more generic
+    /// Blackberry Q10 and Q20 keyboards. In general, it's preferable to
+    /// implement code that requires keyboard input against the more generic
     /// [`KeyboardService`] defined in the cross-platform kernel crate.
     ///
     /// [`KeyboardService`]: kernel::services::keyboard::KeyboardService
@@ -192,7 +194,7 @@ impl I2cPuppetClient {
         }
     }
 
-    /// Returns the `i2c_puppet` Blackberry Q10 keyboard's backlight brightness. 0
+    /// Returns the `i2c_puppet` keyboard's backlight brightness. 0
     /// is off, 255 is maximum brightness.
     pub async fn backlight(&mut self) -> Result<u8, Error> {
         if let Response::Backlight(brightness) = self.request(Request::GetBacklight).await? {
@@ -314,10 +316,10 @@ impl I2cPuppetServer {
             .with(reg::Cfg::KEY_INT, true)
             .with(reg::Cfg::USE_MODS, true)
             .with(reg::Cfg::OVERFLOW_INT, true)
-            // overwrite older keypresses when the FIFO is full. 
-            // since we only poll the keyboard when there are active 
+            // overwrite older keypresses when the FIFO is full.
+            // since we only poll the keyboard when there are active
             // subscriptions, enable this setting so that the
-            // FIFO doesn't fill up with ancient keypresses. 
+            // FIFO doesn't fill up with ancient keypresses.
             .with(reg::Cfg::OVERFLOW_ON, true);
         tracing::info!("setting i2c_puppet config:\n{cfg}");
         i2c.write(ADDR, &[reg::CFG | reg::WRITE, cfg.bits()])

--- a/source/kernel/Cargo.toml
+++ b/source/kernel/Cargo.toml
@@ -128,6 +128,9 @@ default-features = false
 [dependencies.profont]
 version = "0.6.1"
 
+[dependencies.mycelium-bitfield]
+version = "0.1.2"
+
 [build-dependencies]
 vergen = { version = "8.0.0", features = ["cargo", "git", "gitcl", "rustc",] }
 

--- a/source/kernel/src/daemons/shells.rs
+++ b/source/kernel/src/daemons/shells.rs
@@ -8,7 +8,7 @@ use crate::{
     forth::Params,
     services::{
         emb_display::EmbDisplayClient,
-        keyboard::{key_event, KeyClient, KeyEvent},
+        keyboard::{key_event, KeyClient},
         serial_mux::{PortHandle, WellKnown},
     },
     tracing, Kernel,

--- a/source/kernel/src/daemons/shells.rs
+++ b/source/kernel/src/daemons/shells.rs
@@ -235,7 +235,7 @@ pub async fn graphical_shell_mono(k: &'static Kernel, settings: GraphicalShellSe
             futures::select_biased! {
                 event = keyboard.next().fuse() => {
 
-                    let Some(event) = event else {
+                    let Ok(event) = event else {
                         tracing::error!("Keyboard service is dead???");
                         continue;
                     };

--- a/source/kernel/src/daemons/shells.rs
+++ b/source/kernel/src/daemons/shells.rs
@@ -8,6 +8,7 @@ use crate::{
     forth::Params,
     services::{
         emb_display::EmbDisplayClient,
+        keyboard::{key_event, KeyClient, KeyEvent},
         serial_mux::{PortHandle, WellKnown},
     },
     tracing, Kernel,
@@ -108,10 +109,6 @@ pub async fn sermux_shell(k: &'static Kernel, settings: SermuxShellSettings) {
 /// ```
 #[derive(Debug)]
 pub struct GraphicalShellSettings {
-    /// Sermux port to use as a PseudoKeyboard.
-    ///
-    /// Defaults to [WellKnown::PseudoKeyboard]
-    pub port: u16,
     /// Number of bytes used for the sermux buffer
     ///
     /// Defaults to 256
@@ -135,7 +132,6 @@ pub struct GraphicalShellSettings {
 impl GraphicalShellSettings {
     pub fn with_display_size(width_px: u32, height_px: u32) -> Self {
         Self {
-            port: WellKnown::PseudoKeyboard.into(),
             capacity: 256,
             forth_settings: Default::default(),
             disp_width_px: width_px,
@@ -150,8 +146,7 @@ impl GraphicalShellSettings {
 #[tracing::instrument(skip(k))]
 pub async fn graphical_shell_mono(k: &'static Kernel, settings: GraphicalShellSettings) {
     let GraphicalShellSettings {
-        port,
-        capacity,
+        capacity: _cap,
         forth_settings,
         disp_width_px,
         disp_height_px,
@@ -159,9 +154,7 @@ pub async fn graphical_shell_mono(k: &'static Kernel, settings: GraphicalShellSe
         _priv,
     } = settings;
 
-    // TODO: Reconsider using a sermux port here once we have a more real keyboard thing
-    let port = PortHandle::open(k, port, capacity).await.unwrap();
-
+    let mut keyboard = KeyClient::from_registry(k, Default::default()).await;
     let mut disp_hdl = EmbDisplayClient::from_registry(k).await;
     let char_y = font.character_size.height;
     let char_x = font.character_size.width + font.character_spacing;
@@ -237,48 +230,62 @@ pub async fn graphical_shell_mono(k: &'static Kernel, settings: GraphicalShellSe
         ring_drawer::drawer_bw(&mut fc_0, &rline, style.clone()).unwrap();
         disp_hdl.draw_framechunk(fc_0).await.unwrap();
 
-        futures::select_biased! {
-            rgr = port.consumer().read_grant().fuse() => {
-                let mut used = 0;
-                'input: for &b in rgr.iter() {
-                    used += 1;
-                    match rline.append_local_char(b) {
-                        Ok(_) => {}
+        loop {
+            // loop *just* for skipping released key events
+            futures::select_biased! {
+                event = keyboard.next().fuse() => {
+                    use key_event::{Kind, KeyCode};
+
+                    let Some(event) = event else {
+                        tracing::error!("Keyboard service is dead???");
+                        continue;
+                    };
+                    // tracing::debug!(?event, "shell got key event");
+                    if event.kind == Kind::Released {
+                        continue;
+                    }
+                    let Some(ch) = event.code.into_char() else {
+                        continue;
+                    };
+                    if !ch.is_ascii() {
+                        tracing::warn!("skipping non-ASCII character: {ch:?}");
+                        continue;
+                    }
+
+                    match (rline.append_local_char(ch as u8), event.code) {
+                        (Ok(_), _) => {}
                         // backspace
-                        Err(_) if b == 0x7F => {
-                            rline.pop_local_char();
-                        }
-                        Err(_) if b == b'\n' => {
+                        (Err(_), KeyCode::Backspace) | (Err(_), KeyCode::Delete) => rline.pop_local_char(),
+                        (Err(_), KeyCode::Enter) => {
                             let needed = rline.local_editing_len();
                             if needed != 0 {
                                 let mut tid_io_wgr = tid_io.producer().send_grant_exact(needed).await;
                                 rline.copy_local_editing_to(&mut tid_io_wgr).unwrap();
                                 tid_io_wgr.commit(needed);
                                 rline.submit_local_editing();
-                                break 'input;
                             }
                         }
-                        Err(error) => {
-                            tracing::warn!(?error, "Error appending char: {:02X}", b);
+                        (Err(error), _) => {
+                            tracing::warn!(?error, "Error appending char: {ch:?}");
                         }
                     }
-                }
-
-                rgr.release(used);
-            },
-            output = tid_io.consumer().read_grant().fuse() => {
-                let len = output.len();
-                tracing::trace!(len, "Received output from tid_io");
-                for &b in output.iter() {
-                    // TODO(eliza): what if this errors lol
-                    if b == b'\n' {
-                        rline.submit_remote_editing();
-                    } else {
-                        let _ = rline.append_remote_char(b);
+                },
+                output = tid_io.consumer().read_grant().fuse() => {
+                    let len = output.len();
+                    tracing::trace!(len, "Received output from tid_io");
+                    for &b in output.iter() {
+                        // TODO(eliza): what if this errors lol
+                        if b == b'\n' {
+                            rline.submit_remote_editing();
+                        } else {
+                            let _ = rline.append_remote_char(b);
+                        }
                     }
+                    output.release(len);
                 }
-                output.release(len);
             }
+
+            break;
         }
     }
 }

--- a/source/kernel/src/registry/mod.rs
+++ b/source/kernel/src/registry/mod.rs
@@ -29,6 +29,7 @@ pub mod known_uuids {
         pub const EMB_DISPLAY: Uuid = uuid!("b54db574-3eb7-4c89-8bfb-1a20890be68e");
         pub const FORTH_SPAWNULATOR: Uuid = uuid!("4ae4a406-005a-4bde-be91-afc1900f76fa");
         pub const I2C: Uuid = uuid!("011ebd3e-1b14-4bfd-b581-6138239b82f3");
+        pub const KEYBOARD: Uuid = uuid!("524d77b1-499c-440b-bd62-e63c0918efb5");
     }
 
     // In case you need to iterate over every UUID
@@ -38,6 +39,7 @@ pub mod known_uuids {
         kernel::EMB_DISPLAY,
         kernel::FORTH_SPAWNULATOR,
         kernel::I2C,
+        kernel::KEYBOARD,
     ];
 }
 

--- a/source/kernel/src/registry/mod.rs
+++ b/source/kernel/src/registry/mod.rs
@@ -30,6 +30,7 @@ pub mod known_uuids {
         pub const FORTH_SPAWNULATOR: Uuid = uuid!("4ae4a406-005a-4bde-be91-afc1900f76fa");
         pub const I2C: Uuid = uuid!("011ebd3e-1b14-4bfd-b581-6138239b82f3");
         pub const KEYBOARD: Uuid = uuid!("524d77b1-499c-440b-bd62-e63c0918efb5");
+        pub const KEYBOARD_MUX: Uuid = uuid!("70861d1c-9f01-4e9b-89e6-ede77d8f26d8");
     }
 
     // In case you need to iterate over every UUID
@@ -40,6 +41,7 @@ pub mod known_uuids {
         kernel::FORTH_SPAWNULATOR,
         kernel::I2C,
         kernel::KEYBOARD,
+        kernel::KEYBOARD_MUX,
     ];
 }
 

--- a/source/kernel/src/services/keyboard/event.rs
+++ b/source/kernel/src/services/keyboard/event.rs
@@ -1,0 +1,138 @@
+//! Keyboard events
+//!
+//! This module contains types representing keyboard events that are published
+//! over a [`KeySubscription`](super::KeySubscription).
+//!
+//! The structure of the keyboard event API is based loosely on the interface
+//! provided by the [`crossterm`] crate (MIT-licensed), with some modifications.
+//!
+//! [`crossterm`]: https://github.com/crossterm-rs/crossterm/blob/1efdce7ef63cba6992729db5f22262a60936fa8b/src/event.rs
+
+/// A keyboard event.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct KeyEvent {
+    /// What keyboard event occurred?
+    pub kind: Kind,
+    /// What modifier keys (if any) were held when the key event occurred?
+    pub modifiers: Modifiers,
+    /// What key code was pressed?
+    pub code: KeyCode,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Kind {
+    Pressed,
+    Released,
+    Held,
+}
+
+mycelium_bitfield::bitfield! {
+    // Copy, Clone, and Debug are derived for us by `mycelium_bitfield`.
+    #[derive(PartialEq, Eq, Hash)]
+    pub struct Modifiers<u8> {
+        pub const SHIFT: bool;
+        pub const CTRL: bool;
+        pub const ALT: bool;
+        pub const META: bool;
+        pub const CAPSLOCK: bool;
+        pub const NUMLOCK: bool;
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum KeyCode {
+    /// Backspace key.
+    Backspace,
+    /// Enter key.
+    Enter,
+    /// Left arrow key.
+    Left,
+    /// Right arrow key.
+    Right,
+    /// Up arrow key.
+    Up,
+    /// Down arrow key.
+    Down,
+    /// Home key.
+    Home,
+    /// End key.
+    End,
+    /// Page up key.
+    PageUp,
+    /// Page down key.
+    PageDown,
+    /// Tab key.
+    Tab,
+    /// Shift + Tab key.
+    BackTab,
+    /// Delete key.
+    Delete,
+    /// Insert key.
+    Insert,
+    /// F key.
+    ///
+    /// `KeyCode::F(1)` represents F1 key, etc.
+    F(u8),
+    /// A character.
+    ///
+    /// `KeyCode::Char('c')` represents `c` character, etc.
+    Char(char),
+    /// Null.
+    Null,
+    /// Escape key.
+    Esc,
+    /// Num Lock key.
+    NumLock,
+    /// Print Screen key.
+    PrintScreen,
+    /// Pause key.
+    Pause,
+    /// Menu key.
+    Menu,
+    /// The "Begin" key (often mapped to the 5 key when Num Lock is turned on).
+    KeypadBegin,
+    /// A media key.
+    Media(MediaKeyCode),
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum MediaKeyCode {
+    /// Play media key.
+    Play,
+    /// Pause media key.
+    Pause,
+    /// Play/Pause media key.
+    PlayPause,
+    /// Reverse media key.
+    Reverse,
+    /// Stop media key.
+    Stop,
+    /// Fast-forward media key.
+    FastForward,
+    /// Rewind media key.
+    Rewind,
+    /// Next-track media key.
+    TrackNext,
+    /// Previous-track media key.
+    TrackPrevious,
+    /// Record media key.
+    Record,
+    /// Lower-volume media key.
+    LowerVolume,
+    /// Raise-volume media key.
+    RaiseVolume,
+    /// Mute media key.
+    MuteVolume,
+}
+
+impl KeyEvent {
+    pub fn into_char(self) -> Option<char> {
+        match self.code {
+            KeyCode::Char(c) => Some(c),
+            KeyCode::Enter => Some('\n'),
+            KeyCode::Tab => Some('\t'),
+            KeyCode::Null => Some('\0'),
+            _ => None,
+        }
+    }
+}

--- a/source/kernel/src/services/keyboard/key_event.rs
+++ b/source/kernel/src/services/keyboard/key_event.rs
@@ -133,6 +133,7 @@ impl KeyCode {
             KeyCode::Enter => Some('\n'),
             KeyCode::Tab => Some('\t'),
             KeyCode::Null => Some('\0'),
+            KeyCode::Backspace => Some('\x7f'),
             _ => None,
         }
     }

--- a/source/kernel/src/services/keyboard/key_event.rs
+++ b/source/kernel/src/services/keyboard/key_event.rs
@@ -1,7 +1,7 @@
 //! Keyboard events
 //!
 //! This module contains types representing keyboard events that are published
-//! over a [`KeySubscription`](super::KeySubscription).
+//! to a [`KeyClient`](super::KeyClient).
 //!
 //! The structure of the keyboard event API is based loosely on the interface
 //! provided by the [`crossterm`] crate (MIT-licensed), with some modifications.

--- a/source/kernel/src/services/keyboard/mod.rs
+++ b/source/kernel/src/services/keyboard/mod.rs
@@ -1,0 +1,87 @@
+//! # Keyboard Service
+//!
+//! This module defines a generic service for modeling keyboard drivers. This
+//! service can be implemented by drivers for specific keyboards, or by generic
+//! "keyboard multiplexer" services. The latter is useful for systems that have
+//! multiple keyboards, where a centralized service can multiplex the input from
+//! multiple hardware keyboard drivers into a single stream of keyboard events
+//! from all keyboards.
+//!
+//! The [`event`] submodule defines a generic representation of keyboard events,
+//! which is, admittedly, a bit overly complex. It's intended to model as many
+//! different types of keyboard as possible. Not all keyboards will provide all
+//! of the available keyboard event types, based on what keys actually exist on
+//! the keyboard.
+
+use uuid::Uuid;
+
+use crate::comms::kchannel;
+use crate::registry::{known_uuids, RegisteredDriver};
+
+pub mod event;
+
+////////////////////////////////////////////////////////////////////////////////
+// Service Definition
+////////////////////////////////////////////////////////////////////////////////
+
+pub struct KeyboardService;
+
+impl RegisteredDriver for KeyboardService {
+    type Request = Subscribe;
+    type Response = KeySubscription;
+    type Error = KeyboardError;
+
+    const UUID: Uuid = known_uuids::kernel::KEYBOARD;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Message and Error Types
+////////////////////////////////////////////////////////////////////////////////
+pub use self::event::KeyEvent;
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Subscribe {
+    /// Capacity of the key subscription buffer.
+    buffer_capacity: usize,
+}
+
+pub struct KeySubscription {
+    rx: kchannel::KConsumer<KeyEvent>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum KeyboardError {
+    NoKeyboards,
+    TooManySubscriptions,
+}
+
+impl Subscribe {
+    pub const DEFAULT_BUFFER_CAPACITY: usize = 32;
+    pub fn with_buffer_capacity(self, buffer_capacity: usize) -> Self {
+        Self { buffer_capacity }
+    }
+}
+
+impl Default for Subscribe {
+    fn default() -> Self {
+        Self {
+            buffer_capacity: Self::DEFAULT_BUFFER_CAPACITY,
+        }
+    }
+}
+
+impl KeySubscription {
+    pub async fn new(subscription: Subscribe) -> (kchannel::KProducer<KeyEvent>, Self) {
+        let Subscribe { buffer_capacity } = subscription;
+        let (tx, rx) = kchannel::KChannel::new_async(buffer_capacity).await.split();
+        (tx, Self { rx })
+    }
+
+    pub async fn next(&mut self) -> Option<KeyEvent> {
+        self.rx.dequeue_async().await.ok()
+    }
+
+    pub async fn next_char(&mut self) -> Option<char> {
+        self.next().await?.into_char()
+    }
+}

--- a/source/kernel/src/services/keyboard/mod.rs
+++ b/source/kernel/src/services/keyboard/mod.rs
@@ -12,13 +12,20 @@
 //! different types of keyboard as possible. Not all keyboards will provide all
 //! of the available keyboard event types, based on what keys actually exist on
 //! the keyboard.
-
 use uuid::Uuid;
 
-use crate::comms::kchannel;
-use crate::registry::{known_uuids, RegisteredDriver};
+use crate::{
+    comms::{
+        kchannel::{self, KChannel},
+        oneshot,
+    },
+    registry::{known_uuids, RegisteredDriver},
+    Kernel,
+};
+use core::time::Duration;
 
-pub mod event;
+pub mod key_event;
+pub mod mux;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Service Definition
@@ -28,7 +35,7 @@ pub struct KeyboardService;
 
 impl RegisteredDriver for KeyboardService {
     type Request = Subscribe;
-    type Response = KeySubscription;
+    type Response = Subscribed;
     type Error = KeyboardError;
 
     const UUID: Uuid = known_uuids::kernel::KEYBOARD;
@@ -37,29 +44,21 @@ impl RegisteredDriver for KeyboardService {
 ////////////////////////////////////////////////////////////////////////////////
 // Message and Error Types
 ////////////////////////////////////////////////////////////////////////////////
-pub use self::event::KeyEvent;
+pub use self::key_event::KeyEvent;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Subscribe {
-    /// Capacity of the key subscription buffer.
     buffer_capacity: usize,
 }
 
-pub struct KeySubscription {
+pub struct Subscribed {
     rx: kchannel::KConsumer<KeyEvent>,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum KeyboardError {
     NoKeyboards,
     TooManySubscriptions,
-}
-
-impl Subscribe {
-    pub const DEFAULT_BUFFER_CAPACITY: usize = 32;
-    pub fn with_buffer_capacity(self, buffer_capacity: usize) -> Self {
-        Self { buffer_capacity }
-    }
 }
 
 impl Default for Subscribe {
@@ -70,11 +69,66 @@ impl Default for Subscribe {
     }
 }
 
-impl KeySubscription {
-    pub async fn new(subscription: Subscribe) -> (kchannel::KProducer<KeyEvent>, Self) {
-        let Subscribe { buffer_capacity } = subscription;
-        let (tx, rx) = kchannel::KChannel::new_async(buffer_capacity).await.split();
+impl Subscribe {
+    pub const DEFAULT_BUFFER_CAPACITY: usize = 32;
+
+    pub fn with_buffer_capacity(self, buffer_capacity: usize) -> Self {
+        Self { buffer_capacity }
+    }
+}
+
+impl Subscribed {
+    pub fn new(Subscribe { buffer_capacity }: Subscribe) -> (kchannel::KProducer<KeyEvent>, Self) {
+        let (tx, rx) = KChannel::new(buffer_capacity).split();
         (tx, Self { rx })
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Client types
+////////////////////////////////////////////////////////////////////////////////
+pub struct KeyClient {
+    rx: kchannel::KConsumer<KeyEvent>,
+}
+
+impl KeyClient {
+    /// Obtain a `KeyClient`
+    ///
+    /// If the [`KeyboardService`] hasn't been registered yet, we will retry until it
+    /// has been registered.
+    pub async fn from_registry(kernel: &'static Kernel, subscribe: Subscribe) -> Self {
+        loop {
+            match Self::from_registry_no_retry(kernel, subscribe).await {
+                Some(port) => return port,
+                None => {
+                    // I2C probably isn't registered yet. Try again in a bit
+                    kernel.sleep(Duration::from_millis(10)).await;
+                }
+            }
+        }
+    }
+
+    /// Obtain an `KeyClient`
+    ///
+    /// Does NOT attempt to get an [`KeyboardService`] handle more than once.
+    ///
+    /// Prefer [`KeyClient::from_registry`] unless you will not be spawning one
+    /// around the same time as obtaining a client.
+    pub async fn from_registry_no_retry(
+        kernel: &'static Kernel,
+        subscribe: Subscribe,
+    ) -> Option<Self> {
+        let mut handle = kernel
+            .with_registry(|reg| reg.get::<KeyboardService>())
+            .await?;
+        let reply = oneshot::Reusable::new_async().await;
+        let Subscribed { rx } = handle
+            .request_oneshot(subscribe, &reply)
+            .await
+            .ok()?
+            .body
+            .ok()?;
+        Some(Self { rx })
     }
 
     pub async fn next(&mut self) -> Option<KeyEvent> {

--- a/source/kernel/src/services/keyboard/mod.rs
+++ b/source/kernel/src/services/keyboard/mod.rs
@@ -1,11 +1,11 @@
 //! # Keyboard Service
 //!
 //! This module defines a generic service for modeling keyboard drivers. This
-//! service can be implemented by drivers for specific keyboards, or by generic
-//! "keyboard multiplexer" services. The latter is useful for systems that have
-//! multiple keyboards, where a centralized service can multiplex the input from
-//! multiple hardware keyboard drivers into a single stream of keyboard events
-//! from all keyboards.
+//! service can be implemented by drivers for specific keyboards, or by a generic
+//! ["keyboard multiplexer" service](self::mux::KeyboardMuxService) type in the
+//! [`mux`] submodule. The latter is useful for systems that have multiple
+//! keyboards, as it allows clients which consume keyboard input to subscribe to
+//! events from *all* hardware keyboard drivers, rather than a single keyboard.
 //!
 //! The [`event`] submodule defines a generic representation of keyboard events,
 //! which is, admittedly, a bit overly complex. It's intended to model as many

--- a/source/kernel/src/services/keyboard/mux.rs
+++ b/source/kernel/src/services/keyboard/mux.rs
@@ -1,0 +1,202 @@
+use super::{KeyEvent, KeyboardError, KeyboardService, Subscribed};
+use crate::{
+    comms::{
+        kchannel::{KChannel, KConsumer, KProducer},
+        oneshot::Reusable,
+    },
+    mnemos_alloc::containers::FixedVec,
+    registry::{
+        self, known_uuids, Envelope, KernelHandle, OneshotRequestError, RegisteredDriver,
+        RegistrationError,
+    },
+    tracing, Kernel,
+};
+use core::{convert::Infallible, time::Duration};
+use futures::FutureExt;
+use uuid::Uuid;
+
+////////////////////////////////////////////////////////////////////////////////
+// Service Definition
+////////////////////////////////////////////////////////////////////////////////
+
+pub struct KeyboardMuxService;
+
+impl RegisteredDriver for KeyboardMuxService {
+    type Request = Publish;
+    type Response = Response;
+    type Error = core::convert::Infallible;
+
+    const UUID: Uuid = known_uuids::kernel::KEYBOARD_MUX;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Message and Error Types
+////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Publish(KeyEvent);
+
+pub struct Response {
+    _p: (),
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Client Definition
+////////////////////////////////////////////////////////////////////////////////
+
+pub struct KeyboardMuxClient {
+    handle: KernelHandle<KeyboardMuxService>,
+    reply: Reusable<Envelope<Result<Response, Infallible>>>,
+}
+
+impl KeyboardMuxClient {
+    /// Obtain a `KeyboardMuxClient`
+    ///
+    /// If the [`KeyboardMuxService`] hasn't been registered yet, we will retry until it
+    /// has been registered.
+    pub async fn from_registry(kernel: &'static Kernel) -> Self {
+        loop {
+            match Self::from_registry_no_retry(kernel).await {
+                Some(port) => return port,
+                None => {
+                    // I2C probably isn't registered yet. Try again in a bit
+                    kernel.sleep(Duration::from_millis(10)).await;
+                }
+            }
+        }
+    }
+
+    /// Obtain an `KeyboardMuxClient`
+    ///
+    /// Does NOT attempt to get an [`KeyboardMuxService`] handle more than once.
+    ///
+    /// Prefer [`KeyboardMuxClient::from_registry`] unless you will not be spawning one
+    /// around the same time as obtaining a client.
+    pub async fn from_registry_no_retry(kernel: &'static Kernel) -> Option<Self> {
+        let handle = kernel
+            .with_registry(|reg| reg.get::<KeyboardMuxService>())
+            .await?;
+
+        Some(Self {
+            handle,
+            reply: Reusable::new_async().await,
+        })
+    }
+
+    pub async fn publish_key(
+        &mut self,
+        event: impl Into<KeyEvent>,
+    ) -> Result<(), OneshotRequestError> {
+        let event = event.into();
+        let _ = self
+            .handle
+            .request_oneshot(Publish(event), &self.reply)
+            .await?;
+        Ok(())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Server Definition
+////////////////////////////////////////////////////////////////////////////////
+
+pub struct KeyboardMuxServer {
+    key_rx: KConsumer<registry::Message<KeyboardMuxService>>,
+    sub_rx: KConsumer<registry::Message<KeyboardService>>,
+    subscriptions: FixedVec<KProducer<KeyEvent>>,
+    settings: KeyboardMuxSettings,
+}
+
+pub struct KeyboardMuxSettings {
+    max_keyboards: usize,
+    buffer_capacity: usize,
+}
+
+impl KeyboardMuxServer {
+    /// Register the `KeyboardMuxServer`.
+    pub async fn register(
+        kernel: &'static Kernel,
+        settings: KeyboardMuxSettings,
+    ) -> Result<(), RegistrationError> {
+        let (key_tx, key_rx) = KChannel::new_async(settings.buffer_capacity).await.split();
+        let (sub_tx, sub_rx) = KChannel::new_async(8).await.split();
+        let subscriptions = FixedVec::new(settings.max_keyboards).await;
+        kernel
+            .spawn(
+                Self {
+                    sub_rx,
+                    key_rx,
+                    subscriptions,
+                    settings,
+                }
+                .run(),
+            )
+            .await;
+
+        kernel
+            .with_registry(|reg| {
+                reg.register_konly::<KeyboardMuxService>(&key_tx)?;
+                reg.register_konly::<KeyboardService>(&sub_tx)?;
+                Ok(())
+            })
+            .await
+    }
+
+    #[tracing::instrument(level = tracing::Level::INFO, name = "KeyboardMuxServer", skip(self))]
+    pub async fn run(mut self) {
+        loop {
+            futures::select_biased! {
+                msg = self.sub_rx.dequeue_async().fuse() => {
+                    let Ok(registry::Message { msg, reply }) = msg else {
+                        tracing::warn!("Key subscription channel ended!");
+                        break;
+                    };
+                    let (tx, rx) = KChannel::new_async(self.settings.buffer_capacity).await.split();
+                    match self.subscriptions.try_push(tx) {
+                        Ok(()) => {
+                            if reply.reply_konly(msg.reply_with(Ok(Subscribed { rx }))).await.is_err() {
+                                // requester is gone, so remove its subscription
+                                tracing::warn!("Keyboard subscription requester is gone!");
+                                self.subscriptions.pop();
+                            } else {
+                                tracing::info!("New keyboard subscription");
+                            }
+                        },
+                        Err(_) => {
+                            let _ = reply.reply_konly(msg.reply_with(Err(KeyboardError::TooManySubscriptions))).await;
+                        }
+                    }
+                },
+                msg = self.key_rx.dequeue_async().fuse() => {
+                    let Ok(registry::Message { msg, reply }) = msg else {
+                        tracing::warn!("Key publish channel ended!");
+                        break;
+                    };
+
+                    let Publish(key) = msg.body;
+                    tracing::debug!(?key, "publishing key event");
+
+                    for sub in self.subscriptions.as_slice_mut() {
+                        let _ = sub.enqueue_async(key).await;
+                    }
+
+                    let _ = reply.reply_konly(msg.reply_with(Ok(Response { _p: ()}))).await;
+                },
+            }
+        }
+    }
+}
+
+impl KeyboardMuxSettings {
+    pub const DEFAULT_BUFFER_CAPACITY: usize = 32;
+    pub const DEFAULT_MAX_KEYBOARDS: usize = 8;
+}
+
+impl Default for KeyboardMuxSettings {
+    fn default() -> Self {
+        Self {
+            max_keyboards: Self::DEFAULT_MAX_KEYBOARDS,
+            buffer_capacity: Self::DEFAULT_BUFFER_CAPACITY,
+        }
+    }
+}

--- a/source/kernel/src/services/mod.rs
+++ b/source/kernel/src/services/mod.rs
@@ -21,5 +21,6 @@
 pub mod emb_display;
 pub mod forth_spawnulator;
 pub mod i2c;
+pub mod keyboard;
 pub mod serial_mux;
 pub mod simple_serial;

--- a/source/kernel/src/services/serial_mux.rs
+++ b/source/kernel/src/services/serial_mux.rs
@@ -17,10 +17,7 @@ use crate::{
         oneshot::Reusable,
     },
     registry::{Envelope, KernelHandle, Message, RegisteredDriver},
-    services::{
-        keyboard::{mux::KeyboardMuxClient, KeyEvent},
-        simple_serial::SimpleSerialClient,
-    },
+    services::{keyboard::mux::KeyboardMuxClient, simple_serial::SimpleSerialClient},
     Kernel,
 };
 use maitake::sync::Mutex;
@@ -186,7 +183,14 @@ pub struct SerialMuxSettings {
 impl SerialMuxServer {
     /// Register the `SerialMuxServer`.
     ///
-    /// Will retry to obtain a [`SimpleSerialClient`] until success.
+    /// Registering a `SerialMuxServer` will always acquire a
+    /// [`SimpleSerialClient`] to access the serial port. If the SerMux
+    /// pseudo-keyboard is enabled (by
+    /// [`SerialMuxSettings::with_pseudo_keyboard`]), then it will also acquire
+    /// a [`KeyboardMuxClient`] to broadcast pseudo-keyboard input.
+    ///
+    /// Will retry to obtain a [`SimpleSerialClient`] and a
+    /// [`KeyboardMuxClient`] until success.
     pub async fn register(
         kernel: &'static Kernel,
         settings: SerialMuxSettings,
@@ -208,9 +212,15 @@ impl SerialMuxServer {
 
     /// Register the SerialMuxServer.
     ///
-    /// Does NOT attempt to obtain a [`SimpleSerialClient`] more than once.
+    /// Registering a `SerialMuxServer` will always acquire a
+    /// [`SimpleSerialClient`] to access the serial port. If the SerMux
+    /// pseudo-keyboard is enabled (by
+    /// [`SerialMuxSettings::with_pseudo_keyboard`]), then it will also acquire
+    /// a [`KeyboardMuxClient`] to broadcast pseudo-keyboard input.
     ///
-    /// Prefer [`SerialMuxServer::register`] unless you will not be spawning one around
+    /// This method does NOT attempt to obtain a [`SimpleSerialClient`] or
+    /// [`KeyboardMuxClient`] more than once. Prefer
+    /// [`SerialMuxServer::register`] unless you will not be spawning one around
     /// the same time as registering this server.
     pub async fn register_no_retry(
         kernel: &'static Kernel,

--- a/source/kernel/src/services/serial_mux.rs
+++ b/source/kernel/src/services/serial_mux.rs
@@ -17,7 +17,10 @@ use crate::{
         oneshot::Reusable,
     },
     registry::{Envelope, KernelHandle, Message, RegisteredDriver},
-    services::simple_serial::SimpleSerialClient,
+    services::{
+        keyboard::{mux::KeyboardMuxClient, KeyEvent},
+        simple_serial::SimpleSerialClient,
+    },
     Kernel,
 };
 use maitake::sync::Mutex;
@@ -173,17 +176,23 @@ impl PortHandle {
 /// Server implementation for the [`SerialMuxService`].
 pub struct SerialMuxServer;
 
+#[derive(Copy, Clone, Debug)]
+pub struct SerialMuxSettings {
+    max_ports: u16,
+    max_frame: usize,
+    keyboard_port: Option<u16>,
+}
+
 impl SerialMuxServer {
     /// Register the `SerialMuxServer`.
     ///
     /// Will retry to obtain a [`SimpleSerialClient`] until success.
     pub async fn register(
         kernel: &'static Kernel,
-        max_ports: usize,
-        max_frame: usize,
+        settings: SerialMuxSettings,
     ) -> Result<(), RegistrationError> {
         loop {
-            match SerialMuxServer::register_no_retry(kernel, max_ports, max_frame).await {
+            match SerialMuxServer::register_no_retry(kernel, settings).await {
                 Ok(_) => break,
                 Err(RegistrationError::SerialPortNotFound) => {
                     // Uart probably isn't registered yet. Try again in a bit
@@ -205,9 +214,13 @@ impl SerialMuxServer {
     /// the same time as registering this server.
     pub async fn register_no_retry(
         kernel: &'static Kernel,
-        max_ports: usize,
-        max_frame: usize,
+        SerialMuxSettings {
+            max_ports,
+            max_frame,
+            keyboard_port,
+        }: SerialMuxSettings,
     ) -> Result<(), RegistrationError> {
+        let max_ports = max_ports as usize;
         let mut serial_handle = SimpleSerialClient::from_registry(kernel)
             .await
             .ok_or(RegistrationError::SerialPortNotFound)?;
@@ -215,6 +228,15 @@ impl SerialMuxServer {
             .get_port()
             .await
             .ok_or(RegistrationError::NoSerialPortAvailable)?;
+
+        let pseudokeyboard = if let Some(port) = keyboard_port {
+            let client = KeyboardMuxClient::from_registry_no_retry(kernel)
+                .await
+                .ok_or(RegistrationError::KeymuxNotFound)?;
+            Some((client, port))
+        } else {
+            None
+        };
 
         let (sprod, scons) = serial_port.split();
         let sprod = sprod.into_mpmc_producer().await;
@@ -232,6 +254,7 @@ impl SerialMuxServer {
             incoming: scons,
             mux: imutex,
             buf,
+            pseudokeyboard,
         };
 
         kernel.spawn(commander.run()).await;
@@ -251,11 +274,47 @@ impl SerialMuxServer {
     }
 }
 
+impl SerialMuxSettings {
+    pub const DEFAULT_MAX_PORTS: u16 = 16;
+    pub const DEFAULT_MAX_FRAME: usize = 512;
+    pub const DEFAULT_KEYBOARD_PORT: Option<u16> = Some(WellKnown::PseudoKeyboard as u16);
+
+    pub fn with_max_ports(self, max_ports: u16) -> Self {
+        Self { max_ports, ..self }
+    }
+
+    pub fn with_max_frame(self, max_frame: usize) -> Self {
+        Self { max_frame, ..self }
+    }
+
+    pub fn with_pseudo_keyboard(self, keyboard_port: impl Into<Option<u16>>) -> Self {
+        let keyboard_port = keyboard_port.into();
+        if let Some(port) = keyboard_port {
+            assert!(port < self.max_ports);
+        }
+        Self {
+            keyboard_port,
+            ..self
+        }
+    }
+}
+
+impl Default for SerialMuxSettings {
+    fn default() -> Self {
+        Self {
+            max_ports: Self::DEFAULT_MAX_PORTS,
+            max_frame: Self::DEFAULT_MAX_FRAME,
+            keyboard_port: Self::DEFAULT_KEYBOARD_PORT,
+        }
+    }
+}
+
 #[derive(Debug, Eq, PartialEq)]
 pub enum RegistrationError {
     SerialPortNotFound,
     NoSerialPortAvailable,
     MuxAlreadyRegistered,
+    KeymuxNotFound,
 }
 
 struct PortInfo {
@@ -278,6 +337,7 @@ struct IncomingMuxerTask {
     buf: FixedVec<u8>,
     incoming: bbq::Consumer,
     mux: Arc<Mutex<MuxingInfo>>,
+    pseudokeyboard: Option<(KeyboardMuxClient, u16)>,
 }
 
 impl MuxingInfo {
@@ -363,17 +423,35 @@ impl IncomingMuxerTask {
             };
 
             // Great, now we have a message! Let's see if we have someone listening to this port
-            let mux = self.mux.lock().await;
-            if let Some(port) = mux.ports.as_slice().iter().find(|p| p.port == port_id) {
-                if let Some(mut wgr) = port.upstream.send_grant_exact_sync(datab.len()) {
-                    wgr.copy_from_slice(datab);
-                    wgr.commit(datab.len());
-                    debug!(port_id, len = datab.len(), "Sent bytes to port");
-                } else {
-                    warn!(port_id, len = datab.len(), "Discarded bytes, full buffer");
+            match self.pseudokeyboard {
+                Some((ref mut keymux, keyboard_port)) if port_id == keyboard_port => {
+                    // This is the pseudo-keyboard, so forward to the keyboard
+                    // muxer.
+                    match core::str::from_utf8(datab) {
+                        Ok(s) => {
+                            for ch in s.chars() {
+                                if let Err(error) = keymux.publish_key(ch).await {
+                                    warn!(?error, "failed to publish pseudo-keyboard character!");
+                                }
+                            }
+                        }
+                        Err(error) => warn!(%error, "Pseudo-keyboard port received invalid utf8"),
+                    }
                 }
-            } else {
-                warn!(port_id, len = datab.len(), "Discarded bytes, no consumer");
+                _ => {
+                    let mux = self.mux.lock().await;
+                    if let Some(port) = mux.ports.as_slice().iter().find(|p| p.port == port_id) {
+                        if let Some(mut wgr) = port.upstream.send_grant_exact_sync(datab.len()) {
+                            wgr.copy_from_slice(datab);
+                            wgr.commit(datab.len());
+                            debug!(port_id, len = datab.len(), "Sent bytes to port");
+                        } else {
+                            warn!(port_id, len = datab.len(), "Discarded bytes, full buffer");
+                        }
+                    } else {
+                        warn!(port_id, len = datab.len(), "Discarded bytes, no consumer");
+                    }
+                }
             }
 
             // Now we clear the buffer

--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -95,22 +95,16 @@ async fn kernel_entry(opts: MelpomeneOptions) {
 
     // Initialize the SerialMuxServer
     k.initialize({
-        const PORTS: usize = 16;
-        const FRAME_SIZE: usize = 512;
         async {
             // * Up to 16 virtual ports max
             // * Framed messages up to 512 bytes max each
             tracing::debug!("initializing SerialMuxServer...");
-            SerialMuxServer::register(k, PORTS, FRAME_SIZE)
+            SerialMuxServer::register(k, Default::default())
                 .await
                 .unwrap();
             tracing::info!("SerialMuxServer initialized!");
         }
-        .instrument(tracing::info_span!(
-            "SerialMuxServer",
-            ports = PORTS,
-            frame_size = FRAME_SIZE
-        ))
+        .instrument(tracing::info_span!("SerialMuxServer"))
     })
     .unwrap();
 


### PR DESCRIPTION
Currently, we have an implementation of a driver for the Blackberry Q10
keyboard on the Beepy in the `mnemos-beepy` crate. However, there's no
way for cross-platform code in the kernel, such as the graphical forth
shell, to consume keyboard input, because the keyboard driver is
Beepy-specific. This branch fixes this by adding a generic
`KeyboardService` in `kernel::services`, which is not hardware-specific.

In addition, in order to support multiple keyboards, such as the SerMux
pseudo-keyboard, we also add a new `KeyboardMuxServer`, which allows
tasks which want to consume keyboard input to subscribe to key events
from *all* available keyboards. This type implements the
`KeyboardService`, for consumers of keyboard events,  as well as a
`KeyboardMuxService`, which keyboard drivers can use to publish keyboard
events to any task subscribed to the mux. The graphical forth shell now
consumes the `KeyboardService`, allowing it to handle input from both
the SerMux pseudo-keyboard and the Beepy Q10 keyboard without being
aware of either implementation specifically.

This allows us to type on the Beepy keyboard and get text on the screen!
It's currently a bit laggy, which I think is at least partially due to the 50ms
poll interval in the `i2c_puppet` driver. I hope changing the driver to use a
GPIO interrupt instead will reduce this lag...

It does work, though!!!!
![video evidence](https://github.com/tosc-rs/mnemos/assets/2796466/17df3569-8c9b-434f-8696-17adcf4b6808)