### PR TITLE
feat(kernel): add `initialize_default_services`

### DIFF
--- a/platforms/allwinner-d1/core/src/lib.rs
+++ b/platforms/allwinner-d1/core/src/lib.rs
@@ -16,12 +16,7 @@ use core::{
 };
 use d1_pac::{Interrupt, DMAC, TIMER};
 use kernel::{
-    daemons::sermux::{hello, loopback, HelloSettings, LoopbackSettings},
     mnemos_alloc::containers::Box,
-    services::{
-        forth_spawnulator::SpawnulatorServer, keyboard::mux::KeyboardMuxServer,
-        serial_mux::SerialMuxServer,
-    },
     trace::{self, Instrument},
     Kernel, KernelSettings,
 };

--- a/platforms/pomelo/src/main.rs
+++ b/platforms/pomelo/src/main.rs
@@ -83,31 +83,6 @@ async fn kernel_entry() {
     const SERIAL_FRAME_SIZE: usize = 512;
     let (tx, rx) = mpsc::channel::<u8>(64);
     SERMUX_TX.set(tx.clone()).unwrap();
-    kernel
-        .initialize(
-            async {
-                debug!("initializing SerialMuxServer...");
-                SerialMuxServer::register(kernel, Default::default())
-                    .await
-                    .unwrap();
-                info!("SerialMuxServer initialized!");
-            }
-            .instrument(tracing::info_span!("SerialMuxServer")),
-        )
-        .unwrap();
-
-    kernel
-        .initialize(
-            async {
-                debug!("initializing KeyboardMux...");
-                KeyboardMuxServer::register(kernel, Default::default())
-                    .await
-                    .unwrap();
-                info!("KeyboardMux initialized!");
-            }
-            .instrument(tracing::info_span!("SerialMuxServer")),
-        )
-        .unwrap();
 
     // Initialize a loopback UART
     kernel
@@ -130,16 +105,7 @@ async fn kernel_entry() {
         })
         .unwrap();
 
-    // Spawn a loopback port
-    let loopback_settings = LoopbackSettings::default();
-    kernel
-        .initialize(loopback(kernel, loopback_settings))
-        .unwrap();
-
-    // Spawn the spawnulator
-    kernel
-        .initialize(SpawnulatorServer::register(kernel, 16))
-        .unwrap();
+    kernel.initialize_default_services(Default::default());
 
     // go forth and replduce
     spawn_local(async move {

--- a/platforms/pomelo/src/main.rs
+++ b/platforms/pomelo/src/main.rs
@@ -10,12 +10,9 @@ use gloo::timers::future::TimeoutFuture;
 use gloo_utils::format::JsValueSerdeExt;
 use mnemos_alloc::heap::MnemosAlloc;
 use mnemos_kernel::{
-    daemons::sermux::{loopback, LoopbackSettings},
     forth::{self, Forth},
     services::{
-        forth_spawnulator::SpawnulatorServer,
-        keyboard::mux::KeyboardMuxServer,
-        serial_mux::{PortHandle, SerialMuxServer, WellKnown},
+        serial_mux::{PortHandle,WellKnown},
     },
     Kernel, KernelSettings,
 };

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -317,6 +317,12 @@ impl Kernel {
     /// If the kernel's [`maitake::time::Timer`] has not been set as the global
     /// timer, this method will also ensure that the global timer is set as the
     /// default.
+    ///
+    /// [`KeyboardMuxService`]:
+    ///     crate::services::keyboard::mux::KeyboardMuxService
+    /// [`SerialMuxService`]: crate::services::serial_mux::SerialMuxService
+    /// [`SpawnulatorService`]:
+    ///     crate::services::forth_spawnulator::SpawnulatorService
     pub fn initialize_default_services(&'static self, settings: DefaultServiceSettings) {
         // Set the kernel timer as the global timer.
         // Disregard errors --- they just mean someone else has already set up

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -101,6 +101,11 @@ use maitake::{
 pub use mnemos_alloc;
 use mnemos_alloc::containers::Box;
 use registry::Registry;
+use services::{
+    forth_spawnulator::{SpawnulatorServer, SpawnulatorSettings},
+    keyboard::mux::{KeyboardMuxServer, KeyboardMuxSettings},
+    serial_mux::{SerialMuxServer, SerialMuxSettings},
+};
 
 /// Shim to handle tracing v0.1 vs v0.2
 ///
@@ -169,6 +174,18 @@ pub struct KernelInner {
 
     /// Maitake timer wheel.
     timer: Timer,
+}
+
+/// Settings for all services spawned by default.
+#[derive(Debug, Default)]
+pub struct DefaultServiceSettings {
+    pub keyboard_mux: KeyboardMuxSettings,
+    pub serial_mux: SerialMuxSettings,
+    pub spawnulator: SpawnulatorSettings,
+    pub sermux_loopback: daemons::sermux::LoopbackSettings,
+    pub sermux_hello: daemons::sermux::HelloSettings,
+    #[cfg(feature = "tracing-02")]
+    pub sermux_trace: trace::SerialTraceSettings,
 }
 
 impl Kernel {
@@ -266,5 +283,79 @@ impl Kernel {
     #[inline]
     pub fn timeout<F: Future>(&'static self, duration: Duration, f: F) -> Timeout<'static, F> {
         self.inner.timer.timeout(duration, f)
+    }
+
+    /// Initialize the default set of cross-platform kernel [`services`] that
+    /// are spawned on all hardware platforms.
+    ///
+    /// Calling this method is not *mandatory* for a hardware platform
+    /// implementation. The platform implementation may manually spawn these
+    /// services individually, or choose not to spawn them at all. However, this
+    /// method is provided to ensure that a consistent set of cross-platform
+    /// services are initialized on all hardware platforms *if they are
+    /// desired*.
+    ///
+    /// Services spawned by this method include:
+    ///
+    /// - The [`KeyboardMuxService`], which multiplexes keyboard input from
+    ///   multiple keyboards to tasks that depend on keyboard input,
+    /// - The [`SerialMuxService`], which multiplexes serial I/O to virtual
+    ///   serial ports
+    /// - The [`SpawnulatorService`], which is responsible for spawning
+    ///   new Forth tasks
+    ///
+    /// In addition, this method will initialize the following non-service
+    /// daemons:
+    ///
+    /// - [`daemons::sermux::loopback`], which serves a loopback service on a
+    ///   configured loopback port
+    /// - [`daemons::sermux::hello`], which sends periodic "hello world" pings
+    ///   to a configured serial mux port
+    /// - if the "tracing-02" feature flag is enabled, the worker task for the
+    ///   binary serial mux trace protocol
+    ///
+    /// If the kernel's [`maitake::time::Timer`] has not been set as the global
+    /// timer, this method will also ensure that the global timer is set as the
+    /// default.
+    pub fn initialize_default_services(&'static self, settings: DefaultServiceSettings) {
+        // Set the kernel timer as the global timer.
+        // Disregard errors --- they just mean someone else has already set up
+        // the global timer.
+        let _ = self.set_global_timer();
+
+        // Initialize the kernel keyboard mux service.
+        self.initialize(KeyboardMuxServer::register(self, settings.keyboard_mux))
+            .expect("failed to spawn KeyboardMuxService initialization");
+
+        // Initialize the SerialMuxServer
+        let sermux_up = self
+            .initialize(SerialMuxServer::register(self, settings.serial_mux))
+            .expect("failed to spawn SerialMuxService initialization");
+
+        // Initialize the Forth spawnulator.
+        self.initialize(SpawnulatorServer::register(self, settings.spawnulator))
+            .expect("failed to spawn SpawnulatorService initialization");
+
+        // Initialize Serial Mux daemons.
+        self.initialize(async move {
+            sermux_up
+                .await
+                .expect("SerialMuxService initialization should not be cancelled")
+                .expect("SerialMuxService initialization failed");
+
+            #[cfg(feature = "tracing-02")]
+            crate::trace::COLLECTOR
+                .start(self, settings.sermux_trace)
+                .await;
+
+            self.spawn(daemons::sermux::loopback(self, settings.sermux_loopback))
+                .await;
+            tracing::debug!("SerMux loopback started");
+
+            self.spawn(daemons::sermux::hello(self, settings.sermux_hello))
+                .await;
+            tracing::debug!("SerMux Hello World started");
+        })
+        .expect("failed to spawn default serial mux service initialization");
     }
 }

--- a/source/kernel/src/services/serial_mux.rs
+++ b/source/kernel/src/services/serial_mux.rs
@@ -9,7 +9,7 @@
 use core::time::Duration;
 
 use crate::comms::bbq::GrantR;
-use crate::tracing::{debug, warn};
+use crate::tracing::{self, debug, warn, Level};
 use crate::{
     comms::{
         bbq,
@@ -186,6 +186,12 @@ impl SerialMuxServer {
     /// [`SimpleSerialClient`] to access the serial port.
     ///
     /// Will retry to obtain a [`SimpleSerialClient`] until success.
+    #[tracing::instrument(
+        name = "KeyboardMuxServer::register",
+        level = Level::DEBUG,
+        skip(kernel),
+        err(Debug),
+    )]
     pub async fn register(
         kernel: &'static Kernel,
         settings: SerialMuxSettings,

--- a/source/kernel/src/trace.rs
+++ b/source/kernel/src/trace.rs
@@ -42,19 +42,31 @@ pub struct SerialCollector {
     in_send: AtomicBool,
 }
 
+#[derive(Debug)]
+pub struct SerialTraceSettings {
+    /// SerialMux port for sermux tracing.
+    port: u16,
+
+    /// Capacity for the serial port's send buffer.
+    sendbuf_capacity: usize,
+
+    /// Capacity for the trace ring buffer.
+    ///
+    /// Note that *two* buffers of this size will be allocated. One buffer is
+    /// used for the normal trace ring buffer, and another is used for the
+    /// interrupt service routine trace ring buffer.
+    tracebuf_capacity: usize,
+
+    /// Initial level filter used if the debug host does not select a max level.
+    initial_level: LevelFilter,
+}
+
+pub(crate) static COLLECTOR: SerialCollector = SerialCollector::new();
+
 // === impl SerialCollector ===
 
 impl SerialCollector {
-    pub const PORT: u16 = 3;
-
-    // 64k ought to be big enough for anyone
-    const CAPACITY: usize = 1024 * 64;
-
     pub const fn new() -> Self {
-        Self::with_max_level(LevelFilter::OFF)
-    }
-
-    pub const fn with_max_level(max_level: LevelFilter) -> Self {
         Self {
             tx: InitOnce::uninitialized(),
             isr_tx: InitOnce::uninitialized(),
@@ -65,19 +77,22 @@ impl SerialCollector {
             dropped_spans: AtomicUsize::new(0),
             dropped_metas: AtomicUsize::new(0),
             dropped_span_activity: AtomicUsize::new(0),
-            max_level: AtomicU8::new(level_to_u8(max_level)),
+            max_level: AtomicU8::new(level_to_u8(LevelFilter::OFF)),
             in_send: AtomicBool::new(false),
         }
     }
 
-    pub async fn start(&'static self, k: &'static crate::Kernel) {
+    pub async fn start(&'static self, k: &'static crate::Kernel, settings: SerialTraceSettings) {
+        self.max_level
+            .store(level_to_u8(settings.initial_level), Ordering::Release);
+
         // acquire sermux port 3
-        let port = serial_mux::PortHandle::open(k, 3, 1024)
+        let port = serial_mux::PortHandle::open(k, settings.port, settings.sendbuf_capacity)
             .await
             .expect("cannot initialize serial tracing, cannot open port 3!");
 
-        let (tx, rx) = bbq::new_spsc_channel(Self::CAPACITY).await;
-        let (isr_tx, isr_rx) = bbq::new_spsc_channel(Self::CAPACITY).await;
+        let (tx, rx) = bbq::new_spsc_channel(settings.tracebuf_capacity).await;
+        let (isr_tx, isr_rx) = bbq::new_spsc_channel(settings.tracebuf_capacity).await;
         self.tx.init(tx);
         self.isr_tx.init(isr_tx);
 
@@ -377,6 +392,85 @@ impl Collect for SerialCollector {
             self.dropped_span_activity.fetch_add(1, Ordering::Relaxed);
         }
         false
+    }
+}
+
+// === impl SermuxTraceSettings ===
+
+impl SerialTraceSettings {
+    pub const DEFAULT_PORT: u16 = serial_mux::WellKnown::BinaryTracing as u16;
+    pub const DEFAULT_SENDBUF_CAPACITY: usize = 1024;
+    pub const DEFAULT_TRACEBUF_CAPACITY: usize = Self::DEFAULT_SENDBUF_CAPACITY * 64;
+    pub const DEFAULT_INITIAL_LEVEL: LevelFilter = LevelFilter::OFF;
+
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            port: Self::DEFAULT_PORT,
+            sendbuf_capacity: Self::DEFAULT_SENDBUF_CAPACITY,
+            tracebuf_capacity: Self::DEFAULT_TRACEBUF_CAPACITY,
+            initial_level: Self::DEFAULT_INITIAL_LEVEL,
+        }
+    }
+
+    /// Sets the [`serial_mux`] port on which the binary tracing service is
+    /// served.
+    ///
+    /// By default, this is [`Self::DEFAULT_PORT`] (the value of
+    /// [`serial_mux::WellKnown::BinaryTracing`]).
+    #[must_use]
+    pub fn with_port(self, port: impl Into<u16>) -> Self {
+        Self {
+            port: port.into(),
+            ..self
+        }
+    }
+
+    /// Sets the initial [`LevelFilter`] used when no trace client is connected
+    /// or when the trace client does not select a level.
+    ///
+    /// By default, this set to [`Self::DEFAULT_INITIAL_LEVEL`] ([`LevelFilter::OFF`]).
+    #[must_use]
+    pub fn with_initial_level(self, level: impl Into<LevelFilter>) -> Self {
+        Self {
+            initial_level: level.into(),
+            ..self
+        }
+    }
+
+    /// Sets the maximum capacity of the serial port send buffer (the buffer
+    /// used for communication between the trace service task and the serial mux
+    /// server).
+    ///
+    /// By default, this set to [`Self::DEFAULT_SENDBUF_CAPACITY`] (1 KB).
+    #[must_use]
+    pub const fn with_sendbuf_capacity(self, capacity: usize) -> Self {
+        Self {
+            sendbuf_capacity: capacity,
+            ..self
+        }
+    }
+
+    /// Sets the maximum capacity of the trace ring buffer (the buffer into
+    /// which new traces are serialized before being sent to the worker task).
+    ///
+    /// Note that *two* buffers of this size will be allocated. One buffer is
+    /// used for traces emitted by non-interrupt kernel code, and the other is
+    /// used for traces emitted inside of interrupt service routines (ISRs).
+    ///
+    /// By default, this set to [`Self::DEFAULT_TRACEBUF_CAPACITY`] (64 KB).
+    #[must_use]
+    pub const fn with_tracebuf_capacity(self, capacity: usize) -> Self {
+        Self {
+            tracebuf_capacity: capacity,
+            ..self
+        }
+    }
+}
+
+impl Default for SerialTraceSettings {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -8,14 +8,7 @@ use melpomene::{
 };
 use mnemos_alloc::heap::MnemosAlloc;
 use mnemos_kernel::{
-    daemons::{
-        sermux::{hello, loopback, HelloSettings, LoopbackSettings},
-        shells::{graphical_shell_mono, GraphicalShellSettings},
-    },
-    services::{
-        forth_spawnulator::SpawnulatorServer, keyboard::mux::KeyboardMuxServer,
-        serial_mux::SerialMuxServer,
-    },
+    daemons::shells::{graphical_shell_mono, GraphicalShellSettings},
     Kernel, KernelSettings,
 };
 use tokio::{
@@ -23,7 +16,6 @@ use tokio::{
     time::{self, Duration},
 };
 
-use tracing::Instrument;
 const DISPLAY_WIDTH_PX: u32 = 400;
 const DISPLAY_HEIGHT_PX: u32 = 240;
 
@@ -93,6 +85,14 @@ async fn kernel_entry(opts: MelpomeneOptions) {
                 .unwrap();
             tracing::info!("simulated UART ({}) initialized!", opts.serial_addr);
         }
+    })
+    .unwrap();
+
+    // Spawn the graphics driver
+    k.initialize(async move {
+        SimDisplay::register(k, 4, DISPLAY_WIDTH_PX, DISPLAY_HEIGHT_PX)
+            .await
+            .unwrap();
     })
     .unwrap();
 

--- a/source/melpomene/src/main.rs
+++ b/source/melpomene/src/main.rs
@@ -96,48 +96,12 @@ async fn kernel_entry(opts: MelpomeneOptions) {
     })
     .unwrap();
 
-    // Initialize the SerialMuxServer
-    k.initialize(
-        async {
-            // * Up to 16 virtual ports max
-            // * Framed messages up to 512 bytes max each
-            tracing::debug!("initializing SerialMuxServer...");
-            SerialMuxServer::register(k, Default::default())
-                .await
-                .unwrap();
-            tracing::info!("SerialMuxServer initialized!");
-        }
-        .instrument(tracing::info_span!("SerialMuxServer")),
-    )
-    .unwrap();
-
-    // Initialize the kernel keyboard mux service.
-    k.initialize(KeyboardMuxServer::register(k, Default::default()))
-        .unwrap();
-
-    // Spawn the graphics driver
-    k.initialize(async move {
-        SimDisplay::register(k, 4, DISPLAY_WIDTH_PX, DISPLAY_HEIGHT_PX)
-            .await
-            .unwrap();
-    })
-    .unwrap();
-
-    // Spawn a loopback port
-    let loopback_settings = LoopbackSettings::default();
-    k.initialize(loopback(k, loopback_settings)).unwrap();
-
-    // Spawn a hello port
-    let hello_settings = HelloSettings::default();
-    k.initialize(hello(k, hello_settings)).unwrap();
+    k.initialize_default_services(Default::default());
 
     // Spawn a graphical shell
     let mut guish = GraphicalShellSettings::with_display_size(DISPLAY_WIDTH_PX, DISPLAY_HEIGHT_PX);
     guish.capacity = 1024;
     k.initialize(graphical_shell_mono(k, guish)).unwrap();
-
-    // Spawn the spawnulator
-    k.initialize(SpawnulatorServer::register(k, 16)).unwrap();
 
     loop {
         // Tick the scheduler


### PR DESCRIPTION
One issue with the design of kernel services is that the binding between
services and their clients is not enforced at compile time. This means
that it's possible to add new cross-platform services which should be
spawned on all hardware platforms without the hardware platforms failing
to compile if those services are not spawned.

In order to avoid issues where we forget to spawn a cross-platform
service on a particular platform, such as #164, this branch adds a new
`Kernel::initialize_default_services` that spapwns all the default
cross-platform services and daemon tasks. Rather than having to
duplicate the code to spawn these services in each platform
implementation, we can now simple call this method in the platform impl.
New services which we expect to always be spawned can simply be added
here in the cross-platform kernel, and we don't have to remember to add
code for spawning them to each platform.

To allow the platform to customize settings for the default services,
this method takes a struct containing all the services'
`${SERVICE}Settings` types. In the future, that will probably be
replaced by #160.

While working on this, I also did a bit of cleanup/refactoring of the
various services' registration methods and `Settings` types to make them
a bit more consistent.

Closes https://github.com/tosc-rs/mnemos/issues/164