### PR TITLE
fix(trace): always reregister when crowtty connects

### DIFF
--- a/source/kernel/src/trace.rs
+++ b/source/kernel/src/trace.rs
@@ -162,21 +162,19 @@ impl SerialCollector {
                                 let level = lvl
                                     .map(|lvl| lvl as u8)
                                     .unwrap_or(level_to_u8(LevelFilter::OFF));
-                                let prev = self.max_level.swap(level, Ordering::AcqRel);
-                                if prev != level {
-                                    tracing_core_02::callsite::rebuild_interest_cache();
-                                    info!(
-                                        message = %"hello from mnemOS",
-                                        version = %env!("CARGO_PKG_VERSION"),
-                                        git = %format_args!(
-                                            "{}@{}",
-                                            env!("VERGEN_GIT_BRANCH"),
-                                            env!("VERGEN_GIT_DESCRIBE")
-                                        ),
-                                        target = %env!("VERGEN_CARGO_TARGET_TRIPLE"),
-                                        profile = %if cfg!(debug_assertions) { "debug" } else { "release" },
-                                    );
-                                }
+                                self.max_level.store(level, Ordering::Release);
+                                tracing_core_02::callsite::rebuild_interest_cache();
+                                info!(
+                                    message = %"hello from mnemOS",
+                                    version = %env!("CARGO_PKG_VERSION"),
+                                    git = %format_args!(
+                                        "{}@{}",
+                                        env!("VERGEN_GIT_BRANCH"),
+                                        env!("VERGEN_GIT_DESCRIBE")
+                                    ),
+                                    target = %env!("VERGEN_CARGO_TARGET_TRIPLE"),
+                                    profile = %if cfg!(debug_assertions) { "debug" } else { "release" },
+                                );
                             }
                         }
 


### PR DESCRIPTION
Currently, we only re-register all `tracing` callsites if we receive a host trace level request *and* the level has changed. This means that if crowtty disconnects and then a new crowtty session connects, and the new session requests the same max level as the previous one, we won't register the callsites again. This means that the new session won't be able to understand any trace spans/events we have previously sent metadata for.

This branch removes the check that the level has changed, and always blows away the cache. This causes `tracing` to re-register all callsites every time a new `crowtty` session connects, so that the new session can actually understand all trace events.