### PR TITLE
fix(beepy): retry failed `i2c_puppet` polls

### DIFF
--- a/platforms/beepy/src/i2c_puppet.rs
+++ b/platforms/beepy/src/i2c_puppet.rs
@@ -12,6 +12,7 @@ use kernel::{
     embedded_hal_async::i2c::{self, I2c},
     mnemos_alloc::containers::FixedVec,
     registry::{self, Envelope, KernelHandle, RegisteredDriver},
+    retry::{AlwaysRetry, ExpBackoff, Retry, WithMaxRetries},
     services::{
         i2c::{I2cClient, I2cError},
         keyboard::{
@@ -495,7 +496,9 @@ impl I2cPuppetServer {
 
             if !self.subscriptions.is_empty() || self.keymux.is_some() {
                 tracing::trace!("polling keys...");
-                self.poll_keys().await?;
+                if let Err(error) = self.poll_keys().await {
+                    tracing::warn!(%error, "i2c_puppet: error polling keys!");
+                }
             }
         }
     }
@@ -546,13 +549,32 @@ impl I2cPuppetServer {
     }
 
     async fn poll_keys(&mut self) -> Result<(), I2cError> {
+        fn keycode(x: u8) -> key_event::KeyCode {
+            match x {
+                0x08 => key_event::KeyCode::Backspace,
+                // TODO(eliza): figure out other keycodes
+                x => key_event::KeyCode::Char(x as char),
+            }
+        }
+
+        let mut retry = self.settings.retry();
         let mut kbd = AsyncBbq10Kbd::new(&mut self.i2c);
         loop {
-            let status = kbd.get_key_status().await?;
+            let status = retry
+                .retry_with_input(&mut kbd, |kbd| async move {
+                    let res = kbd.get_key_status().await;
+                    (kbd, res)
+                })
+                .await?;
             if let FifoCount::Known(0) = status.fifo_count {
-                break;
+                return Ok(());
             }
-            let key = kbd.get_fifo_key_raw().await?;
+            let key = retry
+                .retry_with_input(&mut kbd, |kbd| async move {
+                    let res = kbd.get_fifo_key_raw().await;
+                    (kbd, res)
+                })
+                .await?;
             trace::debug!(?key);
 
             // TODO(eliza): remove dead subscriptions...
@@ -589,15 +611,6 @@ impl I2cPuppetServer {
                 }
             }
         }
-
-        fn keycode(x: u8) -> key_event::KeyCode {
-            match x {
-                0x08 => key_event::KeyCode::Backspace,
-                // TODO(eliza): figure out other keycodes
-                x => key_event::KeyCode::Char(x as char),
-            }
-        }
-        Ok(())
     }
 }
 
@@ -616,6 +629,8 @@ pub struct I2cPuppetSettings {
     /// If set, the `i2c_puppet` service will also forward keypresses to the kernel's
     /// [`KeyboardMuxService`](kernel::services::keyboard::mux::KeyboardMuxService).
     pub keymux: bool,
+    pub min_backoff: Duration,
+    pub max_retries: usize,
 }
 
 impl Default for I2cPuppetSettings {
@@ -626,10 +641,18 @@ impl Default for I2cPuppetSettings {
             max_subscriptions: 8,
             poll_interval: Duration::from_millis(50),
             keymux: true,
+            max_retries: 10,
+            min_backoff: Duration::from_micros(5),
         }
     }
 }
 
+impl I2cPuppetSettings {
+    fn retry(&self) -> Retry<WithMaxRetries<AlwaysRetry>, ExpBackoff> {
+        let backoff = ExpBackoff::new(self.min_backoff).with_max_backoff(self.poll_interval);
+        Retry::new(AlwaysRetry, backoff).with_max_retries(self.max_retries)
+    }
+}
 // === impl KeySubscription ===
 
 pub enum KeySubscriptionError {

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -80,6 +80,7 @@ pub(crate) mod fmt;
 pub mod forth;
 pub mod isr;
 pub mod registry;
+pub mod retry;
 pub mod services;
 #[cfg(feature = "tracing-02")]
 pub mod trace;

--- a/source/kernel/src/retry.rs
+++ b/source/kernel/src/retry.rs
@@ -1,0 +1,171 @@
+use crate::tracing;
+use core::{fmt, future::Future, num::NonZeroUsize};
+use maitake::time::{self, Duration};
+
+/// An exponential backoff.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct ExpBackoff {
+    min: Duration,
+    max: Duration,
+    cur: Duration,
+}
+
+pub struct Retry<P = ()> {
+    predicate: P,
+    backoff: ExpBackoff,
+    max: Option<NonZeroUsize>,
+}
+
+pub struct MaxRetries<P> {
+    inner: P,
+    max: usize,
+    cur: usize,
+}
+
+pub trait ShouldRetry<E> {
+    fn should_retry(&mut self, error: &E) -> bool;
+    fn reset(&mut self) {
+        // nop
+    }
+}
+
+impl ExpBackoff {
+    const DEFAULT_MAX_BACKOFF: Duration = Duration::from_secs(2);
+
+    #[must_use]
+    pub const fn new(min: Duration) -> Self {
+        Self {
+            max: Self::DEFAULT_MAX_BACKOFF,
+            min,
+            cur: min,
+        }
+    }
+
+    #[must_use]
+    pub const fn with_max(self, max: Duration) -> Self {
+        Self { max, ..self }
+    }
+
+    /// Wait until the current backoff period has elapsed, incrementing the
+    /// backoff for the next call to `wait`.
+    pub async fn wait(&mut self) {
+        tracing::trace!("backing off for {:?}...", self.cur);
+
+        let cur = self.cur;
+
+        if self.cur < self.max {
+            self.cur *= 2;
+        }
+
+        time::sleep(cur).await
+    }
+
+    /// Reset the backoff to the `min` value.
+    pub fn reset(&mut self) {
+        tracing::trace!("reset backoff to {:?}", self.min);
+        self.cur = self.min;
+    }
+
+    pub fn current(&self) -> Duration {
+        self.cur
+    }
+}
+
+// === impl Retry ===
+
+impl Retry {
+    pub const fn new(backoff: ExpBackoff) -> Self {
+        Self {
+            predicate: (),
+            backoff,
+            max: None,
+        }
+    }
+}
+
+impl<P> Retry<P> {
+    pub fn with_predicate<P2>(self, predicate: P2) -> Retry<P2> {
+        Retry {
+            predicate,
+            backoff: self.backoff,
+            max: self.max,
+        }
+    }
+
+    pub fn with_max(self, max: impl Into<Option<NonZeroUsize>>) -> Self {
+        Self {
+            max: max.into(),
+            ..self
+        }
+    }
+
+    pub async fn retry<T, E, F>(&mut self, op: impl Fn() -> F) -> Result<T, E>
+    where
+        F: Future<Output = Result<T, E>>,
+        P: ShouldRetry<E>,
+        E: fmt::Display,
+    {
+        self.predicate.reset();
+        self.backoff.reset();
+        let mut retries: usize = 0;
+        loop {
+            match op().await {
+                Ok(t) => {
+                    if retries > 0 {
+                        tracing::debug!(retries, "succeeded after retrying");
+                    }
+                    return Ok(t);
+                }
+                Err(error) if !self.predicate.should_retry(&error) => {
+                    tracing::debug!(%error, "error is not retryable!");
+                    return Err(error);
+                }
+                Err(error) => {
+                    if let Some(max) = self.max {
+                        if retries >= max.into() {
+                            tracing::debug!(%error, max, "maximum retry limit reached!");
+                            return Err(error);
+                        }
+                    }
+                    self.backoff.wait().await;
+                    tracing::debug!(%error, retries, "retrying after backoff...");
+                    retries += 1;
+                }
+            }
+        }
+    }
+}
+
+impl<E> ShouldRetry<E> for () {
+    fn should_retry(&mut self, _: &E) -> bool {
+        true
+    }
+}
+
+impl<E, F> ShouldRetry<E> for F
+where
+    F: FnMut(&E) -> bool,
+{
+    fn should_retry(&mut self, error: &E) -> bool {
+        (self)(error)
+    }
+}
+
+impl<E, P> ShouldRetry<E> for MaxRetries<P>
+where
+    P: ShouldRetry<E>,
+{
+    fn should_retry(&mut self, error: &E) -> bool {
+        if self.inner.should_retry(error) && self.cur <= self.max {
+            self.cur += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn reset(&mut self) {
+        self.inner.reset();
+        self.cur = 0;
+    }
+}

--- a/source/kernel/src/retry.rs
+++ b/source/kernel/src/retry.rs
@@ -60,7 +60,7 @@ impl ExpBackoff {
     /// Sets the maximum duration to back off for.
     ///
     /// Once the backoff duration reaches the maximum, it will no longer
-    /// increase until the backoff is [`reset`].
+    /// increase until the backoff is [`reset`](Self::reset).
     #[must_use]
     pub const fn with_max_backoff(self, max: Duration) -> Self {
         Self { max, ..self }


### PR DESCRIPTION
Currently, if polling the `i2c_puppet` keyboard firmware ever fails, the
entire driver just bails out permanently. This is...not good.

This branch adds some retry logic, implemented using a generic retry
utility. I don't know if I *love* the API for the retry stuff, but
:woman_shrugging: --- perhaps @jamesmunns will have suggestions?

Fixes #161 (hopefully)