### PR TITLE
qol(melpo): Quit on quit and poll keyboard more often

### DIFF
--- a/platforms/melpomene/src/sim_drivers/emb_display.rs
+++ b/platforms/melpomene/src/sim_drivers/emb_display.rs
@@ -18,7 +18,7 @@
 //! them back to be rendered into the total frame. Any data in the client's sub-frame
 //! will replace the current contents of the whole frame buffer.
 
-use std::{time::Duration, process::exit};
+use std::{process::exit, time::Duration};
 
 use embedded_graphics::{
     image::{Image, ImageRaw},
@@ -276,8 +276,6 @@ async fn render_loop(kernel: &'static Kernel, mutex: Arc<Mutex<Option<Context>>>
             } else {
                 idle_ticks += 1;
             }
-
-
         } else {
             done = true;
         }


### PR DESCRIPTION
This PR switches the polling behavior in cases where we don't need to draw to the screen. This includes reading key events, and potentially catching "stop" events.

We also now hard-exit when the window is closed or a control-c is received.