### PR TITLE
fix(spitebuf + kchannel): Fixes sizing requirements of spitebuf

### DIFF
--- a/platforms/melpomene/src/sim_drivers/emb_display.rs
+++ b/platforms/melpomene/src/sim_drivers/emb_display.rs
@@ -66,7 +66,7 @@ impl SimDisplay {
     ) -> Result<(), FrameError> {
         tracing::debug!("initializing SimDisplay server ({width}x{height})...");
 
-        let (cmd_prod, cmd_cons) = KChannel::new_async(1).await.split();
+        let (cmd_prod, cmd_cons) = KChannel::new_async(2).await.split();
         let commander = CommanderTask {
             kernel,
             cmd: cmd_cons,

--- a/source/kernel/src/comms/kchannel.rs
+++ b/source/kernel/src/comms/kchannel.rs
@@ -55,11 +55,34 @@ impl<T> Deref for KChannel<T> {
     }
 }
 
+fn right_size(mut cap: usize) -> usize {
+    if cap < 2 {
+        tracing::warn!(
+            was = cap,
+            now = 2,
+            "Increasing KChannel size to minimum size of two!"
+        );
+    }
+    let npot = cap.next_power_of_two();
+    if npot != cap {
+        tracing::warn!(
+            was = cap,
+            now = npot,
+            "Increasing KChannel size to a power of two!",
+        );
+        cap = npot;
+    }
+    cap
+}
+
 impl<T> KChannel<T> {
     /// Create a new `KChannel<T>` with room for `count` elements on the given
     /// Kernel's allocator.
+    ///
+    /// `count` should be a power of two >= 2, or the capacity will be increased
+    /// automatically.
     pub async fn new_async(count: usize) -> Self {
-        let ba = ArrayBuf::new_uninit(count).await;
+        let ba = ArrayBuf::new_uninit(right_size(count)).await;
         let q = MpScQueue::new(sealed::SpiteData { data: ba });
         Self {
             q: Arc::new(q).await,
@@ -68,8 +91,11 @@ impl<T> KChannel<T> {
 
     /// Create a new `KChannel<T>` with room for `count` elements on the given
     /// Kernel's allocator. Used for pre-async initialization steps
+    ///
+    /// `count` should be a power of two >= 2, or the capacity will be increased
+    /// automatically.
     pub fn new(count: usize) -> Self {
-        let ba = ArrayBuf::try_new_uninit(count).unwrap();
+        let ba = ArrayBuf::try_new_uninit(right_size(count)).unwrap();
         let q = MpScQueue::new(sealed::SpiteData { data: ba });
         Self {
             q: Arc::try_new(q).map_err(drop).unwrap(),

--- a/source/kernel/src/comms/kchannel.rs
+++ b/source/kernel/src/comms/kchannel.rs
@@ -2,6 +2,7 @@
 //!
 //! Kernel Channels are an async/await, MPSC queue, with a fixed backing storage (e.g. they are bounded).
 
+use crate::tracing;
 use core::{cell::UnsafeCell, ops::Deref, ptr::NonNull};
 use mnemos_alloc::containers::{Arc, ArrayBuf};
 use spitebuf::{DequeueError, EnqueueError, MpScQueue};

--- a/source/spitebuf/src/lib.rs
+++ b/source/spitebuf/src/lib.rs
@@ -49,10 +49,17 @@ pub enum DequeueError {
 
 impl<T, STO: Storage<T>> MpScQueue<T, STO> {
     /// Creates an empty queue
+    ///
+    /// The capacity of `storage` must be >= 2 and a power of two, or this code will panic.
     #[track_caller]
     pub fn new(storage: STO) -> Self {
         let (ptr, len) = storage.buf();
-        assert_eq!(len, len.next_power_of_two());
+        assert_eq!(
+            len,
+            len.next_power_of_two(),
+            "Capacity must be a power of two!"
+        );
+        assert!(len > 1, "Capacity must be larger than 1!");
         let sli = unsafe { core::slice::from_raw_parts(ptr, len) };
         sli.iter().enumerate().for_each(|(i, slot)| unsafe {
             slot.get().write(Cell {


### PR DESCRIPTION
This PR fixes some of the invariants required by the upstream heapless::mpmc implementation that I didn't originally uphold.

SpiteBuf will now panic on an incorrect size of 1, and KChannel will automatically increase the buffer size and emit a warning.