### PR TITLE
feat(d1): add clint and ccu module

### DIFF
--- a/platforms/allwinner-d1/boards/src/bin/lichee-rv.rs
+++ b/platforms/allwinner-d1/boards/src/bin/lichee-rv.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 
 use core::time::Duration;
 use mnemos_d1_core::{
+    ccu::Ccu,
     dmac::Dmac,
     drivers::{spim::kernel_spim1, twi, uart::kernel_uart},
     plic::Plic,
@@ -26,6 +27,11 @@ fn main() -> ! {
     }
 
     let mut p = unsafe { d1_pac::Peripherals::steal() };
+
+    let mut ccu = Ccu::new(p.CCU);
+    ccu.sys_clock_init();
+    p.CCU = ccu.release();
+
     let uart = unsafe { kernel_uart(&mut p.CCU, &mut p.GPIO, p.UART0) };
     let spim = unsafe { kernel_spim1(p.SPI_DBI, &mut p.CCU, &mut p.GPIO) };
     let i2c0 = unsafe { twi::I2c0::lichee_rv_dock(p.TWI2, &mut p.CCU, &mut p.GPIO) };

--- a/platforms/allwinner-d1/boards/src/bin/lichee-rv.rs
+++ b/platforms/allwinner-d1/boards/src/bin/lichee-rv.rs
@@ -30,13 +30,12 @@ fn main() -> ! {
 
     let mut ccu = Ccu::new(p.CCU);
     ccu.sys_clock_init();
-    p.CCU = ccu.release();
 
-    let uart = unsafe { kernel_uart(&mut p.CCU, &mut p.GPIO, p.UART0) };
-    let spim = unsafe { kernel_spim1(p.SPI_DBI, &mut p.CCU, &mut p.GPIO) };
-    let i2c0 = unsafe { twi::I2c0::lichee_rv_dock(p.TWI2, &mut p.CCU, &mut p.GPIO) };
+    let uart = unsafe { kernel_uart(&mut ccu, &mut p.GPIO, p.UART0) };
+    let spim = unsafe { kernel_spim1(p.SPI_DBI, &mut ccu, &mut p.GPIO) };
+    let i2c0 = unsafe { twi::I2c0::lichee_rv_dock(p.TWI2, &mut ccu, &mut p.GPIO) };
     let timers = Timers::new(p.TIMER);
-    let dmac = Dmac::new(p.DMAC, &mut p.CCU);
+    let dmac = Dmac::new(p.DMAC, &mut ccu);
     let plic = Plic::new(p.PLIC);
 
     let d1 = D1::initialize(timers, uart, spim, dmac, plic, i2c0);

--- a/platforms/allwinner-d1/boards/src/bin/mq-pro.rs
+++ b/platforms/allwinner-d1/boards/src/bin/mq-pro.rs
@@ -6,6 +6,7 @@ extern crate alloc;
 use core::time::Duration;
 use mnemos_beepy::i2c_puppet::{HsvColor, I2cPuppetClient, I2cPuppetServer};
 use mnemos_d1_core::{
+    ccu::Ccu,
     dmac::Dmac,
     drivers::{spim::kernel_spim1, twi, uart::kernel_uart},
     plic::Plic,
@@ -27,11 +28,15 @@ fn main() -> ! {
     }
 
     let mut p = unsafe { d1_pac::Peripherals::steal() };
-    let uart = unsafe { kernel_uart(&mut p.CCU, &mut p.GPIO, p.UART0) };
-    let spim = unsafe { kernel_spim1(p.SPI_DBI, &mut p.CCU, &mut p.GPIO) };
-    let i2c0 = unsafe { twi::I2c0::mq_pro(p.TWI0, &mut p.CCU, &mut p.GPIO) };
+
+    let mut ccu = Ccu::new(p.CCU);
+    ccu.sys_clock_init();
+
+    let uart = unsafe { kernel_uart(&mut ccu, &mut p.GPIO, p.UART0) };
+    let spim = unsafe { kernel_spim1(p.SPI_DBI, &mut ccu, &mut p.GPIO) };
+    let i2c0 = unsafe { twi::I2c0::mq_pro(p.TWI0, &mut ccu, &mut p.GPIO) };
     let timers = Timers::new(p.TIMER);
-    let dmac = Dmac::new(p.DMAC, &mut p.CCU);
+    let dmac = Dmac::new(p.DMAC, &mut ccu);
     let plic = Plic::new(p.PLIC);
 
     let d1 = D1::initialize(timers, uart, spim, dmac, plic, i2c0);

--- a/platforms/allwinner-d1/core/src/ccu.rs
+++ b/platforms/allwinner-d1/core/src/ccu.rs
@@ -1,0 +1,199 @@
+//! This module provides a higher-level interface for the `Clock Controller Unit`.
+use d1_pac::CCU;
+
+pub struct Ccu {
+    ccu: CCU,
+}
+
+macro_rules! set_module {
+    ($self: ident, $module: ident) => {
+        if ($self.ccu.$module.read().pll_en().bit_is_clear()) {
+            $self.ccu.$module.modify(|_, w| {
+                w.pll_ldo_en().enable();
+                w.pll_en().enable();
+                w
+            });
+
+            $self.ccu.$module.modify(|_, w| w.lock_enable().enable());
+
+            while $self.ccu.$module.read().lock().bit_is_clear() {
+                core::hint::spin_loop();
+            }
+            sdelay(20);
+
+            $self.ccu.$module.modify(|_, w| w.lock_enable().disable());
+        }
+    };
+}
+
+// temporary
+fn sdelay(delay_us: usize) {
+    let clint = unsafe { crate::clint::Clint::summon() };
+    let t = clint.get_mtime();
+    while clint.get_mtime() < (t + 24 * delay_us) {
+        core::hint::spin_loop()
+    }
+}
+
+impl Ccu {
+    pub fn new(ccu: CCU) -> Self {
+        Self { ccu }
+    }
+
+    pub fn release(self) -> CCU {
+        self.ccu
+    }
+
+    /// This function is currently a copy from
+    /// [xboot](https://github.com/xboot/xboot/blob/master/src/arch/riscv64/mach-d1/sys-clock.c)
+    pub fn sys_clock_init(&mut self) {
+        self.set_pll_cpux_axi();
+        self.set_pll_periph0();
+        self.set_ahb();
+        self.set_apb();
+        self.set_dma();
+        self.set_mbus();
+        set_module!(self, pll_peri_ctrl);
+        set_module!(self, pll_video0_ctrl);
+        set_module!(self, pll_video1_ctrl);
+        set_module!(self, pll_ve_ctrl);
+        set_module!(self, pll_audio0_ctrl);
+        set_module!(self, pll_audio1_ctrl);
+    }
+
+    fn set_pll_cpux_axi(&mut self) {
+        /* Select cpux clock src to osc24m, axi divide ratio is 3, system apb clk ratio is 4 */
+        self.ccu.riscv_clk.write(|w| {
+            w.clk_src_sel().hosc();
+            w.axi_div_cfg().variant(3);
+            w.div_cfg().variant(1);
+            w
+        });
+        sdelay(1);
+
+        /* Disable pll gating */
+        self.ccu
+            .pll_cpu_ctrl
+            .modify(|_, w| w.pll_output_gate().disable());
+
+        /* Enable pll ldo */
+        self.ccu.pll_cpu_ctrl.modify(|_, w| w.pll_ldo_en().enable());
+        sdelay(5);
+
+        /* Set default clk to 1008mhz */
+        self.ccu.pll_cpu_ctrl.modify(|r, w| {
+            // undocumented part of register is cleared by xboot
+            unsafe { w.bits(r.bits() & !(0x3 << 16)) };
+            w.pll_m().variant(0);
+            w.pll_n().variant(41);
+            w
+        });
+
+        /* Lock enable */
+        self.ccu
+            .pll_cpu_ctrl
+            .modify(|_, w| w.lock_enable().enable());
+
+        /* Enable pll */
+        self.ccu.pll_cpu_ctrl.modify(|_, w| w.pll_en().enable());
+
+        /* Wait pll stable */
+        while self.ccu.pll_cpu_ctrl.read().lock().bit_is_clear() {
+            core::hint::spin_loop();
+        }
+        sdelay(20);
+
+        /* Enable pll gating */
+        self.ccu
+            .pll_cpu_ctrl
+            .modify(|_, w| w.pll_output_gate().enable());
+
+        /* Lock disable */
+        self.ccu
+            .pll_cpu_ctrl
+            .modify(|_, w| w.lock_enable().disable());
+        sdelay(1);
+
+        /* Set and change cpu clk src */
+        self.ccu.riscv_clk.modify(|_, w| {
+            w.clk_src_sel().pll_cpu();
+            w.axi_div_cfg().variant(1);
+            w.div_cfg().variant(0);
+            w
+        });
+        sdelay(1);
+    }
+
+    fn set_pll_periph0(&mut self) {
+        /* Periph0 has been enabled */
+        if self.ccu.pll_peri_ctrl.read().pll_en().bit_is_set() {
+            return;
+        }
+
+        /* Change psi src to osc24m */
+        self.ccu.psi_clk.modify(|_, w| w.clk_src_sel().hosc());
+
+        /* Set default val */
+        self.ccu.pll_peri_ctrl.write(|w| w.pll_n().variant(0x63));
+
+        /* Lock enable */
+        self.ccu
+            .pll_peri_ctrl
+            .modify(|_, w| w.lock_enable().enable());
+
+        /* Enabe pll 600m(1x) 1200m(2x) */
+        self.ccu.pll_peri_ctrl.modify(|_, w| w.pll_en().enable());
+
+        /* Wait pll stable */
+        while self.ccu.pll_peri_ctrl.read().lock().bit_is_clear() {
+            core::hint::spin_loop();
+        }
+        sdelay(20);
+
+        /* Lock disable */
+        self.ccu
+            .pll_peri_ctrl
+            .modify(|_, w| w.lock_enable().disable());
+    }
+
+    fn set_ahb(&mut self) {
+        self.ccu
+            .psi_clk
+            .write(|w| w.factor_m().variant(2).factor_n().n1());
+        self.ccu
+            .psi_clk
+            .modify(|_, w| w.clk_src_sel().pll_peri_1x());
+        sdelay(1);
+    }
+
+    fn set_apb(&mut self) {
+        self.ccu.apb_clk[0].write(|w| w.factor_m().variant(2).factor_n().n2());
+        self.ccu.apb_clk[0].modify(|_, w| w.clk_src_sel().pll_peri_1x());
+        sdelay(1);
+    }
+
+    fn set_dma(&mut self) {
+        /* Dma reset */
+        self.ccu.dma_bgr.modify(|_, w| w.rst().deassert());
+        sdelay(20);
+        /* Enable gating clock for dma */
+        self.ccu.dma_bgr.modify(|_, w| w.gating().pass());
+    }
+
+    fn set_mbus(&mut self) {
+        /* Reset mbus domain */
+        self.ccu.mbus_clk.modify(|_, w| w.mbus_rst().deassert());
+        sdelay(1);
+        /* Enable mbus master clock gating */
+        self.ccu.mbus_mat_clk_gating.write(|w| {
+            w.dma_mclk_en().pass();
+            w.ve_mclk_en().pass();
+            w.ce_mclk_en().pass();
+            w.tvin_mclk_en().pass();
+            w.csi_mclk_en().pass();
+            w.g2d_mclk_en().pass();
+            w.riscv_mclk_en().pass();
+            w
+        });
+    }
+}

--- a/platforms/allwinner-d1/core/src/clint.rs
+++ b/platforms/allwinner-d1/core/src/clint.rs
@@ -1,21 +1,27 @@
 use d1_pac::CLINT;
 
-/// Core Local Interruptor (ClINT) interface
+/// Core Local Interruptor (ClINT) interface.
+///
+/// The implementation in the (single) C906 core of the D1 provides timer functionalities
+/// that can be accessed from machine and supervisor mode.
 pub struct Clint {
     clint: CLINT,
 }
 
 impl Clint {
     /// Create a new `Clint` from the [`CLINT`](d1_pac::CLINT) peripheral
+    #[must_use]
     pub fn new(clint: CLINT) -> Self {
         Self { clint }
     }
 
     /// Release the underlying [`CLINT`](d1_pac::CLINT) peripheral
+    #[must_use]
     pub fn release(self) -> CLINT {
         self.clint
     }
 
+    #[must_use]
     pub unsafe fn summon() -> Self {
         Self {
             clint: d1_pac::Peripherals::steal().CLINT,
@@ -23,11 +29,10 @@ impl Clint {
     }
 
     /// Get the (machine) time value.
-    ///
-    /// Note that the CLINT of the C906 core does not implement
-    /// the `mtime` register and we need to get the time value
-    /// with a CSR, which the `riscv` crate implements for us.
     pub fn get_mtime(&self) -> usize {
+        // Note that the CLINT of the C906 core does not implement
+        // the `mtime` register and we need to get the time value
+        // with a CSR, which the `riscv` crate implements for us.
         riscv::register::time::read()
     }
 
@@ -35,7 +40,7 @@ impl Clint {
     ///
     /// When `mtime` >= this value, a (machine) interrupt
     /// will be generated (if configured properly).
-    pub fn set_mtimecmp(&self, cmp: usize) {
+    pub fn set_mtimecmp(&mut self, cmp: usize) {
         let cmph = (cmp >> 32) as u32;
         let cmpl = (cmp & 0xffff_ffff) as u32;
         unsafe {
@@ -45,7 +50,7 @@ impl Clint {
     }
 
     /// Reset the machine time comparator to its default value.
-    pub fn reset_mtimecmp(&self) {
+    pub fn reset_mtimecmp(&mut self) {
         unsafe {
             self.clint.mtimecmph.write(|w| w.bits(0xffff_ffff));
             self.clint.mtimecmpl.write(|w| w.bits(0xffff_ffff));

--- a/platforms/allwinner-d1/core/src/clint.rs
+++ b/platforms/allwinner-d1/core/src/clint.rs
@@ -1,0 +1,54 @@
+use d1_pac::CLINT;
+
+/// Core Local Interruptor (ClINT) interface
+pub struct Clint {
+    clint: CLINT,
+}
+
+impl Clint {
+    /// Create a new `Clint` from the [`CLINT`](d1_pac::CLINT) peripheral
+    pub fn new(clint: CLINT) -> Self {
+        Self { clint }
+    }
+
+    /// Release the underlying [`CLINT`](d1_pac::CLINT) peripheral
+    pub fn release(self) -> CLINT {
+        self.clint
+    }
+
+    pub unsafe fn summon() -> Self {
+        Self {
+            clint: d1_pac::Peripherals::steal().CLINT,
+        }
+    }
+
+    /// Get the (machine) time value.
+    ///
+    /// Note that the CLINT of the C906 core does not implement
+    /// the `mtime` register and we need to get the time value
+    /// with a CSR, which the `riscv` crate implements for us.
+    pub fn get_mtime(&self) -> usize {
+        riscv::register::time::read()
+    }
+
+    /// Set the machine time comparator.
+    ///
+    /// When `mtime` >= this value, a (machine) interrupt
+    /// will be generated (if configured properly).
+    pub fn set_mtimecmp(&self, cmp: usize) {
+        let cmph = (cmp >> 32) as u32;
+        let cmpl = (cmp & 0xffff_ffff) as u32;
+        unsafe {
+            self.clint.mtimecmph.write(|w| w.bits(cmph));
+            self.clint.mtimecmpl.write(|w| w.bits(cmpl));
+        }
+    }
+
+    /// Reset the machine time comparator to its default value.
+    pub fn reset_mtimecmp(&self) {
+        unsafe {
+            self.clint.mtimecmph.write(|w| w.bits(0xffff_ffff));
+            self.clint.mtimecmpl.write(|w| w.bits(0xffff_ffff));
+        }
+    }
+}

--- a/platforms/allwinner-d1/core/src/dmac/mod.rs
+++ b/platforms/allwinner-d1/core/src/dmac/mod.rs
@@ -9,8 +9,10 @@ use core::{
 use d1_pac::{
     dmac::{dmac_desc_addr::DMAC_DESC_ADDR_SPEC, dmac_en::DMAC_EN_SPEC, dmac_mode::DMAC_MODE_SPEC},
     generic::Reg,
-    CCU, DMAC,
+    DMAC,
 };
+
+use crate::ccu::Ccu;
 
 use self::descriptor::Descriptor;
 
@@ -24,8 +26,8 @@ pub struct Dmac {
 impl Dmac {
     pub const CHANNEL_COUNT: u8 = 16;
 
-    pub fn new(dmac: DMAC, ccu: &mut CCU) -> Self {
-        ccu.dma_bgr.write(|w| w.gating().pass().rst().deassert());
+    pub fn new(dmac: DMAC, ccu: &mut Ccu) -> Self {
+        ccu.enable_module::<DMAC>();
         Self {
             dmac,
             channels: [

--- a/platforms/allwinner-d1/core/src/dmac/mod.rs
+++ b/platforms/allwinner-d1/core/src/dmac/mod.rs
@@ -26,8 +26,8 @@ pub struct Dmac {
 impl Dmac {
     pub const CHANNEL_COUNT: u8 = 16;
 
-    pub fn new(dmac: DMAC, ccu: &mut Ccu) -> Self {
-        ccu.enable_module::<DMAC>();
+    pub fn new(mut dmac: DMAC, ccu: &mut Ccu) -> Self {
+        ccu.enable_module(&mut dmac);
         Self {
             dmac,
             channels: [

--- a/platforms/allwinner-d1/core/src/drivers/spim.rs
+++ b/platforms/allwinner-d1/core/src/drivers/spim.rs
@@ -30,7 +30,7 @@ pub struct Spim1 {
 /// - This function should be called only while running on an Allwinner D1.
 pub unsafe fn kernel_spim1(spi1: SPI_DBI, ccu: &mut Ccu, gpio: &mut GPIO) -> Spim1 {
     // Set clock rate (fixed to 2MHz), and enable the SPI peripheral
-    ccu.borrow().spi1_clk.write(|w| {
+    ccu.borrow_raw().spi1_clk.write(|w| {
         // Enable clock
         w.clk_gating().on();
         // base:  24 MHz

--- a/platforms/allwinner-d1/core/src/drivers/spim.rs
+++ b/platforms/allwinner-d1/core/src/drivers/spim.rs
@@ -2,13 +2,14 @@
 
 use core::ptr::NonNull;
 
+use crate::ccu::Ccu;
 use crate::dmac::{
     descriptor::{
         AddressMode, BModeSel, BlockSize, DataWidth, DescriptorConfig, DestDrqType, SrcDrqType,
     },
     Channel, ChannelMode,
 };
-use d1_pac::{CCU, GPIO, SPI_DBI};
+use d1_pac::{GPIO, SPI_DBI};
 use kernel::{
     comms::{kchannel::KChannel, oneshot::Reusable},
     maitake::sync::WaitCell,
@@ -27,9 +28,9 @@ pub struct Spim1 {
 ///
 /// - The `SPI_DBI``s register block must not be concurrently written to.
 /// - This function should be called only while running on an Allwinner D1.
-pub unsafe fn kernel_spim1(spi1: SPI_DBI, ccu: &mut CCU, gpio: &mut GPIO) -> Spim1 {
+pub unsafe fn kernel_spim1(spi1: SPI_DBI, ccu: &mut Ccu, gpio: &mut GPIO) -> Spim1 {
     // Set clock rate (fixed to 2MHz), and enable the SPI peripheral
-    ccu.spi1_clk.write(|w| {
+    ccu.borrow().spi1_clk.write(|w| {
         // Enable clock
         w.clk_gating().on();
         // base:  24 MHz
@@ -40,10 +41,7 @@ pub unsafe fn kernel_spim1(spi1: SPI_DBI, ccu: &mut CCU, gpio: &mut GPIO) -> Spi
         w.factor_m().variant(11);
         w
     });
-    ccu.spi_bgr.modify(|_r, w| {
-        w.spi1_gating().pass().spi1_rst().deassert();
-        w
-    });
+    ccu.enable_module::<SPI_DBI>();
 
     // Map the pins
     gpio.pd_cfg1.write(|w| {

--- a/platforms/allwinner-d1/core/src/drivers/spim.rs
+++ b/platforms/allwinner-d1/core/src/drivers/spim.rs
@@ -28,8 +28,9 @@ pub struct Spim1 {
 ///
 /// - The `SPI_DBI``s register block must not be concurrently written to.
 /// - This function should be called only while running on an Allwinner D1.
-pub unsafe fn kernel_spim1(spi1: SPI_DBI, ccu: &mut Ccu, gpio: &mut GPIO) -> Spim1 {
+pub unsafe fn kernel_spim1(mut spi1: SPI_DBI, ccu: &mut Ccu, gpio: &mut GPIO) -> Spim1 {
     // Set clock rate (fixed to 2MHz), and enable the SPI peripheral
+    // TODO: ccu should provide a higher-level abstraction for this
     ccu.borrow_raw().spi1_clk.write(|w| {
         // Enable clock
         w.clk_gating().on();
@@ -41,7 +42,7 @@ pub unsafe fn kernel_spim1(spi1: SPI_DBI, ccu: &mut Ccu, gpio: &mut GPIO) -> Spi
         w.factor_m().variant(11);
         w
     });
-    ccu.enable_module::<SPI_DBI>();
+    ccu.enable_module(&mut spi1);
 
     // Map the pins
     gpio.pd_cfg1.write(|w| {

--- a/platforms/allwinner-d1/core/src/drivers/twi.rs
+++ b/platforms/allwinner-d1/core/src/drivers/twi.rs
@@ -149,7 +149,7 @@ impl I2c0 {
     /// - The TWI register block must not be concurrently written to.
     /// - This function should be called only while running on a MangoPi MQ Pro
     ///   board.
-    pub unsafe fn mq_pro(_twi: TWI0, ccu: &mut Ccu, gpio: &mut GPIO) -> Self {
+    pub unsafe fn mq_pro(mut twi: TWI0, ccu: &mut Ccu, gpio: &mut GPIO) -> Self {
         // Step 1: Configure GPIO pin mappings.
         gpio.pg_cfg1.modify(|_r, w| {
             // on the Mango Pi MQ Pro, the pi header's I2C0 pins are mapped to
@@ -160,9 +160,9 @@ impl I2c0 {
             w
         });
 
-        ccu.disable_module::<TWI0>();
+        ccu.disable_module(&mut twi);
 
-        ccu.enable_module::<TWI0>();
+        ccu.enable_module(&mut twi);
 
         Self::init(
             unsafe { &*TWI0::ptr() },
@@ -180,7 +180,7 @@ impl I2c0 {
     /// - The TWI register block must not be concurrently written to.
     /// - This function should be called only while running on a Lichee RV
     ///   board.
-    pub unsafe fn lichee_rv_dock(_twi: TWI2, ccu: &mut Ccu, gpio: &mut GPIO) -> Self {
+    pub unsafe fn lichee_rv_dock(mut twi: TWI2, ccu: &mut Ccu, gpio: &mut GPIO) -> Self {
         // Step 1: Configure GPIO pin mappings.
         gpio.pb_cfg0.modify(|_r, w| {
             // on the Lichee RV Dock, the Pi header's I2C0 corresponds to TWI2, not
@@ -192,9 +192,9 @@ impl I2c0 {
             w
         });
 
-        ccu.disable_module::<TWI2>();
+        ccu.disable_module(&mut twi);
 
-        ccu.enable_module::<TWI2>();
+        ccu.enable_module(&mut twi);
 
         Self::init(
             unsafe { &*TWI2::ptr() },

--- a/platforms/allwinner-d1/core/src/drivers/uart.rs
+++ b/platforms/allwinner-d1/core/src/drivers/uart.rs
@@ -1,10 +1,11 @@
-use d1_pac::{CCU, GPIO, UART0};
+use d1_pac::{GPIO, UART0};
 
 use core::{
     ptr::{null_mut, NonNull},
     sync::atomic::{AtomicPtr, Ordering},
 };
 
+use crate::ccu::Ccu;
 use crate::dmac::{
     descriptor::{
         AddressMode, BModeSel, BlockSize, DataWidth, DescriptorConfig, DestDrqType, SrcDrqType,
@@ -208,10 +209,9 @@ impl D1Uart {
 ///
 /// - The `UART0` register block must not be concurrently written to.
 /// - This function should be called only while running on an Allwinner D1.
-pub unsafe fn kernel_uart(ccu: &mut CCU, gpio: &mut GPIO, uart0: UART0) -> Uart {
+pub unsafe fn kernel_uart(ccu: &mut Ccu, gpio: &mut GPIO, uart0: UART0) -> Uart {
     // Enable UART0 clock.
-    ccu.uart_bgr
-        .write(|w| w.uart0_gating().pass().uart0_rst().deassert());
+    ccu.enable_module::<UART0>();
 
     // Set PB8 and PB9 to function 6, UART0, internal pullup.
     gpio.pb_cfg1

--- a/platforms/allwinner-d1/core/src/drivers/uart.rs
+++ b/platforms/allwinner-d1/core/src/drivers/uart.rs
@@ -209,9 +209,9 @@ impl D1Uart {
 ///
 /// - The `UART0` register block must not be concurrently written to.
 /// - This function should be called only while running on an Allwinner D1.
-pub unsafe fn kernel_uart(ccu: &mut Ccu, gpio: &mut GPIO, uart0: UART0) -> Uart {
+pub unsafe fn kernel_uart(ccu: &mut Ccu, gpio: &mut GPIO, mut uart0: UART0) -> Uart {
     // Enable UART0 clock.
-    ccu.enable_module::<UART0>();
+    ccu.enable_module(&mut uart0);
 
     // Set PB8 and PB9 to function 6, UART0, internal pullup.
     gpio.pb_cfg1

--- a/platforms/allwinner-d1/core/src/lib.rs
+++ b/platforms/allwinner-d1/core/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate alloc;
 
+pub mod clint;
 pub mod dmac;
 pub mod drivers;
 pub mod plic;

--- a/platforms/allwinner-d1/core/src/lib.rs
+++ b/platforms/allwinner-d1/core/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate alloc;
 
+pub mod ccu;
 pub mod clint;
 pub mod dmac;
 pub mod drivers;


### PR DESCRIPTION
This PR adds an initial implementation of 2 new modules:
- a `ccu` module for clock initialization and module clock gating/reset
- a `clint` module to provide access to `mtime` and `mtimecmp`

By doing the same clock initialization that `xfel` would do for us,
it becomes possible to boot from a persistent medium (e.g., an SD card).
Relates to #139.