### PR TITLE
fix: remove use of `tracing` v0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
  "tonic",
  "tracing 0.1.37",
  "tracing-core 0.1.31",
- "tracing-subscriber 0.3.17",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -582,9 +582,9 @@ dependencies = [
  "serialport 4.0.1",
  "serialport 4.2.1",
  "sermux-proto",
- "tracing 0.2.0",
+ "tracing 0.1.37",
  "tracing-serde-structured",
- "tracing-subscriber 0.3.0",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1366,7 +1366,7 @@ dependencies = [
  "generator",
  "scoped-tls",
  "tracing 0.1.37",
- "tracing-subscriber 0.3.17",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1446,7 +1446,7 @@ dependencies = [
  "tokio",
  "tracing 0.1.37",
  "tracing-modality",
- "tracing-subscriber 0.3.17",
+ "tracing-subscriber",
  "uuid 1.3.4",
 ]
 
@@ -1576,8 +1576,7 @@ dependencies = [
  "sermux-proto",
  "spitebuf",
  "tracing 0.1.37",
- "tracing 0.2.0",
- "tracing-core 0.2.0",
+ "tracing-core 0.1.31",
  "tracing-serde-structured",
  "uuid 1.3.4",
  "vergen",
@@ -1610,7 +1609,7 @@ dependencies = [
  "futures",
  "mnemos",
  "mycelium-bitfield",
- "tracing 0.2.0",
+ "tracing 0.1.37",
  "uuid 1.3.4",
 ]
 
@@ -1624,7 +1623,7 @@ dependencies = [
  "futures",
  "mnemos",
  "riscv",
- "tracing 0.2.0",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -1645,7 +1644,7 @@ name = "mnemos-trace-proto"
 version = "0.1.0"
 dependencies = [
  "serde",
- "tracing-core 0.2.0",
+ "tracing-core 0.1.31",
  "tracing-serde-structured",
 ]
 
@@ -2987,9 +2986,6 @@ dependencies = [
 name = "tracing-core"
 version = "0.2.0"
 source = "git+https://github.com/tokio-rs/tracing#27f688efb72316a26f3ec1f952c82626692c08ff"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "tracing-log"
@@ -3017,7 +3013,7 @@ dependencies = [
  "tokio",
  "tracing 0.1.37",
  "tracing-core 0.1.31",
- "tracing-subscriber 0.3.17",
+ "tracing-subscriber",
  "url",
  "uuid 1.3.4",
 ]
@@ -3025,20 +3021,12 @@ dependencies = [
 [[package]]
 name = "tracing-serde-structured"
 version = "0.2.0"
-source = "git+https://github.com/jamesmunns/tracing-serde-structured?branch=james/2trace2furious#44571d9c946ada78acddb0783317a659f836ddd7"
+source = "git+https://github.com/hawkw/tracing-serde-structured?branch=eliza/span-fields#d8c384a09f27eb06aaf31dd3f9bb9c69b33f7e66"
 dependencies = [
  "hash32 0.2.1",
  "heapless",
  "serde",
- "tracing-core 0.2.0",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.0"
-source = "git+https://github.com/tokio-rs/tracing#27f688efb72316a26f3ec1f952c82626692c08ff"
-dependencies = [
- "tracing-core 0.2.0",
+ "tracing-core 0.1.31",
 ]
 
 [[package]]

--- a/platforms/allwinner-d1/boards/Cargo.lock
+++ b/platforms/allwinner-d1/boards/Cargo.lock
@@ -467,8 +467,8 @@ dependencies = [
  "serde",
  "sermux-proto",
  "spitebuf",
- "tracing 0.2.0",
- "tracing-core 0.2.0",
+ "tracing 0.1.37",
+ "tracing-core 0.1.31",
  "tracing-serde-structured",
  "uuid",
  "vergen",
@@ -501,7 +501,7 @@ dependencies = [
  "futures",
  "mnemos",
  "mycelium-bitfield",
- "tracing 0.2.0",
+ "tracing 0.1.37",
  "uuid",
 ]
 
@@ -530,7 +530,7 @@ dependencies = [
  "futures",
  "mnemos",
  "riscv",
- "tracing 0.2.0",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -538,7 +538,7 @@ name = "mnemos-trace-proto"
 version = "0.1.0"
 dependencies = [
  "serde",
- "tracing-core 0.2.0",
+ "tracing-core 0.1.31",
  "tracing-serde-structured",
 ]
 
@@ -1057,12 +1057,12 @@ dependencies = [
 [[package]]
 name = "tracing-serde-structured"
 version = "0.2.0"
-source = "git+https://github.com/jamesmunns/tracing-serde-structured?branch=james/2trace2furious#44571d9c946ada78acddb0783317a659f836ddd7"
+source = "git+https://github.com/hawkw/tracing-serde-structured?branch=eliza/span-fields#d8c384a09f27eb06aaf31dd3f9bb9c69b33f7e66"
 dependencies = [
  "hash32 0.2.1",
  "heapless",
  "serde",
- "tracing-core 0.2.0",
+ "tracing-core 0.1.31",
 ]
 
 [[package]]

--- a/platforms/allwinner-d1/boards/Cargo.toml
+++ b/platforms/allwinner-d1/boards/Cargo.toml
@@ -46,8 +46,7 @@ features = ["async-await"]
 # kernel
 [dependencies.mnemos]
 path = "../../../source/kernel"
-default-features = false
-features = ["tracing-02"]
+features = ["serial-trace"]
 
 # tracing 0.2
 [dependencies.tracing]

--- a/platforms/allwinner-d1/core/Cargo.toml
+++ b/platforms/allwinner-d1/core/Cargo.toml
@@ -13,12 +13,9 @@ critical-section = "1.1.1"
 [dependencies.mnemos]
 path = "../../../source/kernel"
 default-features = false
-features = ["tracing-02"]
 
-# tracing 0.2
 [dependencies.tracing]
-git = "https://github.com/tokio-rs/tracing"
-# branch = "master"
+version = "0.1.37"
 features = ["attributes"]
 default-features = false
 

--- a/platforms/allwinner-d1/core/src/drivers/twi.rs
+++ b/platforms/allwinner-d1/core/src/drivers/twi.rs
@@ -63,7 +63,7 @@ use kernel::{
         messages::{OpKind, Transfer},
         Addr, I2cService, Transaction,
     },
-    trace, Kernel,
+    tracing, Kernel,
 };
 
 /// A TWI mapped to the Raspberry Pi header's I²C0 pins.
@@ -322,7 +322,7 @@ impl I2c0 {
         let (tx, rx) = KChannel::new_async(queued).await.split();
 
         kernel.spawn(self.run(rx)).await;
-        trace::info!("TWI driver task spawned");
+        tracing::info!("TWI driver task spawned");
         kernel
             .with_registry(move |reg| reg.register_konly::<I2cService>(&tx).map_err(drop))
             .await?;

--- a/platforms/allwinner-d1/core/src/lib.rs
+++ b/platforms/allwinner-d1/core/src/lib.rs
@@ -17,7 +17,7 @@ use core::{
 use d1_pac::{Interrupt, DMAC, TIMER};
 use kernel::{
     mnemos_alloc::containers::Box,
-    trace::{self, Instrument},
+    tracing::{self, Instrument},
     Kernel, KernelSettings,
 };
 
@@ -143,18 +143,18 @@ impl D1 {
         // spawn Forth shell
         self.kernel
             .initialize(async move {
-                trace::debug!("waiting for SHARP display driver...");
+                tracing::debug!("waiting for SHARP display driver...");
                 sharp_display
                     .await
                     .expect("display driver task isn't cancelled")
                     .expect("display driver must come up");
-                trace::debug!("display driver ready!");
+                tracing::debug!("display driver ready!");
                 let settings = shells::GraphicalShellSettings::with_display_size(
                     SharpDisplay::WIDTH as u32,
                     SharpDisplay::HEIGHT as u32,
                 );
                 k.spawn(shells::graphical_shell_mono(k, settings)).await;
-                trace::info!("graphical shell running.");
+                tracing::info!("graphical shell running.");
             })
             .expect("failed to spawn graphical forth shell");
     }

--- a/platforms/beepy/Cargo.toml
+++ b/platforms/beepy/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies.mnemos]
 path = "../../source/kernel"
 default-features = false
-features = ["tracing-02"]
 
 [dependencies.bbq10kbd]
 version = "0.1.0"
@@ -19,10 +18,8 @@ version = "1.1.2"
 default-features = false
 features = ["serde"]
 
-# tracing 0.2
 [dependencies.tracing]
-git = "https://github.com/tokio-rs/tracing"
-# branch = "master"
+version = "0.1.37"
 features = ["attributes"]
 default-features = false
 

--- a/platforms/beepy/src/i2c_puppet.rs
+++ b/platforms/beepy/src/i2c_puppet.rs
@@ -20,7 +20,7 @@ use kernel::{
             mux::KeyboardMuxClient,
         },
     },
-    trace::{self, instrument, Instrument, Level},
+    tracing::{self, instrument, Instrument, Level},
     Kernel,
 };
 use uuid::{uuid, Uuid};
@@ -347,7 +347,7 @@ impl I2cPuppetServer {
                         tracing::error!(%error, "i2c_puppet server terminating on fatal error!");
                     }
                 }
-                .instrument(trace::info_span!("I2cPuppetServer")),
+                .instrument(tracing::info_span!("I2cPuppetServer")),
             )
             .await;
 
@@ -580,12 +580,12 @@ impl I2cPuppetServer {
                     (kbd, res)
                 })
                 .await?;
-            trace::debug!(?key);
+            tracing::debug!(?key);
 
             // TODO(eliza): remove dead subscriptions...
             for sub in self.subscriptions.as_slice_mut() {
                 if let Err(error) = sub.enqueue_async((status, key)).await {
-                    trace::warn!(?error, "subscription dropped...");
+                    tracing::warn!(?error, "subscription dropped...");
                 }
             }
 

--- a/source/kernel/Cargo.toml
+++ b/source/kernel/Cargo.toml
@@ -18,6 +18,12 @@ build = "build.rs"
 [lib]
 name = "kernel"
 
+[features]
+# enables the serial port trace protocol.
+# this is feature flagged so that it can be disabled in the simulator platforms
+# (melpomene and pomelo), which provide their own native tracing subscribers.
+serial-trace = ["mnemos-trace-proto", "tracing-core", "tracing-serde-structured"]
+
 [dependencies]
 
 [dependencies.futures]
@@ -34,31 +40,19 @@ features = ["serde"]
 version = "0.2.3"
 default-features = false
 
-[dependencies.tracing-01]
-package = "tracing"
+[dependencies.tracing]
 version = "0.1.35"
 features = ["attributes"]
 default-features = false
-optional = true
 
-[dependencies.tracing-02]
-package = "tracing"
-git = "https://github.com/tokio-rs/tracing"
-# branch = "master"
-features = ["attributes"]
-default-features = false
-optional = true
-
-[dependencies.tracing-core-02]
-package = "tracing-core"
-git = "https://github.com/tokio-rs/tracing"
-# branch = "master"
+[dependencies.tracing-core]
+version = "0.1.31"
 default-features = false
 optional = true
 
 [dependencies.tracing-serde-structured]
-git = "https://github.com/jamesmunns/tracing-serde-structured"
-branch = "james/2trace2furious"
+git = "https://github.com/hawkw/tracing-serde-structured"
+branch = "eliza/span-fields"
 default-features = false
 optional = true
 
@@ -138,15 +132,3 @@ vergen = { version = "8.0.0", features = ["cargo", "git", "gitcl", "rustc",] }
 version = "0.3.21"
 features = ["async-await", "executor"]
 default-features = false
-
-[features]
-default = ["tracing-01"]
-tracing-02 = ["dep:tracing-02", "tracing-core-02", "tracing-serde-structured", "mnemos-trace-proto"]
-
-# The `_oops_all_tracing_features` feature is a "trap" for when the package is built
-# with `--all-features`, which is usually just for docs and testing.
-#
-# In that case, the other feature settings (`tracing-01` and `tracing-02`) are ignored
-# and JUST `tracing-01` is enabled. This is an unfortunate hack that works too well
-# not to use for now.
-_oops_all_tracing_features = []

--- a/source/kernel/src/comms/bbq.rs
+++ b/source/kernel/src/comms/bbq.rs
@@ -7,12 +7,12 @@
 use core::ops::{Deref, DerefMut};
 
 use crate::fmt;
-use crate::tracing::{self, info, trace};
 use abi::bbqueue_ipc::{BBBuffer, Consumer as InnerConsumer, Producer as InnerProducer};
 use abi::bbqueue_ipc::{GrantR as InnerGrantR, GrantW as InnerGrantW};
 use maitake::sync::Mutex;
 use maitake::sync::WaitCell;
 use mnemos_alloc::containers::{Arc, ArrayBuf};
+use tracing::{self, info, trace};
 
 struct BBQStorage {
     commit_waitcell: WaitCell,

--- a/source/kernel/src/comms/kchannel.rs
+++ b/source/kernel/src/comms/kchannel.rs
@@ -1,10 +1,10 @@
 //! Kernel Channels
 //!
 //! Kernel Channels are an async/await, MPSC queue, with a fixed backing storage (e.g. they are bounded).
-use crate::tracing;
 use core::{cell::UnsafeCell, ops::Deref, ptr::NonNull};
 use mnemos_alloc::containers::{Arc, ArrayBuf};
 use spitebuf::{DequeueError, EnqueueError, MpScQueue};
+use tracing;
 
 /// A Kernel Channel
 pub struct KChannel<T> {

--- a/source/kernel/src/daemons/sermux.rs
+++ b/source/kernel/src/daemons/sermux.rs
@@ -6,7 +6,7 @@ use core::time::Duration;
 
 use crate::{
     services::serial_mux::{PortHandle, WellKnown},
-    tracing, Kernel,
+    Kernel,
 };
 
 //

--- a/source/kernel/src/daemons/shells.rs
+++ b/source/kernel/src/daemons/shells.rs
@@ -12,7 +12,7 @@ use crate::{
         keyboard::{key_event, KeyClient},
         serial_mux::{PortHandle, WellKnown},
     },
-    tracing, Kernel,
+    Kernel,
 };
 use embedded_graphics::{
     mono_font::{MonoFont, MonoTextStyle},

--- a/source/kernel/src/forth/mod.rs
+++ b/source/kernel/src/forth/mod.rs
@@ -1,5 +1,4 @@
 use crate::services::forth_spawnulator::SpawnulatorClient;
-use crate::tracing;
 use crate::{
     comms::bbq,
     services::serial_mux::{PortHandle, SerialMuxClient},
@@ -20,6 +19,7 @@ use mnemos_alloc::{
     heap::{alloc, dealloc},
 };
 use portable_atomic::{AtomicUsize, Ordering};
+use tracing;
 
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]

--- a/source/kernel/src/registry/mod.rs
+++ b/source/kernel/src/registry/mod.rs
@@ -1,13 +1,11 @@
 use core::{any::TypeId, marker::PhantomData};
 
-use crate::{
-    comms::oneshot::Reusable,
-    tracing::{self, debug, info},
-};
+use crate::comms::oneshot::Reusable;
 use mnemos_alloc::containers::FixedVec;
 use postcard::experimental::max_size::MaxSize;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use spitebuf::EnqueueError;
+use tracing::{self, debug, info};
 pub use uuid::{uuid, Uuid};
 
 use crate::comms::{

--- a/source/kernel/src/retry.rs
+++ b/source/kernel/src/retry.rs
@@ -1,6 +1,6 @@
-use crate::tracing;
 use core::{fmt, future::Future};
 use maitake::time::{self, Duration};
+use tracing;
 
 /// An exponential backoff.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/source/kernel/src/services/forth_spawnulator.rs
+++ b/source/kernel/src/services/forth_spawnulator.rs
@@ -51,7 +51,7 @@ use crate::{
     registry::{
         known_uuids::kernel::FORTH_SPAWNULATOR, Envelope, KernelHandle, Message, RegisteredDriver,
     },
-    tracing, Kernel,
+    Kernel,
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/source/kernel/src/services/i2c.rs
+++ b/source/kernel/src/services/i2c.rs
@@ -399,7 +399,7 @@ where
         let n_ops = operations.len();
         for (n, op) in operations.iter_mut().enumerate() {
             let end = n == n_ops - 1;
-            crate::tracing::trace!(n, n_ops, ?op, ?end);
+            tracing::trace!(n, n_ops, ?op, ?end);
             buf.clear();
             match op {
                 i2c::Operation::Read(dest) => {

--- a/source/kernel/src/services/keyboard/mux.rs
+++ b/source/kernel/src/services/keyboard/mux.rs
@@ -20,11 +20,11 @@ use crate::{
         RegistrationError,
     },
     services::serial_mux,
-    tracing::{self, Level},
     Kernel,
 };
 use core::{convert::Infallible, time::Duration};
 use futures::{future, FutureExt};
+use tracing::Level;
 use uuid::Uuid;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/source/kernel/src/services/serial_mux.rs
+++ b/source/kernel/src/services/serial_mux.rs
@@ -9,7 +9,6 @@
 use core::time::Duration;
 
 use crate::comms::bbq::GrantR;
-use crate::tracing::{self, debug, warn, Level};
 use crate::{
     comms::{
         bbq,
@@ -23,6 +22,7 @@ use crate::{
 use maitake::sync::Mutex;
 use mnemos_alloc::containers::{Arc, FixedVec};
 use sermux_proto::PortChunk;
+use tracing::{self, debug, warn, Level};
 use uuid::Uuid;
 
 // Well known ports live in the sermux_proto crate

--- a/source/trace-proto/Cargo.toml
+++ b/source/trace-proto/Cargo.toml
@@ -12,10 +12,10 @@ default-features = false
 features = ["derive"]
 
 [dependencies.tracing-serde-structured]
-git = "https://github.com/jamesmunns/tracing-serde-structured"
-branch = "james/2trace2furious"
+git = "https://github.com/hawkw/tracing-serde-structured"
+branch = "eliza/span-fields"
 default-features = false
 
 [dependencies.tracing-core]
-git = "https://github.com/tokio-rs/tracing"
+version = "0.1.31"
 default-features = false

--- a/tools/crowtty/Cargo.toml
+++ b/tools/crowtty/Cargo.toml
@@ -37,8 +37,8 @@ version = "3.5"
 features = ["supports-colors"]
 
 [dependencies.tracing-serde-structured]
-git = "https://github.com/jamesmunns/tracing-serde-structured"
-branch = "james/2trace2furious"
+git = "https://github.com/hawkw/tracing-serde-structured"
+branch = "eliza/span-fields"
 default-features = true
 
 [dependencies.sermux-proto]
@@ -49,15 +49,11 @@ features = ["use-std"]
 path = "../../source/trace-proto"
 features = ["std"]
 
-[dependencies.tracing-02]
-package = "tracing"
-git = "https://github.com/tokio-rs/tracing"
-# branch = "master"
+[dependencies.tracing]
+version = "0.1.37"
 default-features = false
 
 [dependencies.tracing-subscriber]
-package = "tracing-subscriber"
-git = "https://github.com/tokio-rs/tracing"
-# branch = "master"
+version = "0.3.17"
 default-features = false
 features = ["std"]

--- a/tools/crowtty/src/main.rs
+++ b/tools/crowtty/src/main.rs
@@ -11,7 +11,7 @@ use std::{
     thread::{sleep, spawn, JoinHandle},
     time::{Duration, Instant},
 };
-use tracing_02::level_filters::LevelFilter;
+use tracing::level_filters::LevelFilter;
 
 /// Unfortunately, the `serialport` crate seems to have some issues on M-series Macs.
 ///


### PR DESCRIPTION
Currently, we use `tracing` v0.2 on some platforms, and v0.1 on others. This was motivated by `tracing` v0.1 requiring a single allocation performed using `liballoc` to allocate an `Arc` when setting the default subscriber, which is not needed in `tracing` v0.2. This was an issue when mnemOS did not use `liballoc`. However, we now use `liballoc` on all platforms, so we can completely cut over from the unreleased `tracing` v0.2 to released `tracing` v0.1 everywhere.

This branch makes that change, rendering the complex feature flagging situation previously used to switch between the released and unreleased `tracing` versions unnecessary. This should fix the build in the root workspace without feature flags.

We still feature flag the automatic spawning of the serial port subscriber, so that Melpomene and Pomelo can use their own native subscribers instead. We may want to change this so that the platform impl is responsible for setting the global default subscriber, instead, but this works for now.

Fixes #142