### PR TITLE
feat(i2c_puppet): pass in a `WaitCell` for IRQs

### DIFF
--- a/platforms/allwinner-d1/boards/src/bin/mq-pro.rs
+++ b/platforms/allwinner-d1/boards/src/bin/mq-pro.rs
@@ -74,7 +74,7 @@ fn main() -> ! {
         .kernel
         .initialize(async move {
             d1.kernel.sleep(Duration::from_secs(2)).await;
-            I2cPuppetServer::register(d1.kernel, Default::default())
+            I2cPuppetServer::register(d1.kernel, Default::default(), None)
                 .await
                 .expect("failed to register i2c_puppet driver!");
         })

--- a/platforms/beepy/src/i2c_puppet.rs
+++ b/platforms/beepy/src/i2c_puppet.rs
@@ -3,13 +3,14 @@
 use bbq10kbd::{AsyncBbq10Kbd, CapsLockState, FifoCount, NumLockState};
 pub use bbq10kbd::{KeyRaw, KeyStatus, Version};
 use core::{fmt, time::Duration};
-use futures::TryFutureExt;
+use futures::{select_biased, FutureExt, TryFutureExt};
 use kernel::{
     comms::{
         kchannel::{KChannel, KConsumer, KProducer},
         oneshot::Reusable,
     },
     embedded_hal_async::i2c::{self, I2c},
+    maitake::sync::WaitCell,
     mnemos_alloc::containers::FixedVec,
     registry::{self, Envelope, KernelHandle, RegisteredDriver},
     retry::{AlwaysRetry, ExpBackoff, Retry, WithMaxRetries},
@@ -234,6 +235,7 @@ pub struct I2cPuppetServer {
 pub enum RegistrationError {
     Registry(registry::RegistrationError),
     NoI2cPuppet(I2cError),
+    InvalidSettings(&'static str),
 }
 
 // https://github.com/solderparty/i2c_puppet#protocol
@@ -340,16 +342,18 @@ impl I2cPuppetServer {
             keymux,
         };
 
-        kernel
-            .spawn(
-                async move {
-                    if let Err(error) = this.run(kernel).await {
-                        tracing::error!(%error, "i2c_puppet server terminating on fatal error!");
-                    }
-                }
-                .instrument(tracing::info_span!("I2cPuppetServer")),
-            )
-            .await;
+        let span = tracing::info_span!("I2cPuppetServer");
+
+        match this.settings.irq_waker {
+            Some(irq) => {
+                kernel
+                    .spawn(this.run_with_irq(kernel, irq).instrument(span))
+                    .await;
+            }
+            None => {
+                kernel.spawn(this.run_no_irq(kernel).instrument(span)).await;
+            }
+        }
 
         kernel
             .with_registry(|reg| reg.register_konly::<I2cPuppetService>(&tx))
@@ -358,151 +362,170 @@ impl I2cPuppetServer {
         Ok(())
     }
 
-    async fn run(mut self, kernel: &'static Kernel) -> Result<(), I2cError> {
+    async fn run_no_irq(mut self, kernel: &'static Kernel) {
+        tracing::info!("running in poll-only mode...");
         loop {
-            // TODO(eliza): this Sucks and we should instead get i2c_puppet to send
-            // us an interrupt...
-            if let Ok(dq) = kernel
+            if let Ok(Ok(msg)) = kernel
                 .timer()
                 .timeout(self.settings.poll_interval, self.rx.dequeue_async())
                 .await
             {
-                let registry::Message { msg, reply } = match dq {
-                    Ok(msg) => msg,
-                    Err(_) => return Ok(()),
-                };
-                let send_reply = |rsp: Result<Response, Error>| {
-                    reply.reply_konly(msg.reply_with(rsp)).map_err(|error| {
-                        tracing::warn!(?error, "failed to reply to request!!");
-                        error
-                    })
-                };
-                match msg.body {
-                    Request::SubscribeToRawKeys => {
-                        let (sub_tx, sub_rx) =
-                            KChannel::new_async(self.settings.subscription_capacity)
-                                .await
-                                .split();
-                        match self.subscriptions.try_push(sub_tx) {
-                            Ok(()) => {
-                                tracing::debug!("new subscription to keys");
-                                let reply = send_reply(Ok(Response::SubscribeToKeys(
-                                    RawKeySubscription(sub_rx),
-                                )))
+                self.handle_message(msg).await;
+            }
+
+            self.poll_keys().await;
+        }
+    }
+
+    async fn run_with_irq(mut self, kernel: &'static Kernel, irq: &'static WaitCell) {
+        tracing::info!("running in IRQ-driven mode...");
+        loop {
+            select_biased! {
+                _ = irq.wait().fuse() => {
+                    tracing::trace!("i2c_puppet IRQ fired!");
+                },
+
+                dequeued = self.rx.dequeue_async().fuse() => {
+                    if let Ok(msg) = dequeued {
+                        self.handle_message(msg).await;
+                    }
+                },
+
+                _ = kernel.sleep(self.settings.poll_interval).fuse() => {
+                    tracing::trace!("`i2c_puppet` poll interval elapsed");
+                }
+            }
+
+            self.poll_keys().await;
+        }
+    }
+
+    async fn handle_message(
+        &mut self,
+        registry::Message { msg, reply }: registry::Message<I2cPuppetService>,
+    ) {
+        let request = &msg.body;
+        let send_reply = |rsp: Result<Response, Error>| {
+            reply.reply_konly(msg.reply_with(rsp)).map_err(|error| {
+                tracing::warn!(?error, ?request, "failed to reply to request!!");
+                error
+            })
+        };
+        match request {
+            Request::SubscribeToRawKeys => {
+                let (sub_tx, sub_rx) = KChannel::new_async(self.settings.subscription_capacity)
+                    .await
+                    .split();
+                match self.subscriptions.try_push(sub_tx) {
+                    Ok(()) => {
+                        tracing::debug!("new subscription to keys");
+                        let reply =
+                            send_reply(Ok(Response::SubscribeToKeys(RawKeySubscription(sub_rx))))
                                 .await;
 
-                                if reply.is_err() {
-                                    // if the client hung up, remove the
-                                    // subscriptions entry we created.
-                                    self.subscriptions.pop();
-                                }
-                            }
-                            Err(_) => {
-                                tracing::warn!("subscriptions at capacity");
-                                // if the reply fails, that's fine, because we
-                                // didn't do anything anyway.
-                                let _ = send_reply(Err(Error::AtMaxSubscriptions)).await;
-                            }
+                        if reply.is_err() {
+                            // if the client hung up, remove the
+                            // subscriptions entry we created.
+                            self.subscriptions.pop();
                         }
                     }
-                    Request::SetColor(color) => {
-                        let res = self.set_color(color).await;
-                        match res {
-                            Ok(color) => {
-                                tracing::trace!(?color, "set i2c_puppet LED color");
-                                let _ = send_reply(Ok(Response::SetColor(color))).await;
-                            }
-                            Err(error) => {
-                                tracing::warn!(%error, "failed to set i2c_puppet LED color");
-                                let _ = send_reply(Err(Error::I2c(error))).await;
-                            }
-                        }
+                    Err(_) => {
+                        tracing::warn!("subscriptions at capacity");
+                        // if the reply fails, that's fine, because we
+                        // didn't do anything anyway.
+                        let _ = send_reply(Err(Error::AtMaxSubscriptions)).await;
                     }
-
-                    Request::ToggleLed(on) => {
-                        tracing::trace!(on, "toggling i2c_puppet LED...");
-                        let res = self
-                            .i2c
-                            .write(ADDR, &[reg::LED_ON | reg::WRITE, on as u8])
-                            .await;
-                        match res {
-                            Ok(()) => {
-                                tracing::trace!(on, "toggled i2c_puppet LED");
-                                let _ = send_reply(Ok(Response::ToggleLed(on))).await;
-                            }
-                            Err(error) => {
-                                tracing::warn!(%error, "failed to toggle i2c_puppet LED");
-                                let _ = send_reply(Err(Error::I2c(error))).await;
-                            }
-                        }
+                }
+            }
+            &Request::SetColor(color) => {
+                let res = self.set_color(color).await;
+                match res {
+                    Ok(color) => {
+                        tracing::trace!(?color, "set i2c_puppet LED color");
+                        let _ = send_reply(Ok(Response::SetColor(color))).await;
                     }
-
-                    Request::GetLedStatus => match self.get_led_status().await {
-                        Ok(led) => {
-                            tracing::trace!(?led.color, led.on, "got i2c_puppet LED status");
-                            let _ = send_reply(Ok(Response::GetLedStatus(led))).await;
-                        }
-                        Err(error) => {
-                            tracing::warn!(%error, "failed to get i2c_puppet LED status");
-                            let _ = send_reply(Err(Error::I2c(error))).await;
-                        }
-                    },
-
-                    Request::SetBacklight(brightness) => {
-                        tracing::trace!(brightness, "setting i2c_puppet backlight");
-                        match AsyncBbq10Kbd::new(&mut self.i2c)
-                            .set_backlight(brightness)
-                            .await
-                        {
-                            Ok(()) => {
-                                tracing::trace!(brightness, "set i2c_puppet backlight",);
-                                let _ = send_reply(Ok(Response::Backlight(brightness))).await;
-                            }
-                            Err(error) => {
-                                tracing::warn!(%error, "failed to set i2c_puppet backlight");
-                                let _ = send_reply(Err(Error::I2c(error))).await;
-                            }
-                        }
-                    }
-
-                    Request::GetBacklight => {
-                        tracing::trace!("getting i2c_puppet backlight");
-                        match AsyncBbq10Kbd::new(&mut self.i2c).get_backlight().await {
-                            Ok(brightness) => {
-                                tracing::trace!(brightness, "got i2c_puppet backlight",);
-                                let _ = send_reply(Ok(Response::Backlight(brightness))).await;
-                            }
-                            Err(error) => {
-                                tracing::warn!(%error, "failed to set i2c_puppet backlight");
-                                let _ = send_reply(Err(Error::I2c(error))).await;
-                            }
-                        }
-                    }
-
-                    Request::GetVersion => {
-                        tracing::debug!("getting i2c_puppet version");
-                        match AsyncBbq10Kbd::new(&mut self.i2c).get_version().await {
-                            Ok(version) => {
-                                tracing::debug!(
-                                    "i2c_puppet firmware version: v{}.{}",
-                                    version.major,
-                                    version.minor
-                                );
-                                let _ = send_reply(Ok(Response::GetVersion(version))).await;
-                            }
-                            Err(error) => {
-                                tracing::warn!(%error, "failed to get i2c_puppet version");
-                                let _ = send_reply(Err(Error::I2c(error))).await;
-                            }
-                        }
+                    Err(error) => {
+                        tracing::warn!(%error, "failed to set i2c_puppet LED color");
+                        let _ = send_reply(Err(Error::I2c(error))).await;
                     }
                 }
             }
 
-            if !self.subscriptions.is_empty() || self.keymux.is_some() {
-                tracing::trace!("polling keys...");
-                if let Err(error) = self.poll_keys().await {
-                    tracing::warn!(%error, "i2c_puppet: error polling keys!");
+            &Request::ToggleLed(on) => {
+                tracing::trace!(on, "toggling i2c_puppet LED...");
+                let res = self
+                    .i2c
+                    .write(ADDR, &[reg::LED_ON | reg::WRITE, on as u8])
+                    .await;
+                match res {
+                    Ok(()) => {
+                        tracing::trace!(on, "toggled i2c_puppet LED");
+                        let _ = send_reply(Ok(Response::ToggleLed(on))).await;
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "failed to toggle i2c_puppet LED");
+                        let _ = send_reply(Err(Error::I2c(error))).await;
+                    }
+                }
+            }
+
+            Request::GetLedStatus => match self.get_led_status().await {
+                Ok(led) => {
+                    tracing::trace!(?led.color, led.on, "got i2c_puppet LED status");
+                    let _ = send_reply(Ok(Response::GetLedStatus(led))).await;
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "failed to get i2c_puppet LED status");
+                    let _ = send_reply(Err(Error::I2c(error))).await;
+                }
+            },
+
+            &Request::SetBacklight(brightness) => {
+                tracing::trace!(brightness, "setting i2c_puppet backlight");
+                match AsyncBbq10Kbd::new(&mut self.i2c)
+                    .set_backlight(brightness)
+                    .await
+                {
+                    Ok(()) => {
+                        tracing::trace!(brightness, "set i2c_puppet backlight",);
+                        let _ = send_reply(Ok(Response::Backlight(brightness))).await;
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "failed to set i2c_puppet backlight");
+                        let _ = send_reply(Err(Error::I2c(error))).await;
+                    }
+                }
+            }
+
+            Request::GetBacklight => {
+                tracing::trace!("getting i2c_puppet backlight");
+                match AsyncBbq10Kbd::new(&mut self.i2c).get_backlight().await {
+                    Ok(brightness) => {
+                        tracing::trace!(brightness, "got i2c_puppet backlight",);
+                        let _ = send_reply(Ok(Response::Backlight(brightness))).await;
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "failed to set i2c_puppet backlight");
+                        let _ = send_reply(Err(Error::I2c(error))).await;
+                    }
+                }
+            }
+
+            Request::GetVersion => {
+                tracing::debug!("getting i2c_puppet version");
+                match AsyncBbq10Kbd::new(&mut self.i2c).get_version().await {
+                    Ok(version) => {
+                        tracing::debug!(
+                            "i2c_puppet firmware version: v{}.{}",
+                            version.major,
+                            version.minor
+                        );
+                        let _ = send_reply(Ok(Response::GetVersion(version))).await;
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "failed to get i2c_puppet version");
+                        let _ = send_reply(Err(Error::I2c(error))).await;
+                    }
                 }
             }
         }
@@ -553,7 +576,21 @@ impl I2cPuppetServer {
         Ok(color)
     }
 
-    async fn poll_keys(&mut self) -> Result<(), I2cError> {
+    async fn poll_keys(&mut self) {
+        // If there are no raw key subscriptions *and* we are not talking to a
+        // keyboard multiplexing service, don't do anything.
+        if self.keymux.is_none() && self.subscriptions.is_empty() {
+            return;
+        }
+
+        tracing::trace!("polling keys...");
+
+        if let Err(error) = self.poll_keys_inner().await {
+            tracing::warn!(%error, "i2c_puppet: error polling keys!");
+        }
+    }
+
+    async fn poll_keys_inner(&mut self) -> Result<(), I2cError> {
         fn keycode(x: u8) -> key_event::KeyCode {
             match x {
                 0x08 => key_event::KeyCode::Backspace,
@@ -630,12 +667,14 @@ pub struct I2cPuppetSettings {
     pub channel_capacity: usize,
     pub subscription_capacity: usize,
     pub max_subscriptions: usize,
-    pub poll_interval: Duration,
     /// If set, the `i2c_puppet` service will also forward keypresses to the kernel's
     /// [`KeyboardMuxService`](kernel::services::keyboard::mux::KeyboardMuxService).
     pub keymux: bool,
     pub min_backoff: Duration,
     pub max_retries: usize,
+
+    pub poll_interval: Duration,
+    irq_waker: Option<&'static WaitCell>,
 }
 
 impl Default for I2cPuppetSettings {
@@ -644,15 +683,38 @@ impl Default for I2cPuppetSettings {
             channel_capacity: 8,
             subscription_capacity: 32,
             max_subscriptions: 8,
-            poll_interval: Duration::from_millis(50),
+            poll_interval: Self::DEFAULT_POLL_INTERVAL,
             keymux: true,
             max_retries: 10,
-            min_backoff: Duration::from_micros(5),
+            min_backoff: Self::DEFAULT_MIN_BACKOFF,
+            irq_waker: None,
         }
     }
 }
 
 impl I2cPuppetSettings {
+    /// The default `i2c_puppet` poll interval.
+    pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+    /// The default initial retry backoff for key status polling.
+    pub const DEFAULT_MIN_BACKOFF: Duration = Duration::from_micros(5);
+
+    /// Provides a [`WaitCell`] that will be notified when the `i2c_puppet` IRQ
+    /// line is asserted.
+    ///
+    /// If the [`WaitCell`] is [`Some`], the `i2c_puppet` driver will poll key
+    /// status when the `WaitCell` is woken. If the [`WaitCell`] is [`None`], the
+    /// driver will only poll the `i2c_puppet` device when the poll interval
+    /// elapses.
+    ///
+    /// By default, this is [`None`].
+    pub fn with_irq_waker(self, irq_waker: impl Into<Option<&'static WaitCell>>) -> Self {
+        Self {
+            irq_waker: irq_waker.into(),
+            ..self
+        }
+    }
+
     fn retry(&self) -> Retry<WithMaxRetries<AlwaysRetry>, ExpBackoff> {
         let backoff = ExpBackoff::new(self.min_backoff).with_max_backoff(self.poll_interval);
         Retry::new(AlwaysRetry, backoff).with_max_retries(self.max_retries)


### PR DESCRIPTION
This commit updates the `i2c_puppet` driver to allow passing in an optional `WaitCell` via the `I2cPuppetSettings` struct. This `WaitCell` can be woken whenever the `i2c_puppet` IRQ line is asserted, to allow interrupt-driven operation. If no `WaitCell` is provided, the driver will run in polling-only mode, the current behavior.

We will still poll periodically when the poll interval elapses regardless of whether a `WaitCell` is provided. This way, we can ensure that the keyboard is always polled even if an interrupt request is occasionally missed. Future changes may allow disabling the periodic polling mode.