### PR TITLE
docs: populate Cargo metadata for every crate

### DIFF
--- a/oranda.json
+++ b/oranda.json
@@ -2,6 +2,9 @@
     "project": {
         "name": "Mnemos Project Overview",
         "description": "This page provides an overview of the entire MnemOS project. The other boxes on this page provide an overview of the individual crates that make up MnemOS.",
-        "readme_path": "./README.md"
+        "readme_path": "./README.md",
+        "repository": "https://github.com/tosc-rs/mnemos",
+        "homepage": "https://mnemos.dev",
+        "license": "MIT OR Apache-2.0"
     }
 }

--- a/platforms/allwinner-d1/boards/Cargo.toml
+++ b/platforms/allwinner-d1/boards/Cargo.toml
@@ -8,6 +8,10 @@ members = [
 name = "mnemos-d1"
 version = "0.1.0"
 edition = "2021"
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
+readme = "./README.md"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/platforms/allwinner-d1/core/Cargo.toml
+++ b/platforms/allwinner-d1/core/Cargo.toml
@@ -6,7 +6,10 @@ description = """
 A hardware abstraction library for the Allwinner D1, targeted
 at use in the mnemos operating system.
 """
-
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
+readme = "./README.md"
+license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/platforms/beepy/Cargo.toml
+++ b/platforms/beepy/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 description = """
 Hardware support specific to the SQFMI Beepy development board
 """
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
+readme = "./README.md"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/platforms/esp32c3-buddy/Cargo.toml
+++ b/platforms/esp32c3-buddy/Cargo.toml
@@ -12,8 +12,10 @@ authors = [
     "James Munns <james@onevariable.com>",
 ]
 edition = "2021"
-license = "MIT OR Apache-2.0"
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
 readme = "./README.md"
+license = "MIT OR Apache-2.0"
 
 [profile.release]
 # it turns out that we basically just "can't" build in debug mode (or our code

--- a/platforms/melpomene/Cargo.toml
+++ b/platforms/melpomene/Cargo.toml
@@ -6,6 +6,10 @@ description = """
 A desktop simulator, suitable for experimenting with MnemOS without
 any external hardware requirements.
 """
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
+readme = "./README.md"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/platforms/pomelo/Cargo.toml
+++ b/platforms/pomelo/Cargo.toml
@@ -6,6 +6,10 @@ description = """
 Pomelo is a browser-based simulator for MnemOS, compiled as
 a WASM binary.
 """
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
+readme = "./README.md"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 chrono = { version = "0.4.26", features = ["wasmbind"] }

--- a/source/abi/Cargo.toml
+++ b/source/abi/Cargo.toml
@@ -7,12 +7,13 @@ Data structures and definitions shared between the kernel and userspace.
 authors = ["James Munns <james@onevariable.com>"]
 edition = "2021"
 readme = "./README.md"
-
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
 categories = [
     "embedded",
     "no-std",
 ]
-license = "MIT OR Apache-2.0"
 
 [lib]
 name = "abi"

--- a/source/alloc/Cargo.toml
+++ b/source/alloc/Cargo.toml
@@ -6,12 +6,14 @@ for async handling of allocations, including turning allocation async.
 """
 version = "0.1.0"
 edition = "2021"
-
+readme = "./README.md"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
 categories = [
     "embedded",
     "no-std",
 ]
-license = "MIT OR Apache-2.0"
 
 [dependencies.cordyceps]
 version = "0.3"

--- a/source/forth3/Cargo.toml
+++ b/source/forth3/Cargo.toml
@@ -7,6 +7,10 @@ forth3 is a forth-inspired scripting language runtime. It can be used
 on targets without an allocator, and supports native builtins written
 in Rust, either as async or blocking functions.
 """
+readme = "./README.md"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/source/kernel/Cargo.toml
+++ b/source/kernel/Cargo.toml
@@ -8,15 +8,17 @@ no_std library crate.
 """
 authors = [
     "James Munns <james@onevariable.com>",
+    "Eliza Weisman <eliza@elizas.website>",
 ]
 edition = "2021"
 readme = "./README.md"
-
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
 categories = [
     "embedded",
     "no-std",
 ]
-license = "MIT OR Apache-2.0"
 
 build = "build.rs"
 

--- a/source/mstd/Cargo.toml
+++ b/source/mstd/Cargo.toml
@@ -2,16 +2,16 @@
 name = "mnemos-std"
 version = "0.1.0"
 description = "A tiny embedded operating system userspace library"
-repository = "https://github.com/jamesmunns/pellegrino"
 authors = ["James Munns <james@onevariable.com>"]
 edition = "2021"
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
 readme = "./README.md"
-
+license = "MIT OR Apache-2.0"
 categories = [
     "embedded",
     "no-std",
 ]
-license = "MIT OR Apache-2.0"
 
 [lib]
 name = "mstd"

--- a/source/sermux-proto/Cargo.toml
+++ b/source/sermux-proto/Cargo.toml
@@ -7,6 +7,10 @@ Wire types used by the `SerialMuxService` in the mnemos kernel. Extracted as a
 separate crate to allow external decoders (like `crowtty`) to share protocol
 definitions
 """
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
+readme = "./README.md"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/source/spitebuf/Cargo.toml
+++ b/source/spitebuf/Cargo.toml
@@ -7,6 +7,10 @@ Spitebuf is an async MPSC queue, based on the Vyukov algorithm
 originally implemented in the heapless crate. It can be used on
 targets with or without an allocator.
 """
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
+readme = "./README.md"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/source/trace-proto/Cargo.toml
+++ b/source/trace-proto/Cargo.toml
@@ -7,6 +7,10 @@ Wire types used by the binary tracing subscriber used on hardware targets.
 Extracted as a separate crate to allow external decoders (like `crowtty`)
 to share protocol definitions.
 """
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
+readme = "./README.md"
+license = "MIT OR Apache-2.0"
 
 [features]
 std = ["tracing-serde-structured/std", "serde/std"]

--- a/tools/crowtty/Cargo.toml
+++ b/tools/crowtty/Cargo.toml
@@ -7,6 +7,10 @@ crowtty is a host tool, aimed at speaking the sermux protocol with a
 simulator or physical target. It allows for receiving tracing messages,
 as well as mapping multiplexed "ports" as TCP sockets on the host.
 """
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
+readme = "./README.md"
+license = "MIT OR Apache-2.0"
 
 ### See `main.rs::serial` comments for why these duplicate dependencies exit
 

--- a/tools/dumbloader/Cargo.toml
+++ b/tools/dumbloader/Cargo.toml
@@ -2,6 +2,10 @@
 name = "dumbloader"
 version = "0.1.0"
 edition = "2021"
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
+readme = "./README.md"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tools/f3repl/Cargo.toml
+++ b/tools/f3repl/Cargo.toml
@@ -6,6 +6,10 @@ description = """
 f3repl is a host tool that provides a REPL of the forth3 VM. It is
 used for testing and development of forth3.
 """
+repository = "https://github.com/tosc-rs/mnemos"
+homepage = "https://mnemos.dev"
+readme = "./README.md"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Oranda will use this to generate GitHub links on the various crate pages.