### PR TITLE
docs: enable Oranda-generated changelog

### DIFF
--- a/oranda.json
+++ b/oranda.json
@@ -6,5 +6,8 @@
         "repository": "https://github.com/tosc-rs/mnemos",
         "homepage": "https://mnemos.dev",
         "license": "MIT OR Apache-2.0"
+    },
+    "components": {
+        "changelog": true
     }
 }


### PR DESCRIPTION
Now that #211 has added repo metadata for Oranda, it can generate a nice changelog page from our GitHub releases, automagically.