### PR TITLE
feat(docs): Switch to curlbash for oranda to save CI time

### DIFF
--- a/scripts/install-ci-deps.sh
+++ b/scripts/install-ci-deps.sh
@@ -9,7 +9,9 @@ mkdir -p ./target
 rustup toolchain install stable
 
 # Install Oranda
-# TODO: switch to curlbash once they release a prerelease binary!
-cargo install oranda -f \
-    --git https://github.com/axodotdev/oranda \
-    --rev ec4b0b8360b0adc1aa5240e213bf275b262670e2
+curl \
+    --proto '=https' \
+    --tlsv1.2 \
+    -LsSf \
+    https://github.com/axodotdev/oranda/releases/download/v0.3.0-prerelease.4/oranda-installer.sh \
+    | sh


### PR DESCRIPTION
This PR switches the CI to use the pre-compiled+released version of oranda in order to save CI time.