### PR TITLE
bug(docs): Add netlify dry run in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
   netlify_dryrun:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: install netlify deps
         run: ./scripts/install-ci-deps.sh
       - name: run netlify ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,3 +139,12 @@ jobs:
     - uses: extractions/setup-just@v1
     - name: run rustdoc
       run: just docs --message-format=json --document-private-items
+
+  # check that netlify CI should work
+  netlify_dryrun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install netlify deps
+        run: ./scripts/install-ci-deps.sh
+      - name: run netlify ci
+        run: ./scripts/run-ci-build.sh

--- a/scripts/install-ci-deps.sh
+++ b/scripts/install-ci-deps.sh
@@ -5,8 +5,8 @@ set -euxo pipefail
 # make sure the target output directory exists
 mkdir -p ./target
 
-# Install docs deps
-rustup toolchain install stable
+# Install libudev
+sudo apt-get update && sudo apt-get install -y libudev-dev
 
 # Install Oranda
 curl \

--- a/scripts/install-ci-deps.sh
+++ b/scripts/install-ci-deps.sh
@@ -15,3 +15,6 @@ curl \
     -LsSf \
     https://github.com/axodotdev/oranda/releases/download/v0.3.0-prerelease.4/oranda-installer.sh \
     | sh
+
+# Install just
+curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to .

--- a/scripts/run-ci-build.sh
+++ b/scripts/run-ci-build.sh
@@ -2,13 +2,7 @@
 
 set -euxo pipefail
 
-cargo doc \
-    --no-deps \
-    --all-features \
-    --document-private-items \
-    --workspace \
-    --exclude crowtty \
-    --exclude lichee-rv
+just docs
 
 rm -rf ./target/ci-publish || :
 mkdir -p ./target/ci-publish/

--- a/scripts/run-ci-build.sh
+++ b/scripts/run-ci-build.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-just docs
+./just docs
 
 rm -rf ./target/ci-publish || :
 mkdir -p ./target/ci-publish/


### PR DESCRIPTION
This PR changes the netlify CI to use `just doc`, and adds a GH action to run these steps
to give us an advance warning if the netlify job is likely to fail.