### PR TITLE
bug(docs): No double format arg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
     - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
     - uses: extractions/setup-just@v1
     - name: run rustdoc
-      run: just docs --message-format=json --document-private-items
+      run: just docs --document-private-items
 
   # check that netlify CI should work
   netlify_dryrun:


### PR DESCRIPTION
This PR removes a redundant specification of message format that was causing the docs CI to silently fail.