### PR TITLE
chore: make VS Code rust-analyzer run `just clippy`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,14 +2,14 @@
     "rust-analyzer.check.invocationLocation": "workspace",
     "rust-analyzer.cargo.buildScripts.invocationLocation": "workspace",
     "rust-analyzer.cargo.buildScripts.overrideCommand": [
-        "cargo",
-        "check",
+        "just",
+        "clippy",
         "--quiet",
         "--message-format=json",
         "--all-targets"
     ],
     "rust-analyzer.check.overrideCommand": [
-        "cargo",
+        "just",
         "clippy",
         "--quiet",
         "--message-format=json",

--- a/justfile
+++ b/justfile
@@ -70,38 +70,42 @@ default:
     @just --list
 
 # check all crates, across workspaces
-check: && (check-crate _d1_pkg) (check-crate _espbuddy_pkg) (check-crate _x86_pkg) (check-crate _x86_bootloader_pkg)
+check *ARGS: && (check-crate _d1_pkg ARGS) (check-crate _espbuddy_pkg ARGS) (check-crate _x86_pkg ARGS) (check-crate _x86_bootloader_pkg ARGS)
     #!/usr/bin/env bash
     set -euxo pipefail
     {{ _cargo }} check \
         --lib --bins --examples --tests --benches \
+        {{ ARGS }} \
         {{ _fmt_check_doc }}
 
 # check a crate.
-check-crate crate:
+check-crate crate *ARGS:
     #!/usr/bin/env bash
     set -euxo pipefail
     {{ _cargo }} check \
         --lib --bins --examples --tests --benches --all-features \
         --package {{ crate }} \
+        {{ ARGS }} \
         {{ _fmt_check_doc }}
 
 # run Clippy checks for all crates, across workspaces.
-clippy: && (clippy-crate _d1_pkg) (clippy-crate _espbuddy_pkg) (clippy-crate _x86_pkg) (clippy-crate _x86_bootloader_pkg)
+clippy *ARGS: && (clippy-crate _d1_pkg ARGS) (clippy-crate _espbuddy_pkg ARGS) (clippy-crate _x86_pkg ARGS) (clippy-crate _x86_bootloader_pkg ARGS)
     #!/usr/bin/env bash
     set -euxo pipefail
     {{ _cargo }} clippy \
         --lib --bins --examples --tests --benches --all-features \
+        {{ ARGS }} \
         {{ _fmt_clippy }}
 
 # run clippy checks for a crate.
 # NOTE: -Dwarnings is added by _fmt because reasons
-clippy-crate crate:
+clippy-crate crate *ARGS:
     #!/usr/bin/env bash
     set -euxo pipefail
     {{ _cargo }} clippy \
         --lib --bins --examples --tests --benches \
         --package {{ crate }} \
+        {{ ARGS }} \
         {{ _fmt_clippy }}
 
 # test all packages, across workspaces


### PR DESCRIPTION
This commit changes the VS Code settings so that rust-analyzer will run the `just clippy` command instead of `cargo clippy` when running checks. Because the `just clippy` command will check all crates in the workspace, not just the default members, this means VS Code users will get clippy warnings/errors for *all* crates in the workspace, even the ones that can't be checked as part of a global `cargo clippy --workspace` command. This should substantially improve the dev experience for VS Code users.

This change required adding an optional trailing `ARGS` argument to the `just clippy` recipe so that additional args can be passed to Clippy (in this case `--message-format=json --quiet --all-targets`, to mimic the way `rust-analyzer` normally invokes `cargo check`).