### PR TITLE
docs: add top-level docs to workspace page

### DIFF
--- a/assets/INDEX.md
+++ b/assets/INDEX.md
@@ -1,0 +1,36 @@
+
+<nav class="nav">
+    <img src = "https://mnemos.dev/mnemosprojectoverview/assets/logo-mnemos-1280px.png" width = "700" alt="MnemOS" />
+    <ul>
+        <li><a href="https://mnemos.dev/mnemosprojectoverview/book/">book</a></li>
+        <li><a href="https://mnemos.dev/doc/kernel/">API RustDoc</a></li>
+        <li><a href="https://github.com/tosc-rs/mnemos">GitHub</a></li>
+        <li><a href="https://mnemos.dev/mnemosprojectoverview/changelog/">dev updates</a></li>
+    </ul>
+</nav>
+<!-- oranda doesn't automatically put the markdown in a container with this
+     class for whatever reason? -->
+<div class="rendered-markdown">
+
+MnemOS ([`mnɛːmos`][name]) is a hobby-grade, experimental operating system for
+[small computers][d1] (and [bigger ones, too][x86]). The MnemOS kernel and
+userspace use a design based on asynchronous message passing, inspired by
+[Erlang] and [microkernels], although MnemOS is not a true microkernel.
+
+To learn more about MnemOS, you can:
+
+- read the [book]
+- check out the [project overview]
+- read [dev blogs]
+
+The following pages summarize various components of MnemOS:
+
+[name]: https://mnemos.dev/mnemosprojectoverview/book/#where-does-the-name-come-fromhow-do-i-pronounce-it
+[d1]: https://github.com/tosc-rs/mnemos/tree/main/platforms/allwinner-d1
+[x86]: https://github.com/tosc-rs/mnemos/tree/main/platforms/x86_64
+[Erlang]: https://en.wikipedia.org/wiki/Erlang_(programming_language)#Processes
+[microkernels]: https://en.wikipedia.org/wiki/Microkernel
+[book]: https://mnemos.dev/mnemosprojectoverview/book/
+[project overview]: https://mnemos.dev/mnemosprojectoverview/
+[dev blogs]: https://onevariable.com/blog/mnemos-moment-1/
+</div>

--- a/oranda-workspace.json
+++ b/oranda-workspace.json
@@ -3,7 +3,8 @@
     "static_dir": "assets"
   },
   "workspace": {
-    "name": "MnemOS",
+    "name": "",
+    "docs_path": "./assets/INDEX.md",
     "members": [
       {
         "slug": "MnemosProjectOverview",
@@ -62,5 +63,10 @@
         "path": "tools/f3repl"
       }
     ]
+  },
+  "project": {
+    "repository": "https://github.com/tosc-rs/mnemos",
+    "homepage": "https://mnemos.dev",
+    "license": "MIT OR Apache-2.0"
   }
 }

--- a/scripts/install-ci-deps.sh
+++ b/scripts/install-ci-deps.sh
@@ -10,7 +10,7 @@ curl \
     --proto '=https' \
     --tlsv1.2 \
     -LsSf \
-    https://github.com/axodotdev/oranda/releases/download/v0.3.0-prerelease.4/oranda-installer.sh \
+    https://github.com/axodotdev/oranda/releases/download/v0.3.1/oranda-installer.sh \
     | sh
 
 # Install just


### PR DESCRIPTION
Depends on #240

Oranda v0.3.1 now supports the ability to add a top-level Markdown file
to the workspace page, before the list of workspace components. This
branch updates the docs site to use the new version of Oranda, and adds
this top-level docs file so that our main landing page actually says
what MnemOS is.

![image](https://github.com/tosc-rs/mnemos/assets/2796466/5d3d7c22-a7ef-4fab-a5a0-3a272b064d6a)
