### PR TITLE
feat(kernel): add listeners to services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5040,6 +5040,7 @@ dependencies = [
  "tracing 0.1.37",
  "tracing-core 0.1.31",
  "tracing-serde-structured",
+ "tracing-subscriber",
  "uuid 1.4.1",
  "vergen",
 ]

--- a/platforms/allwinner-d1/core/src/drivers/spim.rs
+++ b/platforms/allwinner-d1/core/src/drivers/spim.rs
@@ -95,6 +95,8 @@ impl RegisteredDriver for SpiSender {
     type Request = SpiSenderRequest;
     type Response = SpiSenderResponse;
     type Error = SpiSenderError;
+    type Hello = ();
+    type ConnectError = core::convert::Infallible;
 
     const UUID: Uuid = uuid!("b5fd3487-08c4-4c0c-ae97-65dd1b151138");
 }
@@ -107,11 +109,11 @@ impl SpiSenderServer {
         kernel: &'static Kernel,
         queued: usize,
     ) -> Result<(), registry::RegistrationError> {
-        let (kprod, kcons) = KChannel::new_async(queued).await.split();
+        let (listener, registration) = registry::Listener::new(queued).await;
 
+        let reqs = listener.into_request_stream(queued).await;
         kernel
             .spawn(async move {
-                let kcons = kcons;
                 let spi = unsafe { &*SPI_DBI::PTR };
 
                 let txd_ptr: *mut u32 = spi.spi_txd.as_ptr();
@@ -119,9 +121,7 @@ impl SpiSenderServer {
                 let txd_ptr: *mut () = txd_ptr.cast();
 
                 loop {
-                    let msg: Message<SpiSender> = kcons.dequeue_async().await.unwrap();
-                    // println!("DEQUEUE");
-                    let Message { msg, reply } = msg;
+                    let Message { msg, reply } = reqs.next_request().await;
                     let SpiSenderRequest::Send(ref payload) = msg.body;
 
                     let len = payload.as_slice().len();
@@ -199,7 +199,7 @@ impl SpiSenderServer {
             .await;
 
         kernel
-            .with_registry(move |reg| reg.register_konly::<SpiSender>(&kprod))
+            .with_registry(move |reg| reg.register_konly::<SpiSender>(registration))
             .await?;
 
         Ok(())
@@ -224,8 +224,10 @@ pub struct SpiSenderClient {
 }
 
 impl SpiSenderClient {
-    pub async fn from_registry(kernel: &'static Kernel) -> Result<SpiSenderClient, ()> {
-        let hdl = kernel.with_registry(|reg| reg.get()).await.ok_or(())?;
+    pub async fn from_registry(
+        kernel: &'static Kernel,
+    ) -> Result<SpiSenderClient, registry::ConnectError<SpiSender>> {
+        let hdl = kernel.registry().await.get().await?;
 
         Ok(SpiSenderClient {
             hdl,

--- a/platforms/allwinner-d1/core/src/drivers/spim.rs
+++ b/platforms/allwinner-d1/core/src/drivers/spim.rs
@@ -14,7 +14,7 @@ use crate::dmac::{
 };
 use d1_pac::{GPIO, SPI_DBI};
 use kernel::{
-    comms::{kchannel::KChannel, oneshot::Reusable},
+    comms::oneshot::Reusable,
     maitake::sync::WaitCell,
     mnemos_alloc::containers::FixedVec,
     registry::{self, uuid, Envelope, KernelHandle, Message, RegisteredDriver, ReplyTo, Uuid},

--- a/platforms/allwinner-d1/core/src/drivers/spim.rs
+++ b/platforms/allwinner-d1/core/src/drivers/spim.rs
@@ -227,7 +227,7 @@ impl SpiSenderClient {
     pub async fn from_registry(
         kernel: &'static Kernel,
     ) -> Result<SpiSenderClient, registry::ConnectError<SpiSender>> {
-        let hdl = kernel.registry().await.get().await?;
+        let hdl = kernel.registry().await.connect().await?;
 
         Ok(SpiSenderClient {
             hdl,

--- a/platforms/allwinner-d1/core/src/drivers/uart.rs
+++ b/platforms/allwinner-d1/core/src/drivers/uart.rs
@@ -16,13 +16,10 @@ use crate::dmac::{
     Channel, ChannelMode,
 };
 use kernel::{
-    comms::{
-        bbq::{new_bidi_channel, BidiHandle, Consumer, GrantW, SpscProducer},
-        kchannel::{KChannel, KConsumer},
-    },
+    comms::bbq::{new_bidi_channel, BidiHandle, Consumer, GrantW, SpscProducer},
     maitake::sync::WaitCell,
     mnemos_alloc::containers::Box,
-    registry::{self, Message},
+    registry,
     services::simple_serial::{Request, Response, SimpleSerialError, SimpleSerialService},
     Kernel,
 };

--- a/platforms/beepy/src/i2c_puppet.rs
+++ b/platforms/beepy/src/i2c_puppet.rs
@@ -132,7 +132,11 @@ impl I2cPuppetClient {
     pub async fn from_registry_no_retry(
         kernel: &'static Kernel,
     ) -> Result<Self, registry::ConnectError<I2cPuppetService>> {
-        let handle = kernel.registry().await.get::<I2cPuppetService>().await?;
+        let handle = kernel
+            .registry()
+            .await
+            .connect::<I2cPuppetService>()
+            .await?;
 
         Ok(I2cPuppetClient {
             handle,

--- a/platforms/beepy/src/i2c_puppet.rs
+++ b/platforms/beepy/src/i2c_puppet.rs
@@ -35,6 +35,8 @@ impl RegisteredDriver for I2cPuppetService {
     type Request = Request;
     type Response = Response;
     type Error = Error;
+    type Hello = ();
+    type ConnectError = core::convert::Infallible;
 
     const UUID: Uuid = uuid!("f5f26c40-6079-4233-8894-39887b878dec");
 }

--- a/platforms/esp32c3-buddy/src/drivers/uart.rs
+++ b/platforms/esp32c3-buddy/src/drivers/uart.rs
@@ -10,13 +10,10 @@ use esp32c3_hal::{
 };
 
 use kernel::{
-    comms::{
-        bbq::{new_bidi_channel, BidiHandle, Consumer, GrantW, SpscProducer},
-        kchannel::{KChannel, KConsumer},
-    },
+    comms::bbq::{new_bidi_channel, BidiHandle, Consumer, GrantW, SpscProducer},
     maitake::sync::WaitCell,
     mnemos_alloc::containers::Box,
-    registry::{self, Message},
+    registry,
     services::simple_serial::{Request, Response, SimpleSerialError, SimpleSerialService},
     Kernel,
 };

--- a/platforms/esp32c3-buddy/src/drivers/uart.rs
+++ b/platforms/esp32c3-buddy/src/drivers/uart.rs
@@ -63,25 +63,23 @@ impl C3Uart<UART0> {
 }
 
 impl<T: Instance> C3Uart<T> {
-    async fn serial_server(handle: BidiHandle, kcons: KConsumer<Message<SimpleSerialService>>) {
-        loop {
-            if let Ok(req) = kcons.dequeue_async().await {
-                let Request::GetPort = req.msg.body;
-                let resp = req.msg.reply_with(Ok(Response::PortHandle { handle }));
-                let _ = req.reply.reply_konly(resp).await;
-                break;
-            }
-        }
+    async fn serial_server(
+        handle: BidiHandle,
+        reqs: registry::listener::RequestStream<SimpleSerialService>,
+    ) {
+        let req = reqs.next_request().await;
+        let Request::GetPort = req.msg.body;
+        let resp = req.msg.reply_with(Ok(Response::PortHandle { handle }));
+        let _ = req.reply.reply_konly(resp).await;
 
         // And deny all further requests after the first
         loop {
-            if let Ok(req) = kcons.dequeue_async().await {
-                let Request::GetPort = req.msg.body;
-                let resp = req
-                    .msg
-                    .reply_with(Err(SimpleSerialError::AlreadyAssignedPort));
-                let _ = req.reply.reply_konly(resp).await;
-            }
+            let req = reqs.next_request().await;
+            let Request::GetPort = req.msg.body;
+            let resp = req
+                .msg
+                .reply_with(Err(SimpleSerialError::AlreadyAssignedPort));
+            let _ = req.reply.reply_konly(resp).await;
         }
     }
 
@@ -113,12 +111,11 @@ impl<T: Instance> C3Uart<T> {
         cap_in: usize,
         cap_out: usize,
     ) -> Result<(), registry::RegistrationError> {
-        let (kprod, kcons) = KChannel::<Message<SimpleSerialService>>::new_async(4)
-            .await
-            .split();
+        let (listener, registration) = registry::Listener::new(4).await;
+        let reqs = listener.into_request_stream(4).await;
         let (fifo_a, fifo_b) = new_bidi_channel(cap_in, cap_out).await;
 
-        let _server_hdl = k.spawn(Self::serial_server(fifo_b, kcons)).await;
+        let _server_hdl = k.spawn(Self::serial_server(fifo_b, reqs)).await;
 
         let (prod, cons) = fifo_a.split();
         let _send_hdl = k.spawn(async move { self.sending(cons).await }).await;
@@ -128,7 +125,7 @@ impl<T: Instance> C3Uart<T> {
         let old = UART_RX.swap(leaked_prod, Ordering::AcqRel);
         assert_eq!(old, null_mut());
 
-        k.with_registry(|reg| reg.register_konly::<SimpleSerialService>(&kprod))
+        k.with_registry(|reg| reg.register_konly::<SimpleSerialService>(registration))
             .await?;
 
         Ok(())

--- a/platforms/esp32c3-buddy/src/drivers/usb_serial.rs
+++ b/platforms/esp32c3-buddy/src/drivers/usb_serial.rs
@@ -2,12 +2,9 @@ use esp32c3_hal::{peripherals::USB_DEVICE, prelude::*};
 
 use futures::FutureExt;
 use kernel::{
-    comms::{
-        bbq::{new_bidi_channel, BidiHandle, GrantW},
-        kchannel::{KChannel, KConsumer},
-    },
+    comms::bbq::{new_bidi_channel, BidiHandle, GrantW},
     maitake::sync::WaitCell,
-    registry::{self, Message},
+    registry,
     services::simple_serial::{Request, Response, SimpleSerialError, SimpleSerialService},
     Kernel,
 };

--- a/platforms/esp32c3-buddy/src/drivers/usb_serial.rs
+++ b/platforms/esp32c3-buddy/src/drivers/usb_serial.rs
@@ -60,26 +60,23 @@ impl UsbSerialServer {
         Self { dev }
     }
 
-    async fn serial_server(handle: BidiHandle, kcons: KConsumer<Message<SimpleSerialService>>) {
-        loop {
-            // esp_println::println!("get port");
-            if let Ok(req) = kcons.dequeue_async().await {
-                let Request::GetPort = req.msg.body;
-                let resp = req.msg.reply_with(Ok(Response::PortHandle { handle }));
-                let _ = req.reply.reply_konly(resp).await;
-                break;
-            }
-        }
+    async fn serial_server(
+        handle: BidiHandle,
+        reqs: registry::listener::RequestStream<SimpleSerialService>,
+    ) {
+        let req = reqs.next_request().await;
+        let Request::GetPort = req.msg.body;
+        let resp = req.msg.reply_with(Ok(Response::PortHandle { handle }));
+        let _ = req.reply.reply_konly(resp).await;
 
         // And deny all further requests after the first
         loop {
-            if let Ok(req) = kcons.dequeue_async().await {
-                let Request::GetPort = req.msg.body;
-                let resp = req
-                    .msg
-                    .reply_with(Err(SimpleSerialError::AlreadyAssignedPort));
-                let _ = req.reply.reply_konly(resp).await;
-            }
+            let req = reqs.next_request().await;
+            let Request::GetPort = req.msg.body;
+            let resp = req
+                .msg
+                .reply_with(Err(SimpleSerialError::AlreadyAssignedPort));
+            let _ = req.reply.reply_konly(resp).await;
         }
     }
 
@@ -179,16 +176,15 @@ impl UsbSerialServer {
         cap_in: usize,
         cap_out: usize,
     ) -> Result<(), registry::RegistrationError> {
-        let (kprod, kcons) = KChannel::<Message<SimpleSerialService>>::new_async(4)
-            .await
-            .split();
+        let (listener, registration) = registry::Listener::new(4).await;
+        let reqs = listener.into_request_stream(4).await;
         let (fifo_a, fifo_b) = new_bidi_channel(cap_in, cap_out).await;
 
-        k.spawn(Self::serial_server(fifo_b, kcons)).await;
+        k.spawn(Self::serial_server(fifo_b, reqs)).await;
 
         k.spawn(self.worker(fifo_a)).await;
 
-        k.with_registry(|reg| reg.register_konly::<SimpleSerialService>(&kprod))
+        k.with_registry(|reg| reg.register_konly::<SimpleSerialService>(registration))
             .await?;
 
         Ok(())

--- a/platforms/melpomene/src/sim_drivers/emb_display.rs
+++ b/platforms/melpomene/src/sim_drivers/emb_display.rs
@@ -33,8 +33,7 @@ use maitake::sync::Mutex;
 use melpo_config::DisplayConfig;
 use mnemos_alloc::containers::{Arc, HeapArray};
 use mnemos_kernel::{
-    comms::kchannel::{KChannel, KConsumer},
-    registry::{self, Message},
+    registry,
     services::{
         emb_display::{
             DisplayMetadata, EmbDisplayService, FrameChunk, FrameError, FrameKind, MonoChunk,

--- a/platforms/melpomene/src/sim_drivers/tcp_serial.rs
+++ b/platforms/melpomene/src/sim_drivers/tcp_serial.rs
@@ -1,10 +1,7 @@
 use melpo_config::TcpUartConfig;
 use mnemos_kernel::{
-    comms::{
-        bbq::{new_bidi_channel, BidiHandle},
-        kchannel::KChannel,
-    },
-    registry::{self, Message},
+    comms::bbq::{new_bidi_channel, BidiHandle},
+    registry,
     services::simple_serial::{Request, Response, SimpleSerialError, SimpleSerialService},
     Kernel,
 };
@@ -28,10 +25,9 @@ impl TcpSerial {
     ) -> Result<(), registry::RegistrationError> {
         let (a_ring, b_ring) =
             new_bidi_channel(settings.incoming_size, settings.outgoing_size).await;
-        let (prod, cons) =
-            KChannel::<Message<SimpleSerialService>>::new_async(settings.kchannel_depth)
-                .await
-                .split();
+        let (listener, registration) = registry::Listener::new(settings.kchannel_depth).await;
+        let reqs = listener.into_request_stream(settings.kchannel_depth).await;
+
         let socket_addr = &settings.socket_addr;
         let listener = TcpListener::bind(socket_addr).await.unwrap();
         tracing::info!(
@@ -44,15 +40,16 @@ impl TcpSerial {
                 let handle = b_ring;
 
                 // Reply to the first request, giving away the serial port
-                let req = cons.dequeue_async().await.map_err(drop).unwrap();
+                let req = reqs.next_request().await;
                 let Request::GetPort = req.msg.body;
                 let resp = req.msg.reply_with(Ok(Response::PortHandle { handle }));
 
                 req.reply.reply_konly(resp).await.map_err(drop).unwrap();
 
                 // And deny all further requests after the first
+                // TODO(eliza): use a connect error for this?
                 loop {
-                    let req = cons.dequeue_async().await.map_err(drop).unwrap();
+                    let req = reqs.next_request().await;
                     let Request::GetPort = req.msg.body;
                     let resp = req
                         .msg
@@ -83,7 +80,7 @@ impl TcpSerial {
         );
 
         kernel
-            .with_registry(|reg| reg.register_konly::<SimpleSerialService>(&prod))
+            .with_registry(|reg| reg.register_konly::<SimpleSerialService>(registration))
             .await
     }
 }

--- a/platforms/pomelo/src/sim_drivers/emb_display.rs
+++ b/platforms/pomelo/src/sim_drivers/emb_display.rs
@@ -31,7 +31,7 @@ use embedded_graphics_web_simulator::{
 use mnemos_kernel::{
     comms::kchannel::{KChannel, KConsumer},
     mnemos_alloc::containers::HeapArray,
-    registry::{Envelope, Message, OpenEnvelope, ReplyTo},
+    registry::{self, listener, Envelope, Message, OpenEnvelope, ReplyTo},
     services::{
         emb_display::{
             DisplayMetadata, EmbDisplayService, FrameChunk, FrameError, FrameKind, MonoChunk,
@@ -91,12 +91,9 @@ impl SimDisplay {
         tracing::debug!("initializing SimDisplay server ({width}x{height})...");
 
         // TODO settings.kchannel_depth
-        let (cmd_prod, cmd_cons) = KChannel::new_async(2).await.split();
-        let commander = CommanderTask {
-            cmd: cmd_cons,
-            width,
-            height,
-        };
+        let (listener, registration) = registry::Listener::new(2).await;
+        let cmd = listener.into_request_stream(2).await;
+        let commander = CommanderTask { cmd, width, height };
 
         kernel.spawn(commander.run(kernel, width, height)).await;
 
@@ -105,7 +102,7 @@ impl SimDisplay {
         kernel.spawn(key_event_handler(key_rx, keymux)).await;
 
         kernel
-            .with_registry(|reg| reg.register_konly::<EmbDisplayService>(&cmd_prod))
+            .with_registry(|reg| reg.register_konly::<EmbDisplayService>(registration))
             .await
             .map_err(|_| FrameError::DisplayAlreadyExists)?;
 
@@ -154,7 +151,7 @@ impl SimDisplay {
 /// async function that will process requests, and periodically redraw the
 /// framebuffer.
 struct CommanderTask {
-    cmd: KConsumer<Message<EmbDisplayService>>,
+    cmd: listener::RequestStream<EmbDisplayService>,
     width: u32,
     height: u32,
 }
@@ -234,8 +231,7 @@ impl CommanderTask {
         let draw_callback = Box::leak(Box::new(draw_callback));
 
         loop {
-            let msg = self.cmd.dequeue_async().await.map_err(drop).unwrap();
-            let (req, env, reply_tx) = msg.split();
+            let (req, env, reply_tx) = self.cmd.next_request().await.split();
 
             match req {
                 Request::Draw(FrameChunk::Mono(fc)) => {

--- a/platforms/pomelo/src/sim_drivers/emb_display.rs
+++ b/platforms/pomelo/src/sim_drivers/emb_display.rs
@@ -31,7 +31,7 @@ use embedded_graphics_web_simulator::{
 use mnemos_kernel::{
     comms::kchannel::{KChannel, KConsumer},
     mnemos_alloc::containers::HeapArray,
-    registry::{self, listener, Envelope, Message, OpenEnvelope, ReplyTo},
+    registry::{self, listener, Envelope, OpenEnvelope, ReplyTo},
     services::{
         emb_display::{
             DisplayMetadata, EmbDisplayService, FrameChunk, FrameError, FrameKind, MonoChunk,

--- a/platforms/pomelo/src/sim_drivers/serial.rs
+++ b/platforms/pomelo/src/sim_drivers/serial.rs
@@ -6,11 +6,8 @@ use futures::{
 };
 use futures_util::{FutureExt, Stream, StreamExt};
 use mnemos_kernel::{
-    comms::{
-        bbq::{new_bidi_channel, BidiHandle},
-        kchannel::KChannel,
-    },
-    registry::{self, Message},
+    comms::bbq::{new_bidi_channel, BidiHandle},
+    registry,
     services::simple_serial::{Request, Response, SimpleSerialError, SimpleSerialService},
     Kernel,
 };

--- a/source/kernel/Cargo.toml
+++ b/source/kernel/Cargo.toml
@@ -141,3 +141,16 @@ vergen = { version = "8.0.0", features = ["cargo", "git", "gitcl", "rustc",] }
 version = "0.3.21"
 features = ["async-await", "executor"]
 default-features = false
+
+[dev-dependencies.mnemos-alloc]
+version = "0.1.0"
+features = ["use-std"]
+path = "../alloc"
+
+[dev-dependencies.tracing-subscriber]
+version = "0.3.17"
+features = ["fmt", "env-filter"]
+
+[dev-dependencies.postcard]
+version = "1.0.1"
+features = ["use-std"]

--- a/source/kernel/src/comms/kchannel.rs
+++ b/source/kernel/src/comms/kchannel.rs
@@ -3,7 +3,8 @@
 //! Kernel Channels are an async/await, MPSC queue, with a fixed backing storage (e.g. they are bounded).
 use core::{cell::UnsafeCell, ops::Deref, ptr::NonNull};
 use mnemos_alloc::containers::{Arc, ArrayBuf};
-use spitebuf::{DequeueError, EnqueueError, MpScQueue};
+use spitebuf::MpScQueue;
+pub use spitebuf::{DequeueError, EnqueueError};
 use tracing;
 
 /// A Kernel Channel

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -90,11 +90,7 @@ use abi::{
     syscall::{KernelResponse, UserRequest},
 };
 use comms::kchannel::KChannel;
-use core::{
-    convert::identity,
-    future::{Future, IntoFuture},
-    ptr::NonNull,
-};
+use core::{convert::identity, future::Future, ptr::NonNull};
 pub use embedded_hal_async;
 pub use maitake;
 use maitake::{

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -90,7 +90,11 @@ use abi::{
     syscall::{KernelResponse, UserRequest},
 };
 use comms::kchannel::KChannel;
-use core::{convert::identity, future::Future, ptr::NonNull};
+use core::{
+    convert::identity,
+    future::{Future, IntoFuture},
+    ptr::NonNull,
+};
 pub use embedded_hal_async;
 pub use maitake;
 use maitake::{
@@ -230,6 +234,10 @@ impl Kernel {
     {
         let mut guard = self.registry.lock().await;
         f(&mut guard)
+    }
+
+    pub async fn registry(&'static self) -> maitake::sync::MutexGuard<'_, Registry> {
+        self.registry.lock().await
     }
 
     #[track_caller]

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -67,7 +67,7 @@
 //! The pieces that exist currently are likely to be removed or reworked heavily before they are
 //! usable, and should be considered nonfunctional at the moment.
 
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![allow(clippy::missing_safety_doc)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(async_fn_in_trait)] // needed for `embedded-hal-async`
@@ -84,6 +84,9 @@ pub mod retry;
 #[cfg(feature = "serial-trace")]
 pub mod serial_trace;
 pub mod services;
+
+#[cfg(test)]
+pub(crate) mod test_util;
 
 use abi::{
     bbqueue_ipc::BBBuffer,

--- a/source/kernel/src/registry/listener.rs
+++ b/source/kernel/src/registry/listener.rs
@@ -1,0 +1,102 @@
+use super::{Message, RegisteredDriver};
+use crate::comms::{
+    kchannel::{KChannel, KConsumer, KProducer},
+    oneshot,
+};
+
+/// A listener for incoming [`Connection`]s to a [`RegisteredDriver`].
+pub struct Listener<D: RegisteredDriver> {
+    rx: KConsumer<Connection<D>>,
+}
+
+/// A registration for a [`RegisteredDriver`]. This type is provided to
+/// [`Registry::register`] in order to add the driver to the registry.
+pub struct Registration<D: RegisteredDriver> {
+    pub(super) tx: KProducer<Connection<D>>,
+}
+
+/// A connection request received from a [`Listener`].
+#[non_exhaustive]
+pub struct Connection<D: RegisteredDriver> {
+    pub hello: D::Hello,
+    pub accept: Accept<D>,
+    // TODO(eliza): consider adding client metadata here?
+}
+
+/// Accepts or rejects an incoming [`Connection`].
+pub struct Accept<D: RegisteredDriver> {
+    pub(super) reply: oneshot::Sender<Result<Channel<D>, D::ConnectError>>,
+}
+
+pub enum AcceptError {
+    /// The client of the connection has cancelled the connection.
+    Canceled,
+}
+
+type Channel<D> = KProducer<Message<D>>;
+
+// === impl Listener ===
+
+impl<D: RegisteredDriver> Listener<D> {
+    pub async fn new(incoming_capacity: usize) -> (Self, Registration<D>) {
+        let (tx, rx) = KChannel::new(incoming_capacity).split();
+        let registration = Registration { tx };
+        let listener = Self { rx };
+        (listener, registration)
+    }
+
+    pub async fn next(&mut self) -> Connection<D> {
+        self.rx
+            .dequeue_async()
+            .await
+            .expect("the kernel should never drop the sender end of a service's incoming channel!")
+    }
+
+    pub async fn try_next(&mut self) -> Option<Connection<D>> {
+        self.rx.dequeue_sync()
+    }
+}
+
+// === impl Connection ===
+
+impl<D: RegisteredDriver> Connection<D> {
+    /// Accept the connection, returning the provided `channel` to the client.
+    pub fn accept(self, channel: Channel<D>) -> Result<(), AcceptError> {
+        self.accept.accept(channel)
+    }
+
+    /// Reject the connection, returning the provided `error` to the client.
+    pub fn reject(self, error: D::ConnectError) -> Result<(), AcceptError> {
+        self.accept.reject(error)
+    }
+
+    pub fn split(self) -> (D::Hello, Accept<D>) {
+        (self.hello, self.accept)
+    }
+}
+
+// === impl Accept ===
+
+impl<D: RegisteredDriver> Accept<D> {
+    /// Accept the connection, returning the provided `channel` to the client.
+    pub fn accept(self, channel: Channel<D>) -> Result<(), AcceptError> {
+        match self.reply.send(Ok(channel)) {
+            Ok(()) => Ok(()),
+            Err(oneshot::ReusableError::ChannelClosed) => Err(AcceptError::Canceled),
+            Err(error) => unreachable!(
+                "we are the sender, so we should only ever see `ChannelClosed` errors: {error:?}"
+            ),
+        }
+    }
+
+    /// Reject the connection, returning the provided `error` to the client.
+    pub fn reject(self, error: D::ConnectError) -> Result<(), AcceptError> {
+        match self.reply.send(Err(error)) {
+            Ok(()) => Ok(()),
+            Err(oneshot::ReusableError::ChannelClosed) => Err(AcceptError::Canceled),
+            Err(error) => unreachable!(
+                "we are the sender, so we should only ever see `ChannelClosed` errors: {error:?}"
+            ),
+        }
+    }
+}

--- a/source/kernel/src/registry/listener.rs
+++ b/source/kernel/src/registry/listener.rs
@@ -109,7 +109,7 @@ impl<D: RegisteredDriver> Listener<D> {
     ///
     /// To return an incoming connection if one is available, *without* waiting,
     /// use the [`try_next`](Self::try_next) method.
-    pub async fn next(&self) -> Handshake<D> {
+    pub async fn handshake(&self) -> Handshake<D> {
         self.rx
             .dequeue_async()
             .await
@@ -265,11 +265,11 @@ impl<D: RegisteredDriver> RequestStream<D> {
                             // die --- new receivers may be created by new
                             // incoming connections. So, wait for the next
                             // connection request.
-                            self.listener.next().await
+                            self.listener.handshake().await
                         }
                     }
                 },
-                conn = self.listener.next().fuse() => {
+                conn = self.listener.handshake().fuse() => {
                     conn
                 }
             };

--- a/source/kernel/src/registry/listener.rs
+++ b/source/kernel/src/registry/listener.rs
@@ -3,6 +3,7 @@ use crate::comms::{
     kchannel::{KChannel, KConsumer, KProducer},
     oneshot,
 };
+use futures::{select_biased, FutureExt};
 
 /// A listener for incoming [`Connection`]s to a [`RegisteredDriver`].
 pub struct Listener<D: RegisteredDriver> {
@@ -26,6 +27,39 @@ pub struct Connection<D: RegisteredDriver> {
 /// Accepts or rejects an incoming [`Connection`].
 pub struct Accept<D: RegisteredDriver> {
     pub(super) reply: oneshot::Sender<Result<Channel<D>, D::ConnectError>>,
+}
+
+/// A stream of incoming requests from all clients.
+///
+/// This type is used when a service wishes all clients to send requests to the
+/// same channel. It automatically accepts all incoming connections with the
+/// same request channel, and returns any received requests to the service.
+///
+/// A [`Listener`] can be converted into a [`RequestStream`] using the
+/// [`Listener::into_request_stream`] method.
+///
+/// Any [`Hello`] messages received from new connections are discarded by the
+/// [`RequestStream`], and connections are never [`reject`]ed with a
+/// [`ConnectError`].
+///
+/// Note, however, that this type does *not* require that the
+/// [`RegisteredDriver`] type's [`RegisteredDriver::Hello`] type is [`()`], or
+/// that its [`RegisteredDriver::ConnectError`] type is
+/// [`core::convert::Infallible`]. This is because a [`RegisteredDriver`]
+/// *declaration* which includes a [`Hello`] and/or [`ConnectError`] type may be
+/// implemented by a server that does not care about [`Hello`]s or about
+/// [`reject`]ing connections on some platforms. Other platforms may
+/// implement the same [`RegisteredDriver`] declaration with a service that does
+/// consume [`Hello`]s or [`reject`] connections, but `RequestStream` is still
+/// usable with that `RegisteredDriver` in cases where the implementation does
+/// not need those features.
+///
+/// [`reject`]: Connection::reject
+/// [`Hello`]: RegisteredDriver::Hello
+/// [`ConnectError`]: RegisteredDriver::ConnectError
+pub struct RequestStream<D: RegisteredDriver> {
+    chan: KConsumer<Message<D>>,
+    listener: Listener<D>,
 }
 
 pub enum AcceptError {
@@ -54,6 +88,29 @@ impl<D: RegisteredDriver> Listener<D> {
 
     pub async fn try_next(&mut self) -> Option<Connection<D>> {
         self.rx.dequeue_sync()
+    }
+
+    /// Converts this `Listener` into a [`RequestStream`] --- a simple stream of
+    /// incoming requests, which [accepts](Self::accept) all connections with
+    /// the same channel.
+    ///
+    /// The next request from any client may be awaited from the
+    /// [`RequestStream`] using the [`RequestStream::next_request`] method.
+    ///
+    /// This is useful when a service wishes to handle all requests with the
+    /// same channel, rather than spawning separate worker tasks for each
+    /// client, or routing requests based on a connection's [`Hello`] message.
+    ///
+    /// **Note**: Any [`Hello`] messages received from new connections are
+    /// discarded by the [`RequestStream`].
+    ///
+    /// [`Hello`]: RegisteredDriver::Hello
+    pub async fn into_request_stream(self, capacity: usize) -> RequestStream<D> {
+        let chan = KChannel::new(capacity).into_consumer();
+        RequestStream {
+            chan,
+            listener: self,
+        }
     }
 }
 
@@ -97,6 +154,50 @@ impl<D: RegisteredDriver> Accept<D> {
             Err(error) => unreachable!(
                 "we are the sender, so we should only ever see `ChannelClosed` errors: {error:?}"
             ),
+        }
+    }
+}
+
+// === impl RequestStream ===
+
+impl<D: RegisteredDriver> RequestStream<D> {
+    /// Returns the next incoming message, accepting any new connections until a
+    /// message is received.
+    ///
+    /// If all request senders have been dropped, this method waits until a new
+    /// connection is available to accept, and then waits for a message from a
+    /// client.
+    ///
+    /// **Note**: Any [`Hello`] messages received from new connections are
+    /// discarded.
+    ///
+    /// [`Hello`]: RegisteredDriver::Hello
+    pub async fn next_request(&mut self) -> Message<D> {
+        loop {
+            let conn = select_biased! {
+                msg = self.chan.dequeue_async().fuse() => {
+                    match msg {
+                        Ok(msg) => return msg,
+                        Err(_) => {
+                            // if the request stream is "closed", that just
+                            // means that all the senders are dropped. That
+                            // doesn't mean that it's time for the service to
+                            // die --- new receivers may be created by new
+                            // incoming connections. So, wait for the next
+                            // connection request.
+                            self.listener.next().await
+                        }
+                    }
+                },
+                conn = self.listener.next().fuse() => {
+                    conn
+                }
+            };
+
+            tracing::trace!("accepting new connection...");
+            if conn.accept(self.chan.producer()).is_err() {
+                tracing::debug!("incoming connection canceled");
+            }
         }
     }
 }

--- a/source/kernel/src/registry/listener.rs
+++ b/source/kernel/src/registry/listener.rs
@@ -6,6 +6,7 @@ use crate::comms::{
 use futures::{select_biased, FutureExt};
 
 /// A listener for incoming connection [`Handshake`]s to a [`RegisteredDriver`].
+#[must_use = "a `Listener` does nothing if incoming connections are not accepted"]
 pub struct Listener<D: RegisteredDriver> {
     rx: KConsumer<Handshake<D>>,
 }
@@ -14,6 +15,7 @@ pub struct Listener<D: RegisteredDriver> {
 /// [`Registry::register`] in order to add the driver to the registry.
 ///
 /// [`Registry::register`]: crate::registry::Registry::register
+#[must_use = "a `Registration` does nothing if not registered with a `Registry`"]
 pub struct Registration<D: RegisteredDriver> {
     pub(super) tx: KProducer<Handshake<D>>,
 }
@@ -26,6 +28,7 @@ pub struct Registration<D: RegisteredDriver> {
 /// potentially using the value of the [`Hello`] message to make this decision.
 ///
 /// [`Hello`]: RegisteredDriver::Hello
+#[must_use = "a `Handshake` does nothing if not `accept`ed or `reject`ed"]
 #[non_exhaustive]
 pub struct Handshake<D: RegisteredDriver> {
     /// The [`RegisteredDriver::Hello`] message sent by the client to identify
@@ -44,6 +47,7 @@ pub struct Handshake<D: RegisteredDriver> {
 }
 
 /// Accepts or rejects an incoming connection [`Handshake`].
+#[must_use = "an `Accept` does nothing if not `accept`ed or `reject`ed"]
 pub struct Accept<D: RegisteredDriver> {
     pub(super) reply: oneshot::Sender<Result<Channel<D>, D::ConnectError>>,
 }
@@ -76,6 +80,7 @@ pub struct Accept<D: RegisteredDriver> {
 /// [`reject`]: Handshake::reject
 /// [`Hello`]: RegisteredDriver::Hello
 /// [`ConnectError`]: RegisteredDriver::ConnectError
+#[must_use = "a `RequestStream` does nothing if `next_request` is not called"]
 pub struct RequestStream<D: RegisteredDriver> {
     chan: KConsumer<Message<D>>,
     listener: Listener<D>,

--- a/source/kernel/src/registry/listener.rs
+++ b/source/kernel/src/registry/listener.rs
@@ -79,14 +79,14 @@ impl<D: RegisteredDriver> Listener<D> {
         (listener, registration)
     }
 
-    pub async fn next(&mut self) -> Connection<D> {
+    pub async fn next(&self) -> Connection<D> {
         self.rx
             .dequeue_async()
             .await
             .expect("the kernel should never drop the sender end of a service's incoming channel!")
     }
 
-    pub async fn try_next(&mut self) -> Option<Connection<D>> {
+    pub async fn try_next(&self) -> Option<Connection<D>> {
         self.rx.dequeue_sync()
     }
 
@@ -172,7 +172,7 @@ impl<D: RegisteredDriver> RequestStream<D> {
     /// discarded.
     ///
     /// [`Hello`]: RegisteredDriver::Hello
-    pub async fn next_request(&mut self) -> Message<D> {
+    pub async fn next_request(&self) -> Message<D> {
         loop {
             let conn = select_biased! {
                 msg = self.chan.dequeue_async().fuse() => {

--- a/source/kernel/src/registry/mod.rs
+++ b/source/kernel/src/registry/mod.rs
@@ -462,7 +462,7 @@ impl Registry {
             // Safety: we just checked that the type IDs match above.
             item.value
                 .conn_prod
-                .clone_typed::<listener::Connection<RD>>()
+                .clone_typed::<listener::Handshake<RD>>()
         };
 
         // TODO(eliza): it would be nice if we could reuse the oneshot receiver
@@ -474,7 +474,7 @@ impl Registry {
             .await
             .expect("we just created the oneshot, so this should never fail");
         // send the connection request...
-        tx.enqueue_async(listener::Connection {
+        tx.enqueue_async(listener::Handshake {
             hello,
             accept: listener::Accept { reply }
         }).await.map_err(|err| match err {

--- a/source/kernel/src/registry/mod.rs
+++ b/source/kernel/src/registry/mod.rs
@@ -96,8 +96,9 @@ pub trait RegisteredDriver {
     /// This is the UUID of the driver service
     const UUID: Uuid;
 
-    /// Get the type_id used to make sure that driver instances are correctly typed.
-    /// Corresponds to the same type ID as `(Self::Request, Self::Response, Self::Error)`
+    /// Get the [`TypeId`] used to make sure that driver instances are correctly typed.
+    /// Corresponds to the same type ID as `(`[`Self::Request`]`, `[`Self::Response`]`,
+    /// `[`Self::Error`]`, `[`Self::Hello`]`, `[`Self::ConnectError`]`)`.
     fn type_id() -> RegistryType {
         RegistryType {
             tuple_type_id: TypeId::of::<(

--- a/source/kernel/src/registry/mod.rs
+++ b/source/kernel/src/registry/mod.rs
@@ -20,8 +20,10 @@ use crate::comms::{
 };
 
 pub mod listener;
-
 pub use self::listener::{Listener, Registration};
+
+#[cfg(test)]
+mod tests;
 
 /// A partial list of known UUIDs of driver services
 pub mod known_uuids {
@@ -608,9 +610,9 @@ impl Registry {
     /// Driver services registered with [Registry::register_konly] cannot be retrieved via
     /// a call to [Registry::connect_userspace_with_hello].
     #[tracing::instrument(
-        name = "Registry::connect_userspace",
+        name = "Registry::connect_userspace_with_hello",
         level = "debug",
-        skip(self),
+        skip(self, scheduler),
         fields(uuid = ?RD::UUID),
     )]
     pub async fn connect_userspace_with_hello<RD>(

--- a/source/kernel/src/registry/tests.rs
+++ b/source/kernel/src/registry/tests.rs
@@ -1,0 +1,221 @@
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use super::*;
+use crate::{comms, test_util::TestKernel, Kernel};
+
+struct TestService;
+
+impl RegisteredDriver for TestService {
+    type Request = TestMessage;
+    type Response = TestMessage;
+    type Error = TestMessage;
+    type Hello = TestMessage;
+    type ConnectError = TestMessage;
+    const UUID: Uuid = uuid!("05bcd4b7-dd81-434a-a958-f18ee84f8635");
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct TestMessage(usize);
+
+#[test]
+fn konly_connect() {
+    TestKernel::run(|k| async move {
+        let (listener, registration) = listener::Listener::<TestService>::new(2).await;
+
+        // server
+        k.spawn(async move {
+            loop {
+                let conn = listener.handshake().await;
+                if conn.hello == TestMessage(1) {
+                    let (tx, rx) = crate::comms::kchannel::KChannel::new_async(2).await.split();
+                    k.spawn(async move {
+                        while let Ok(Message { msg, reply }) = rx.dequeue_async().await {
+                            reply
+                                .reply_konly(msg.reply_with_body(|TestMessage(val)| {
+                                    tracing::info!(val, "received request");
+                                    Ok(TestMessage(val + 1))
+                                }))
+                                .await
+                                .unwrap();
+                        }
+                    })
+                    .await;
+                    conn.accept(tx).unwrap();
+                } else {
+                    conn.reject(TestMessage(666)).unwrap();
+                }
+            }
+        })
+        .await;
+
+        k.with_registry(|r| r.register_konly(registration))
+            .await
+            .unwrap();
+
+        let reply = comms::oneshot::Reusable::new_async().await;
+        let mut client1 = k
+            .registry()
+            .await
+            .connect_with_hello::<TestService>(TestMessage(1))
+            .await
+            .expect("connect should succeed");
+
+        let rsp = client1
+            .request_oneshot(TestMessage(1), &reply)
+            .await
+            .expect("client 1 request 1 should succeed");
+        assert_eq!(rsp.body, Ok(TestMessage(2)));
+
+        // should be rejected
+        let res = k
+            .registry()
+            .await
+            .connect_with_hello::<TestService>(TestMessage(2))
+            .await;
+        match res {
+            Ok(_) => panic!("rejected connect should fail"),
+            Err(ConnectError::Rejected(TestMessage(666))) => {}
+            Err(e) => panic!(
+                "rejected connect should return ConnectError::Rejected, got {:?}",
+                e
+            ),
+        }
+
+        let mut client2 = k
+            .registry()
+            .await
+            .connect_with_hello::<TestService>(TestMessage(1))
+            .await
+            .expect("connect with accepted Hello should succeed");
+
+        let rsp = client2
+            .request_oneshot(TestMessage(2), &reply)
+            .await
+            .expect("client 2 request 1 should succeed");
+        assert_eq!(rsp.body, Ok(TestMessage(3)));
+
+        let rsp = client1
+            .request_oneshot(TestMessage(3), &reply)
+            .await
+            .expect("client 1 request 2 should succeed");
+        assert_eq!(rsp.body, Ok(TestMessage(4)));
+    })
+}
+
+#[test]
+fn user_connect() {
+    TestKernel::run(|k| async move {
+        let (listener, registration) = listener::Listener::<TestService>::new(2).await;
+
+        // server
+        k.spawn(async move {
+            loop {
+                let conn = listener.handshake().await;
+                if conn.hello == TestMessage(1) {
+                    let (tx, rx) = crate::comms::kchannel::KChannel::new_async(2).await.split();
+                    k.spawn(async move {
+                        while let Ok(Message { msg, reply }) = rx.dequeue_async().await {
+                            let TestMessage(val) = msg.body;
+                            tracing::info!(val, "received request");
+                            match reply {
+                                ReplyTo::Userspace { nonce, outgoing } => {
+                                    let reply = UserResponse {
+                                        nonce,
+                                        uuid: TestService::UUID,
+                                        reply: Ok::<_, TestMessage>(TestMessage(val + 1)),
+                                    };
+
+                                    let bytes =
+                                        postcard::to_stdvec(&reply).expect("must serialize!");
+                                    let mut wgr = outgoing.send_grant_exact(bytes.len()).await;
+                                    wgr.copy_from_slice(&bytes[..]);
+                                    wgr.commit(bytes.len());
+                                }
+
+                                _ => panic!("all requests should be from 'userspace'"),
+                            }
+                        }
+                    })
+                    .await;
+                    conn.accept(tx).unwrap();
+                } else {
+                    conn.reject(TestMessage(666)).unwrap();
+                }
+            }
+        })
+        .await;
+
+        k.with_registry(|r| r.register(registration)).await.unwrap();
+
+        #[tracing::instrument(skip(k), err(Debug))]
+        async fn user_connect(
+            k: &'static Kernel,
+            hello: TestMessage,
+        ) -> Result<UserspaceHandle, UserConnectError<TestService>> {
+            let bytes = postcard::to_stdvec(&hello).expect("must serialize!");
+
+            k.registry()
+                .await
+                .connect_userspace_with_hello::<TestService>(&k.inner().scheduler, &bytes[..])
+                .await
+        }
+
+        #[tracing::instrument(skip(user_tx, user_rx, handle), ret)]
+        async fn user_request(
+            handle: &UserspaceHandle,
+            user_tx: &bbq::MpscProducer,
+            user_rx: &bbq::Consumer,
+            req: TestMessage,
+        ) -> Result<TestMessage, TestMessage> {
+            static NEXT_NONCE: AtomicU32 = AtomicU32::new(0);
+            tracing::info!(?req, "sending user request");
+            let bytes = postcard::to_stdvec(&req).expect("request must serialize");
+            let nonce = NEXT_NONCE.fetch_add(1, Ordering::Relaxed);
+            let user_req = UserRequest {
+                req_bytes: &bytes[..],
+                nonce,
+                uid: TestService::UUID,
+            };
+            handle
+                .process_msg(user_req, user_tx)
+                .expect("process_msg should succeed");
+            let rgr = user_rx.read_grant().await;
+            let len = rgr.len();
+            let rsp: UserResponse<TestMessage, TestMessage> =
+                postcard::from_bytes(&rgr[..]).expect("response should deserialize");
+            rgr.release(len);
+            assert_eq!(rsp.nonce, nonce);
+            rsp.reply
+        }
+
+        let (user_tx, user_rx) = bbq::new_spsc_channel(256).await;
+        let user_tx = user_tx.into_mpmc_producer().await;
+
+        let client1 = user_connect(k, TestMessage(1))
+            .await
+            .expect("connect should succeed");
+
+        let rsp = user_request(&client1, &user_tx, &user_rx, TestMessage(1)).await;
+        assert_eq!(Ok(TestMessage(2)), rsp);
+
+        // should be rejected
+        let res = user_connect(k, TestMessage(2)).await;
+        match res {
+            Ok(_) => panic!("request with rejected hello should fail"),
+            Err(e) => assert_eq!(
+                e,
+                UserConnectError::Connect(ConnectError::Rejected(TestMessage(666)))
+            ),
+        };
+
+        let client2 = user_connect(k, TestMessage(1))
+            .await
+            .expect("connect should succeed");
+
+        let rsp = user_request(&client2, &user_tx, &user_rx, TestMessage(2)).await;
+        assert_eq!(Ok(TestMessage(3)), rsp);
+
+        let rsp = user_request(&client1, &user_tx, &user_rx, TestMessage(3)).await;
+        assert_eq!(Ok(TestMessage(4)), rsp);
+    })
+}

--- a/source/kernel/src/services/emb_display.rs
+++ b/source/kernel/src/services/emb_display.rs
@@ -39,6 +39,8 @@ impl RegisteredDriver for EmbDisplayService {
     type Request = Request;
     type Response = Response;
     type Error = FrameError;
+    type Hello = ();
+    type ConnectError = core::convert::Infallible;
     const UUID: Uuid = registry::known_uuids::kernel::EMB_DISPLAY_V2;
 }
 
@@ -87,8 +89,11 @@ impl EmbDisplayClient {
     pub async fn from_registry(kernel: &'static Kernel) -> Self {
         loop {
             match Self::from_registry_no_retry(kernel).await {
-                Some(me) => return me,
-                None => {
+                Ok(me) => return me,
+                Err(registry::ConnectError::Rejected(_)) => {
+                    unreachable!("the EmbDisplayService does not return connect errors!")
+                }
+                Err(_) => {
                     kernel.sleep(Duration::from_millis(10)).await;
                 }
             }
@@ -99,12 +104,12 @@ impl EmbDisplayClient {
     /// [`EmbDisplayService`].
     ///
     /// Will not retry if not immediately successful
-    pub async fn from_registry_no_retry(kernel: &'static Kernel) -> Option<Self> {
-        let prod = kernel
-            .with_registry(|reg| reg.get::<EmbDisplayService>())
-            .await?;
+    pub async fn from_registry_no_retry(
+        kernel: &'static Kernel,
+    ) -> Result<Self, registry::ConnectError<EmbDisplayService>> {
+        let prod = kernel.registry().await.get::<EmbDisplayService>().await?;
 
-        Some(EmbDisplayClient {
+        Ok(EmbDisplayClient {
             prod,
             reply: Reusable::new_async().await,
         })

--- a/source/kernel/src/services/emb_display.rs
+++ b/source/kernel/src/services/emb_display.rs
@@ -107,7 +107,11 @@ impl EmbDisplayClient {
     pub async fn from_registry_no_retry(
         kernel: &'static Kernel,
     ) -> Result<Self, registry::ConnectError<EmbDisplayService>> {
-        let prod = kernel.registry().await.get::<EmbDisplayService>().await?;
+        let prod = kernel
+            .registry()
+            .await
+            .connect::<EmbDisplayService>()
+            .await?;
 
         Ok(EmbDisplayClient {
             prod,

--- a/source/kernel/src/services/forth_spawnulator.rs
+++ b/source/kernel/src/services/forth_spawnulator.rs
@@ -100,7 +100,11 @@ impl SpawnulatorClient {
     pub async fn from_registry_no_retry(
         kernel: &'static Kernel,
     ) -> Result<Self, registry::ConnectError<SpawnulatorService>> {
-        let prod = kernel.registry().await.get::<SpawnulatorService>().await?;
+        let prod = kernel
+            .registry()
+            .await
+            .connect::<SpawnulatorService>()
+            .await?;
 
         Ok(SpawnulatorClient {
             hdl: prod,

--- a/source/kernel/src/services/forth_spawnulator.rs
+++ b/source/kernel/src/services/forth_spawnulator.rs
@@ -42,7 +42,7 @@ use core::{convert::Infallible, time::Duration};
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-
+use futures::FutureExt;
 use crate::{
     comms::{
         kchannel::{KChannel, KConsumer},
@@ -50,7 +50,8 @@ use crate::{
     },
     forth::{self, Forth},
     registry::{
-        known_uuids::kernel::FORTH_SPAWNULATOR, Envelope, KernelHandle, Message, RegisteredDriver,
+        self, known_uuids::kernel::FORTH_SPAWNULATOR, Envelope, KernelHandle, Message,
+        RegisteredDriver,
     },
     Kernel,
 };
@@ -64,6 +65,9 @@ impl RegisteredDriver for SpawnulatorService {
     type Request = Request;
     type Response = Response;
     type Error = Infallible;
+
+    type Hello = ();
+    type ConnectError = core::convert::Infallible;
 
     const UUID: Uuid = FORTH_SPAWNULATOR;
 }
@@ -87,21 +91,23 @@ impl SpawnulatorClient {
     pub async fn from_registry(kernel: &'static Kernel) -> Self {
         loop {
             match Self::from_registry_no_retry(kernel).await {
-                Some(port) => return port,
-                None => {
-                    // SerialMux probably isn't registered yet. Try again in a bit
+                Ok(me) => return me,
+                Err(registry::ConnectError::Rejected(_)) => {
+                    unreachable!("the SpawnulatorService does not return connect errors!")
+                }
+                Err(_) => {
                     kernel.sleep(Duration::from_millis(10)).await;
                 }
             }
         }
     }
 
-    pub async fn from_registry_no_retry(kernel: &'static Kernel) -> Option<Self> {
-        let prod = kernel
-            .with_registry(|reg| reg.get::<SpawnulatorService>())
-            .await?;
+    pub async fn from_registry_no_retry(
+        kernel: &'static Kernel,
+    ) -> Result<Self, registry::ConnectError<SpawnulatorService>> {
+        let prod = kernel.registry().await.get::<SpawnulatorService>().await?;
 
-        Some(SpawnulatorClient {
+        Ok(SpawnulatorClient {
             hdl: prod,
             reply: Reusable::new_async().await,
         })
@@ -155,37 +161,52 @@ impl SpawnulatorServer {
         kernel: &'static Kernel,
         settings: SpawnulatorSettings,
     ) -> Result<(), RegistrationError> {
-        let (cmd_prod, cmd_cons) = KChannel::new_async(settings.capacity).await.split();
+        let vms = KChannel::new_async(settings.capacity).await.into_consumer();
+        let (listener, r) = registry::Listener::new(settings.capacity).await;
         tracing::debug!("who spawns the spawnulator?");
         kernel
-            .spawn(SpawnulatorServer::spawnulate(kernel, cmd_cons))
+            .spawn(SpawnulatorServer::spawnulate(kernel, vms, listener))
             .await;
         tracing::debug!("spawnulator spawnulated!");
         kernel
-            .with_registry(|reg| reg.register_konly::<SpawnulatorService>(&cmd_prod))
+            .with_registry(|reg| reg.register_konly::<SpawnulatorService>(r))
             .await
             .map_err(|_| RegistrationError::SpawnulatorAlreadyRegistered)?;
         tracing::info!("ForthSpawnulatorService registered");
         Ok(())
     }
 
-    #[tracing::instrument(skip(kernel, vms))]
-    async fn spawnulate(kernel: &'static Kernel, vms: KConsumer<Message<SpawnulatorService>>) {
+    #[tracing::instrument(skip(kernel, vms, listener))]
+    async fn spawnulate(
+        kernel: &'static Kernel,
+        vms: KConsumer<Message<SpawnulatorService>>,
+        listener: registry::Listener<SpawnulatorService>,
+    ) {
         tracing::debug!("spawnulator running...");
-        while let Ok(msg) = vms.dequeue_async().await {
-            let mut vm = None;
+        loop {
+            futures::select_biased! {
+                msg = vms.dequeue_async().fuse() => {
+                    let Ok(msg) = msg else { break; };
+                    let mut vm = None;
 
-            // TODO(AJM): I really need a better "extract request contents" function
-            let resp = msg.msg.reply_with_body(|msg| {
-                vm = Some(msg.0);
-                Ok(Response)
-            });
+                    // TODO(AJM): I really need a better "extract request contents" function
+                    let resp = msg.msg.reply_with_body(|msg| {
+                        vm = Some(msg.0);
+                        Ok(Response)
+                    });
 
-            let vm = vm.unwrap();
-            let id = vm.forth.host_ctxt().id();
-            kernel.spawn(vm.run()).await;
-            let _ = msg.reply.reply_konly(resp).await;
-            tracing::trace!(task.id = id, "spawnulated!");
+                    let vm = vm.unwrap();
+                    let id = vm.forth.host_ctxt().id();
+                    kernel.spawn(vm.run()).await;
+                    let _ = msg.reply.reply_konly(resp).await;
+                    tracing::trace!(task.id = id, "spawnulated!");
+                },
+                conn = listener.next().fuse() => {
+                    if conn.accept(vms.producer()).is_err() {
+                        tracing::info!("connection attempt canceled");
+                    }
+                }
+            }
         }
         tracing::info!("spawnulator channel closed!");
     }

--- a/source/kernel/src/services/forth_spawnulator.rs
+++ b/source/kernel/src/services/forth_spawnulator.rs
@@ -41,18 +41,13 @@
 use core::{convert::Infallible, time::Duration};
 
 use crate::{
-    comms::{
-        kchannel::{KChannel, KConsumer},
-        oneshot::Reusable,
-    },
+    comms::oneshot::Reusable,
     forth::{self, Forth},
     registry::{
-        self, known_uuids::kernel::FORTH_SPAWNULATOR, Envelope, KernelHandle, Message,
-        RegisteredDriver,
+        self, known_uuids::kernel::FORTH_SPAWNULATOR, Envelope, KernelHandle, RegisteredDriver,
     },
     Kernel,
 };
-use futures::FutureExt;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -179,7 +174,7 @@ impl SpawnulatorServer {
     #[tracing::instrument(skip(kernel, vms))]
     async fn spawnulate(
         kernel: &'static Kernel,
-        mut vms: registry::listener::RequestStream<SpawnulatorService>,
+        vms: registry::listener::RequestStream<SpawnulatorService>,
     ) {
         tracing::debug!("spawnulator running...");
         loop {

--- a/source/kernel/src/services/i2c.rs
+++ b/source/kernel/src/services/i2c.rs
@@ -327,7 +327,7 @@ impl I2cClient {
     pub async fn from_registry_no_retry(
         kernel: &'static Kernel,
     ) -> Result<Self, registry::ConnectError<I2cService>> {
-        let handle = kernel.registry().await.get::<I2cService>().await?;
+        let handle = kernel.registry().await.connect::<I2cService>().await?;
 
         Ok(I2cClient {
             handle,

--- a/source/kernel/src/services/keyboard/mod.rs
+++ b/source/kernel/src/services/keyboard/mod.rs
@@ -132,7 +132,7 @@ impl KeyClient {
         let mut handle = kernel
             .registry()
             .await
-            .get::<KeyboardService>()
+            .connect::<KeyboardService>()
             .await
             .ok()?;
         let reply = oneshot::Reusable::new_async().await;

--- a/source/kernel/src/services/keyboard/mod.rs
+++ b/source/kernel/src/services/keyboard/mod.rs
@@ -37,6 +37,8 @@ impl RegisteredDriver for KeyboardService {
     type Request = Subscribe;
     type Response = Subscribed;
     type Error = KeyboardError;
+    type Hello = ();
+    type ConnectError = core::convert::Infallible;
 
     const UUID: Uuid = known_uuids::kernel::KEYBOARD;
 }

--- a/source/kernel/src/services/keyboard/mod.rs
+++ b/source/kernel/src/services/keyboard/mod.rs
@@ -130,8 +130,11 @@ impl KeyClient {
         subscribe: Subscribe,
     ) -> Option<Self> {
         let mut handle = kernel
-            .with_registry(|reg| reg.get::<KeyboardService>())
-            .await?;
+            .registry()
+            .await
+            .get::<KeyboardService>()
+            .await
+            .ok()?;
         let reply = oneshot::Reusable::new_async().await;
         let Subscribed { rx } = handle
             .request_oneshot(subscribe, &reply)

--- a/source/kernel/src/services/keyboard/mux.rs
+++ b/source/kernel/src/services/keyboard/mux.rs
@@ -98,7 +98,11 @@ impl KeyboardMuxClient {
     pub async fn from_registry_no_retry(
         kernel: &'static Kernel,
     ) -> Result<Self, registry::ConnectError<KeyboardMuxService>> {
-        let handle = kernel.registry().await.get::<KeyboardMuxService>().await?;
+        let handle = kernel
+            .registry()
+            .await
+            .connect::<KeyboardMuxService>()
+            .await?;
         Ok(Self {
             handle,
             reply: Reusable::new_async().await,

--- a/source/kernel/src/services/serial_mux.rs
+++ b/source/kernel/src/services/serial_mux.rs
@@ -375,7 +375,7 @@ impl MuxingInfo {
 // impl CommanderTask
 
 impl CommanderTask {
-    async fn run(mut self) {
+    async fn run(self) {
         loop {
             let Message { msg: req, reply } = self.cmd.next_request().await;
             match req.body {

--- a/source/kernel/src/services/serial_mux.rs
+++ b/source/kernel/src/services/serial_mux.rs
@@ -111,7 +111,11 @@ impl SerialMuxClient {
     pub async fn from_registry_no_retry(
         kernel: &'static Kernel,
     ) -> Result<Self, registry::ConnectError<SerialMuxService>> {
-        let prod = kernel.registry().await.get::<SerialMuxService>().await?;
+        let prod = kernel
+            .registry()
+            .await
+            .connect::<SerialMuxService>()
+            .await?;
 
         Ok(SerialMuxClient {
             prod,

--- a/source/kernel/src/services/simple_serial.rs
+++ b/source/kernel/src/services/simple_serial.rs
@@ -11,7 +11,7 @@ use crate::comms::bbq::BidiHandle;
 use crate::comms::oneshot::Reusable;
 use crate::Kernel;
 
-use crate::registry::{known_uuids, Envelope, KernelHandle, RegisteredDriver, ReplyTo};
+use crate::registry::{self, known_uuids, Envelope, KernelHandle, RegisteredDriver, ReplyTo};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Service Definition
@@ -23,6 +23,13 @@ impl RegisteredDriver for SimpleSerialService {
     type Request = Request;
     type Response = Response;
     type Error = SimpleSerialError;
+
+    // TODO(eliza): maybe we should do a v2 of this trait where the `Hello`
+    // message is `GetPort` and the request/response types are serial frames?
+    // but we can't do this until services can be bidi pipes instead of req
+    // channels...
+    type Hello = ();
+    type ConnectError = core::convert::Infallible;
 
     const UUID: Uuid = known_uuids::kernel::SIMPLE_SERIAL_PORT;
 }
@@ -54,12 +61,12 @@ pub struct SimpleSerialClient {
 }
 
 impl SimpleSerialClient {
-    pub async fn from_registry(kernel: &'static Kernel) -> Option<Self> {
-        let kprod = kernel
-            .with_registry(|reg| reg.get::<SimpleSerialService>())
-            .await?;
+    pub async fn from_registry(
+        kernel: &'static Kernel,
+    ) -> Result<Self, registry::ConnectError<SimpleSerialService>> {
+        let kprod = kernel.registry().await.get::<SimpleSerialService>().await?;
 
-        Some(SimpleSerialClient {
+        Ok(SimpleSerialClient {
             kprod,
             rosc: Reusable::new_async().await,
         })

--- a/source/kernel/src/services/simple_serial.rs
+++ b/source/kernel/src/services/simple_serial.rs
@@ -64,7 +64,11 @@ impl SimpleSerialClient {
     pub async fn from_registry(
         kernel: &'static Kernel,
     ) -> Result<Self, registry::ConnectError<SimpleSerialService>> {
-        let kprod = kernel.registry().await.get::<SimpleSerialService>().await?;
+        let kprod = kernel
+            .registry()
+            .await
+            .connect::<SimpleSerialService>()
+            .await?;
 
         Ok(SimpleSerialClient {
             kprod,

--- a/source/kernel/src/test_util.rs
+++ b/source/kernel/src/test_util.rs
@@ -1,0 +1,95 @@
+use super::*;
+
+use mnemos_alloc::heap::MnemosAlloc;
+use std::{
+    future::Future,
+    ptr::NonNull,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+#[global_allocator]
+static ALLOC: MnemosAlloc<std::alloc::System> = MnemosAlloc::new();
+
+pub(crate) struct TestKernel {
+    kernel: NonNull<Kernel>,
+}
+
+impl TestKernel {
+    fn new() -> Self {
+        trace_init();
+        // XXX(eliza): the test kernel is gonna be leaked forever...maybe we
+        // should do something about that, if we wanna have a lot of tests. but,
+        // at least it means we never create a dangling pointer to it.
+        let kernel = unsafe {
+            NonNull::new(mnemos_alloc::containers::Box::into_raw(
+                Kernel::new(KernelSettings {
+                    max_drivers: 16,
+                    timer_granularity: Duration::from_millis(1),
+                })
+                .unwrap(),
+            ))
+            .expect("newly-allocated kernel mustn't be null!")
+        };
+
+        Self { kernel }
+    }
+
+    pub fn run<F: Future + 'static>(future: impl FnOnce(&'static Kernel) -> F) {
+        let running = Arc::new(AtomicBool::new(true));
+        let test = Self::new();
+        let k = unsafe { test.kernel.as_ref() };
+        k.initialize({
+            let running = running.clone();
+            let f = future(k);
+            async move {
+                f.await;
+                running.store(false, Ordering::SeqCst);
+            }
+        })
+        .unwrap();
+        let mut ticks = 0;
+        while running.load(Ordering::SeqCst) {
+            tracing::trace!("\n");
+            tracing::trace!("---- TICK {ticks} ---");
+            tracing::trace!("\n");
+            let tick = k.tick();
+
+            tracing::trace!("\n");
+            tracing::trace!(?tick);
+            ticks += 1;
+            if running.load(Ordering::SeqCst) {
+                assert!(
+                    tick.has_remaining,
+                    "no tasks were woken, but the test future hasn't finished \
+                     yet.this would hang forever --- seems bad!"
+                );
+            }
+        }
+    }
+}
+
+fn trace_init() {
+    use tracing_subscriber::{
+        filter::{EnvFilter, LevelFilter},
+        prelude::*,
+    };
+    let env = std::env::var("RUST_LOG").unwrap_or_default();
+    let builder = EnvFilter::builder().with_default_directive(LevelFilter::INFO.into());
+    let filter = if env.is_empty() {
+        builder.parse("kernel=debug").unwrap()
+    } else {
+        builder.parse_lossy(env)
+    };
+
+    let _res = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_test_writer()
+        .with_thread_names(true)
+        .without_time()
+        .finish()
+        .try_init();
+}


### PR DESCRIPTION
Currently, when a task (or userspace) wishes to connect to a `RegisteredDriver`,
it performs a registry lookup, which returns a handle for sending requests to
that service. These handles are essentially producers for a single `KChannel`
which is associated with the service when it's registered, and the service can
use this channel's `KConsumer` to receive a stream of incoming requests.

This approach works fine, but it limits what a service can do with its incoming
request stream. Because all requests arrive on the same `KConsumer`, the server
may not spawn a separate task to handle requests from each client. Similarly, it cannot
route requests to different worker tasks based on which resource the request is
associated with.

This branch changes the way clients communicate with servers by introducing a
_handshake_ to this process. Rather than registering a service by giving the
registry a `KProducer` for a single request channel, the registry now owns a
producer for a channel of _incoming connections_. These connections contain a
`Hello` message sent by the client, of a type defined by the `RegisteredDriver`
implementation for the service. This may be used by the service to determine
what resource the client wants to access, or otherwise route connections to
different tasks. This handshake is completed by the service responding to the
incoming connection with a `KProducer` for a request channel, which is then
returned to the client.

The returned `KProducer` _may_ still point to a single global request channel
for that service, allowing us to continue to implement the existing behavior.
However, the service may alternatively spawn a new task for that connection and
create a new channel for that worker. Or, it may return a different `KProducer`
for a different request channel depending on the `Hello` message, allowing the
server to have separate worker tasks for different resources managed by the same
service, and route the connection to one of those workers depending on which
resource was requested in the `Hello` message.

An adapter, `into_request_stream`, is provided, to make it easier for services
which want the current behavior of one global stream of requests to have that.
Currently, all the existing services use this, but in the future, many of our
existing services can be rewritten to use the new handshake mechanism more
effectively. I'd also like to do some additional refactoring, but I wanted to
get a working PR up first.