### PR TITLE
chore: pomelo workspace checks unfucking

### DIFF
--- a/justfile
+++ b/justfile
@@ -59,7 +59,8 @@ _espbuddy_pkg := "mnemos-esp32c3-buddy"
 _x86_pkg := "mnemos-x86_64-bootloader"
 _x86_bootloader_pkg := "mnemos-x86_64-bootloader"
 
-_pomelo_index_path := "platforms"/"pomelo"/"index.html"
+_pomelo_pkg := "pomelo"
+_pomelo_index_path := "platforms"/_pomelo_pkg/"index.html"
 
 # arguments to pass to all RustDoc invocations
 _rustdoc := _cargo + " doc --no-deps --all-features"
@@ -72,7 +73,7 @@ default:
     @just --list
 
 # check all crates, across workspaces
-check *ARGS: && (check-crate _d1_pkg ARGS) (check-crate _espbuddy_pkg ARGS) (check-crate _x86_pkg ARGS) (check-crate _x86_bootloader_pkg ARGS)
+check *ARGS: && (check-crate _d1_pkg ARGS) (check-crate _espbuddy_pkg ARGS) (check-crate _x86_pkg ARGS) (check-crate _x86_bootloader_pkg ARGS) (check-crate _pomelo_pkg ARGS)
     #!/usr/bin/env bash
     set -euxo pipefail
     {{ _cargo }} check \
@@ -91,7 +92,7 @@ check-crate crate *ARGS:
         {{ _fmt_check_doc }}
 
 # run Clippy checks for all crates, across workspaces.
-clippy *ARGS: && (clippy-crate _d1_pkg ARGS) (clippy-crate _espbuddy_pkg ARGS) (clippy-crate _x86_pkg ARGS) (clippy-crate _x86_bootloader_pkg ARGS)
+clippy *ARGS: && (clippy-crate _d1_pkg ARGS) (clippy-crate _espbuddy_pkg ARGS) (clippy-crate _x86_pkg ARGS) (clippy-crate _x86_bootloader_pkg ARGS) (clippy-crate _pomelo_pkg ARGS)
     #!/usr/bin/env bash
     set -euxo pipefail
     {{ _cargo }} clippy \
@@ -173,7 +174,7 @@ melpomene *FLAGS:
     {{ _cargo }} run --profile {{ profile }} --bin melpomene -- {{ FLAGS }}
 
 # build all RustDoc documentation
-all-docs *FLAGS: (docs FLAGS) (docs "-p " + _d1_pkg + FLAGS) (docs "-p " + _espbuddy_pkg + FLAGS)  (docs "-p " + _x86_bootloader_pkg + FLAGS)
+all-docs *FLAGS: (docs FLAGS) (docs "-p " + _d1_pkg + FLAGS) (docs "-p " + _espbuddy_pkg + FLAGS)  (docs "-p " + _x86_bootloader_pkg + FLAGS) (docs "-p " + _pomelo_pkg + FLAGS)
 
 # serve Pomelo and open it in the browser
 pomelo *ARGS="--release --open": (trunk "serve " + ARGS + " " + _pomelo_index_path)

--- a/platforms/pomelo/Cargo.toml
+++ b/platforms/pomelo/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["per-package-target", "profile-rustflags"]
+
 [package]
 name = "pomelo"
 version = "0.1.0"
@@ -10,6 +12,7 @@ repository = "https://github.com/tosc-rs/mnemos"
 homepage = "https://mnemos.dev"
 readme = "./README.md"
 license = "MIT OR Apache-2.0"
+forced-target = "wasm32-unknown-unknown"
 
 [dependencies]
 chrono = { version = "0.4.26", features = ["wasmbind"] }

--- a/platforms/pomelo/src/sim_drivers/serial.rs
+++ b/platforms/pomelo/src/sim_drivers/serial.rs
@@ -62,8 +62,8 @@ impl Serial {
 
         spawn_local(
             async move {
-                let mut handle = a_ring;
-                process_stream(&mut handle, recv, irq_tx, recv_callback)
+                let handle = a_ring;
+                process_stream(&handle, recv, irq_tx, recv_callback)
                     .instrument(info_span!("process_stream", ?port))
                     .await
             }
@@ -76,7 +76,7 @@ impl Serial {
 }
 
 async fn process_stream(
-    handle: &mut BidiHandle,
+    handle: &BidiHandle,
     mut in_stream: impl Stream<Item = u8>,
     mut irq: mpsc::Sender<()>,
     recv_callback: fn(String),


### PR DESCRIPTION
This branch makes two changes:

1. Turns out I had forgotten to add `pomelo` to the Just commands that run a
   check for all crates, like `just check`, `just clippy`, and `just docs`. So,
   it was never actually being checked, on CI or in VS Code (MY BAD LMAO).
   Therefore, this branch adds it to those recipes so it actually gets checked.

2. Once we actually include `pomelo` in `just check`, it turns out that the
   build is fucked, because Cargo doesn't realize what target to build `pomelo`
   for. Thus, I've also added a missing `forced-target="wasm32-unknown-unknown`
   to `pomelo`'s `Cargo.toml`, which should unfuck it.

3. Also I fixed an "unnecessary mut" warning, because now that we're actually
    linting `pomelo` on CI, it turns out that it, uh, has lints. Whoops.