### PR TITLE
feat(kernel): `RwLock` registry and add helpers

### DIFF
--- a/platforms/allwinner-d1/core/src/drivers/sharp_display.rs
+++ b/platforms/allwinner-d1/core/src/drivers/sharp_display.rs
@@ -111,7 +111,7 @@ impl SharpDisplay {
         kernel.spawn(draw.draw_run()).await;
 
         kernel
-            .with_registry(|reg| reg.register_konly::<EmbDisplayService>(registration))
+            .register_konly::<EmbDisplayService>(registration)
             .await
             .map_err(|_| FrameError::DisplayAlreadyExists)?;
 

--- a/platforms/allwinner-d1/core/src/drivers/sharp_display.rs
+++ b/platforms/allwinner-d1/core/src/drivers/sharp_display.rs
@@ -30,7 +30,7 @@ use embedded_graphics::{pixelcolor::Gray8, prelude::*, primitives::Rectangle};
 use kernel::{
     maitake::sync::{Mutex, WaitQueue},
     mnemos_alloc::containers::{Arc, FixedVec},
-    registry::{self, listener},
+    registry::listener,
     services::emb_display::{
         DisplayMetadata, EmbDisplayService, FrameChunk, FrameError, FrameKind, MonoChunk, Request,
         Response,
@@ -87,9 +87,14 @@ impl SharpDisplay {
         }))
         .await;
 
-        let (listener, registration) = registry::Listener::new(2).await;
+        let cmd = kernel
+            .bind_konly_service(2)
+            .await
+            .map_err(|_| FrameError::DisplayAlreadyExists)?
+            .into_request_stream(2)
+            .await;
         let commander = CommanderTask {
-            cmd: listener.into_request_stream(2).await,
+            cmd,
             ctxt: ctxt.clone(),
             height: HEIGHT as u32,
             width: WIDTH as u32,
@@ -109,11 +114,6 @@ impl SharpDisplay {
         kernel.spawn(commander.cmd_run()).await;
         kernel.spawn(vcom.vcom_run()).await;
         kernel.spawn(draw.draw_run()).await;
-
-        kernel
-            .register_konly::<EmbDisplayService>(registration)
-            .await
-            .map_err(|_| FrameError::DisplayAlreadyExists)?;
 
         Ok(())
     }

--- a/platforms/allwinner-d1/core/src/drivers/spim.rs
+++ b/platforms/allwinner-d1/core/src/drivers/spim.rs
@@ -109,9 +109,11 @@ impl SpiSenderServer {
         kernel: &'static Kernel,
         queued: usize,
     ) -> Result<(), registry::RegistrationError> {
-        let (listener, registration) = registry::Listener::new(queued).await;
-
-        let reqs = listener.into_request_stream(queued).await;
+        let reqs = kernel
+            .bind_konly_service::<SpiSender>(queued)
+            .await?
+            .into_request_stream(queued)
+            .await;
         kernel
             .spawn(async move {
                 let spi = unsafe { &*SPI_DBI::PTR };
@@ -197,8 +199,6 @@ impl SpiSenderServer {
                 Result::<(), ()>::Ok(())
             })
             .await;
-
-        kernel.register_konly::<SpiSender>(registration).await?;
 
         Ok(())
     }

--- a/platforms/allwinner-d1/core/src/drivers/spim.rs
+++ b/platforms/allwinner-d1/core/src/drivers/spim.rs
@@ -198,9 +198,7 @@ impl SpiSenderServer {
             })
             .await;
 
-        kernel
-            .with_registry(move |reg| reg.register_konly::<SpiSender>(registration))
-            .await?;
+        kernel.register_konly::<SpiSender>(registration).await?;
 
         Ok(())
     }

--- a/platforms/allwinner-d1/core/src/drivers/twi.rs
+++ b/platforms/allwinner-d1/core/src/drivers/twi.rs
@@ -309,9 +309,7 @@ impl I2c0 {
 
         kernel.spawn(self.run(rx)).await;
         tracing::info!("TWI driver task spawned");
-        kernel
-            .with_registry(move |reg| reg.register_konly::<I2cService>(registration))
-            .await?;
+        kernel.register_konly(registration).await?;
 
         Ok(())
     }

--- a/platforms/allwinner-d1/core/src/drivers/twi.rs
+++ b/platforms/allwinner-d1/core/src/drivers/twi.rs
@@ -304,12 +304,14 @@ impl I2c0 {
         kernel: &'static Kernel,
         queued: usize,
     ) -> Result<(), registry::RegistrationError> {
-        let (listener, registration) = registry::Listener::new(queued).await;
-        let rx = listener.into_request_stream(queued).await;
+        let rx = kernel
+            .bind_konly_service::<I2cService>(queued)
+            .await?
+            .into_request_stream(queued)
+            .await;
 
         kernel.spawn(self.run(rx)).await;
         tracing::info!("TWI driver task spawned");
-        kernel.register_konly(registration).await?;
 
         Ok(())
     }

--- a/platforms/allwinner-d1/core/src/drivers/uart.rs
+++ b/platforms/allwinner-d1/core/src/drivers/uart.rs
@@ -195,8 +195,7 @@ impl D1Uart {
         let old = UART_RX.swap(leaked_prod, Ordering::AcqRel);
         assert_eq!(old, null_mut());
 
-        k.with_registry(|reg| reg.register_konly::<SimpleSerialService>(registration))
-            .await?;
+        k.register_konly(registration).await?;
 
         Ok(())
     }

--- a/platforms/beepy/src/i2c_puppet.rs
+++ b/platforms/beepy/src/i2c_puppet.rs
@@ -414,9 +414,10 @@ impl I2cPuppetServer {
         }
 
         kernel
-            .with_registry(|reg| reg.register_konly::<I2cPuppetService>(registration))
+            .register_konly(registration)
             .await
             .map_err(RegistrationError::Registry)?;
+
         Ok(())
     }
 

--- a/platforms/esp32c3-buddy/src/drivers/uart.rs
+++ b/platforms/esp32c3-buddy/src/drivers/uart.rs
@@ -122,7 +122,7 @@ impl<T: Instance> C3Uart<T> {
         let old = UART_RX.swap(leaked_prod, Ordering::AcqRel);
         assert_eq!(old, null_mut());
 
-        k.with_registry(|reg| reg.register_konly::<SimpleSerialService>(registration))
+        k.register_konly::<SimpleSerialService>(registration)
             .await?;
 
         Ok(())

--- a/platforms/esp32c3-buddy/src/drivers/usb_serial.rs
+++ b/platforms/esp32c3-buddy/src/drivers/usb_serial.rs
@@ -181,7 +181,7 @@ impl UsbSerialServer {
 
         k.spawn(self.worker(fifo_a)).await;
 
-        k.with_registry(|reg| reg.register_konly::<SimpleSerialService>(registration))
+        k.register_konly::<SimpleSerialService>(registration)
             .await?;
 
         Ok(())

--- a/platforms/melpomene/src/sim_drivers/emb_display.rs
+++ b/platforms/melpomene/src/sim_drivers/emb_display.rs
@@ -78,7 +78,7 @@ impl SimDisplay {
         kernel.spawn(commander.run(width, height, settings)).await;
 
         kernel
-            .with_registry(|reg| reg.register_konly::<EmbDisplayService>(registration))
+            .register_konly(registration)
             .await
             .map_err(|_| FrameError::DisplayAlreadyExists)?;
 

--- a/platforms/melpomene/src/sim_drivers/emb_display.rs
+++ b/platforms/melpomene/src/sim_drivers/emb_display.rs
@@ -65,8 +65,12 @@ impl SimDisplay {
         height: u32,
     ) -> Result<(), FrameError> {
         tracing::debug!("initializing SimDisplay server ({width}x{height})...");
-        let (listener, registration) = registry::Listener::new(settings.kchannel_depth).await;
-        let cmd = listener.into_request_stream(settings.kchannel_depth).await;
+        let cmd = kernel
+            .bind_konly_service(settings.kchannel_depth)
+            .await
+            .map_err(|_| FrameError::DisplayAlreadyExists)?
+            .into_request_stream(settings.kchannel_depth)
+            .await;
 
         let commander = CommanderTask {
             kernel,
@@ -76,11 +80,6 @@ impl SimDisplay {
         };
 
         kernel.spawn(commander.run(width, height, settings)).await;
-
-        kernel
-            .register_konly(registration)
-            .await
-            .map_err(|_| FrameError::DisplayAlreadyExists)?;
 
         tracing::info!("SimDisplayServer initialized!");
 

--- a/platforms/melpomene/src/sim_drivers/tcp_serial.rs
+++ b/platforms/melpomene/src/sim_drivers/tcp_serial.rs
@@ -80,7 +80,7 @@ impl TcpSerial {
         );
 
         kernel
-            .with_registry(|reg| reg.register_konly::<SimpleSerialService>(registration))
+            .register_konly::<SimpleSerialService>(registration)
             .await
     }
 }

--- a/platforms/pomelo/src/sim_drivers/emb_display.rs
+++ b/platforms/pomelo/src/sim_drivers/emb_display.rs
@@ -102,7 +102,7 @@ impl SimDisplay {
         kernel.spawn(key_event_handler(key_rx, keymux)).await;
 
         kernel
-            .with_registry(|reg| reg.register_konly::<EmbDisplayService>(registration))
+            .register_konly::<EmbDisplayService>(registration)
             .await
             .map_err(|_| FrameError::DisplayAlreadyExists)?;
 

--- a/platforms/pomelo/src/sim_drivers/serial.rs
+++ b/platforms/pomelo/src/sim_drivers/serial.rs
@@ -67,7 +67,7 @@ impl Serial {
             )
             .await;
         kernel
-            .with_registry(|reg| reg.register_konly::<SimpleSerialService>(registration))
+            .register_konly::<SimpleSerialService>(registration)
             .await
     }
 }

--- a/source/kernel/src/registry/mod.rs
+++ b/source/kernel/src/registry/mod.rs
@@ -7,6 +7,7 @@ use core::{
 
 use crate::comms::{kchannel, oneshot::Reusable};
 use mnemos_alloc::containers::FixedVec;
+use portable_atomic::{AtomicU32, Ordering};
 use postcard::experimental::max_size::MaxSize;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use spitebuf::EnqueueError;
@@ -119,7 +120,7 @@ pub struct RegistryType {
 /// The driver registry used by the kernel.
 pub struct Registry {
     items: FixedVec<RegistryItem>,
-    counter: u32,
+    counter: AtomicU32,
 }
 
 // TODO: This probably goes into the ABI crate, here is fine for now
@@ -405,7 +406,7 @@ impl Registry {
     pub fn new(max_items: usize) -> Self {
         Self {
             items: FixedVec::try_new(max_items).unwrap(),
-            counter: 0,
+            counter: AtomicU32::new(0),
         }
     }
 
@@ -429,6 +430,8 @@ impl Registry {
             return Err(RegistrationError::UuidAlreadyRegistered);
         }
         let conn_prod = registration.tx.type_erase();
+
+        let service_id = self.counter.fetch_add(1, Ordering::Relaxed);
         self.items
             .try_push(RegistryItem {
                 key: RD::UUID,
@@ -436,12 +439,11 @@ impl Registry {
                     req_resp_tuple_id: RD::type_id().type_of(),
                     conn_prod,
                     user_vtable: None,
-                    service_id: ServiceId(self.counter),
+                    service_id: ServiceId(service_id),
                 },
             })
             .map_err(|_| RegistrationError::RegistryFull)?;
-        info!(uuid = ?RD::UUID, service_id = self.counter, "Registered KOnly");
-        self.counter = self.counter.wrapping_add(1);
+        info!(uuid = ?RD::UUID, service_id, "Registered KOnly");
         Ok(())
     }
 
@@ -471,6 +473,7 @@ impl Registry {
             return Err(RegistrationError::UuidAlreadyRegistered);
         }
 
+        let service_id = self.counter.fetch_add(1, Ordering::Relaxed);
         let conn_prod = registration.tx.type_erase();
         self.items
             .try_push(RegistryItem {
@@ -479,12 +482,13 @@ impl Registry {
                     req_resp_tuple_id: RD::type_id().type_of(),
                     conn_prod,
                     user_vtable: Some(UserVtable::new::<RD>()),
-                    service_id: ServiceId(self.counter),
+                    service_id: ServiceId(service_id),
                 },
             })
             .map_err(|_| RegistrationError::RegistryFull)?;
-        info!(svc = %any::type_name::<RD>(), uuid = ?RD::UUID, service_id = self.counter, "Registered");
-        self.counter = self.counter.wrapping_add(1);
+
+        info!(svc = %any::type_name::<RD>(), uuid = ?RD::UUID, service_id, "Registered");
+
         Ok(())
     }
 
@@ -515,7 +519,7 @@ impl Registry {
         fields(svc = %any::type_name::<RD>()),
     )]
     pub async fn connect_with_hello<RD: RegisteredDriver>(
-        &mut self,
+        &self,
         hello: RD::Hello,
     ) -> Result<KernelHandle<RD>, ConnectError<RD>> {
         let item = Self::get(&self.items)?;
@@ -554,14 +558,15 @@ impl Registry {
             // ...and the inner `Result` is the error returned by the driver.
             .map_err(ConnectError::Rejected)?;
 
+        let client_id = self.counter.fetch_add(1, Ordering::Relaxed);
         let res = Ok(KernelHandle {
             prod,
             service_id: item.value.service_id,
-            client_id: ClientId(self.counter),
+            client_id: ClientId(client_id),
             request_ctr: 0,
         });
-        info!(svc = %any::type_name::<RD>(), uuid = ?RD::UUID, service_id = item.value.service_id.0, client_id = self.counter, "Got KernelHandle from Registry");
-        self.counter = self.counter.wrapping_add(1);
+        info!(svc = %any::type_name::<RD>(), uuid = ?RD::UUID, service_id = item.value.service_id.0, client_id, "Got KernelHandle from Registry");
+
         res
     }
 
@@ -588,7 +593,8 @@ impl Registry {
     ///   connection.
     ///
     /// [rejected]: listener::Handshake::reject
-    pub async fn connect<RD>(&mut self) -> Result<KernelHandle<RD>, ConnectError<RD>>
+
+    pub async fn connect<RD>(&self) -> Result<KernelHandle<RD>, ConnectError<RD>>
     where
         RD: RegisteredDriver<Hello = ()>,
     {
@@ -611,7 +617,7 @@ impl Registry {
         fields(svc = %any::type_name::<RD>()),
     )]
     pub async fn connect_userspace_with_hello<RD>(
-        &mut self,
+        &self,
         scheduler: &maitake::scheduler::LocalScheduler,
         user_hello: &[u8],
     ) -> Result<UserspaceHandle, UserConnectError<RD>>
@@ -661,15 +667,14 @@ impl Registry {
             },
         };
 
-        let client_id = self.counter;
+        let client_id = self.counter.fetch_add(1, Ordering::Relaxed);
         info!(
             svc = %any::type_name::<RD>(),
             uuid = ?RD::UUID,
             service_id = item.value.service_id.0,
-            client_id = self.counter,
+            client_id,
             "Got KernelHandle from Registry",
         );
-        self.counter = self.counter.wrapping_add(1);
 
         Ok(UserspaceHandle {
             req_producer_leaked,

--- a/source/kernel/src/registry/tests.rs
+++ b/source/kernel/src/registry/tests.rs
@@ -48,9 +48,7 @@ fn konly_connect() {
         })
         .await;
 
-        k.with_registry(|r| r.register_konly(registration))
-            .await
-            .unwrap();
+        k.register_konly(registration).await.unwrap();
 
         let reply = comms::oneshot::Reusable::new_async().await;
         let mut client1 = k
@@ -145,7 +143,7 @@ fn user_connect() {
         })
         .await;
 
-        k.with_registry(|r| r.register(registration)).await.unwrap();
+        k.register(registration).await.unwrap();
 
         #[tracing::instrument(skip(k), err(Debug))]
         async fn user_connect(

--- a/source/kernel/src/services/forth_spawnulator.rs
+++ b/source/kernel/src/services/forth_spawnulator.rs
@@ -168,7 +168,7 @@ impl SpawnulatorServer {
             .await;
         tracing::debug!("spawnulator spawnulated!");
         kernel
-            .with_registry(|reg| reg.register_konly::<SpawnulatorService>(r))
+            .register_konly::<SpawnulatorService>(r)
             .await
             .map_err(|_| RegistrationError::SpawnulatorAlreadyRegistered)?;
         tracing::info!("ForthSpawnulatorService registered");

--- a/source/kernel/src/services/forth_spawnulator.rs
+++ b/source/kernel/src/services/forth_spawnulator.rs
@@ -134,11 +134,6 @@ impl SpawnulatorClient {
 
 pub struct SpawnulatorServer;
 
-#[derive(Debug)]
-pub enum RegistrationError {
-    SpawnulatorAlreadyRegistered,
-}
-
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct SpawnulatorSettings {
     #[serde(default)]
@@ -159,18 +154,18 @@ impl SpawnulatorServer {
     pub async fn register(
         kernel: &'static Kernel,
         settings: SpawnulatorSettings,
-    ) -> Result<(), RegistrationError> {
-        let (listener, r) = registry::Listener::new(settings.capacity).await;
-        let vms = listener.into_request_stream(settings.capacity).await;
+    ) -> Result<(), registry::RegistrationError> {
+        let vms = kernel
+            .bind_konly_service::<SpawnulatorService>(settings.capacity)
+            .await?
+            .into_request_stream(settings.capacity)
+            .await;
         tracing::debug!("who spawns the spawnulator?");
         kernel
             .spawn(SpawnulatorServer::spawnulate(kernel, vms))
             .await;
         tracing::debug!("spawnulator spawnulated!");
-        kernel
-            .register_konly::<SpawnulatorService>(r)
-            .await
-            .map_err(|_| RegistrationError::SpawnulatorAlreadyRegistered)?;
+
         tracing::info!("ForthSpawnulatorService registered");
         Ok(())
     }

--- a/source/kernel/src/services/keyboard/mux.rs
+++ b/source/kernel/src/services/keyboard/mux.rs
@@ -200,13 +200,10 @@ impl KeyboardMuxServer {
             )
             .await;
 
-        kernel
-            .with_registry(|reg| {
-                reg.register_konly::<KeyboardMuxService>(key_tx)?;
-                reg.register_konly::<KeyboardService>(sub_tx)?;
-                Ok(())
-            })
-            .await?;
+        let mut registry = kernel.registry_mut().await;
+        registry.register_konly::<KeyboardMuxService>(key_tx)?;
+        registry.register_konly::<KeyboardService>(sub_tx)?;
+
         tracing::info!("KeyboardMuxServer registered!");
         Ok(())
     }

--- a/source/kernel/src/services/serial_mux.rs
+++ b/source/kernel/src/services/serial_mux.rs
@@ -275,7 +275,7 @@ impl SerialMuxServer {
             .await;
 
         kernel
-            .with_registry(|reg| reg.register_konly::<SerialMuxService>(registration))
+            .register_konly::<SerialMuxService>(registration)
             .await
             .map_err(|_| RegistrationError::MuxAlreadyRegistered)?;
 

--- a/source/kernel/src/services/serial_mux.rs
+++ b/source/kernel/src/services/serial_mux.rs
@@ -253,7 +253,12 @@ impl SerialMuxServer {
 
         let ports = FixedVec::new(max_ports).await;
         let imutex = Arc::new(Mutex::new(MuxingInfo { ports, max_frame })).await;
-        let (listener, registration) = registry::Listener::new(max_ports).await;
+
+        let listener = kernel
+            .bind_konly_service::<SerialMuxService>(max_ports)
+            .await
+            .map_err(|_| RegistrationError::MuxAlreadyRegistered)?;
+
         let buf = FixedVec::new(max_frame).await;
         let commander = CommanderTask {
             cmd: listener.into_request_stream(max_ports).await,
@@ -273,11 +278,6 @@ impl SerialMuxServer {
                 muxer.run().await;
             })
             .await;
-
-        kernel
-            .register_konly::<SerialMuxService>(registration)
-            .await
-            .map_err(|_| RegistrationError::MuxAlreadyRegistered)?;
 
         Ok(())
     }


### PR DESCRIPTION
If we replace the `u32` counter with an `AtomicU32`, we can make the
various `connect` methods on the registry borrow it immutably. This
allows us to store it in a `RwLock` rather than a `Mutex`, with the
write lock only being needed to register a new driver. I've done this,
as well as replacing `Kernel::with_registry` with `Kernel::registry` and
`Kernel::registry_mut` accessors.

Additionally, I've added new `Registry::bind` and `Registry::bind_konly`
helpers. These create a new listener for a service and register it with
the registry. This can be implemented using existing code, but now it
can be done in a single function call. One thing to note is that doing
this in one call means that the service is added to the registry
_before_ the server task is actually spawned, because we need to create
a listener to give to the server task. However, I don't actually believe
that's a problem, since the the listener is a queue. If some other task
connects to the service before the server is actually running, that's
fine; the request will just go in the queue for use later. This also has
the substantial advantage that server tasks don't get spawned if there's
already a registration for that service. With the current design, we
spawn tasks first and _then_ register, and if the registration fails,
those tasks are still running and nothing will get rid of them. So,
using `bind` also avoids a potential task leak when spawning a duplicate
service.