### PR TITLE
Add that `mn` requires bindeps

### DIFF
--- a/tools/manganese/README.md
+++ b/tools/manganese/README.md
@@ -21,6 +21,15 @@ yes, this is a wildly deranged idea. i'm so smart.
 > installed through other means, simply "don't run `cargo mn`", and you'll be
 > fine.
 
+
+## installing it
+
+`mn` depends on  the unstable cargo `bindeps` feature so it must be enbaled on the command line.
+
+```sh
+cargo +nightly install --path . -Z bindeps
+```
+
 ## using it
 
 `mn` is a [cargo alias] that invokes the Manganese binary. run Manganese using


### PR DESCRIPTION
Without this installing errors with:

```rust
error: failed to parse manifest at `mnemos/tools/manganese/Cargo.toml`

Caused by:
  `artifact = …` requires `-Z bindeps` (cargo-binutils)
```