### PR TITLE
bug(forth3): Fix the behavior of `leave` in forth3

### DIFF
--- a/source/forth3/src/lib.rs
+++ b/source/forth3/src/lib.rs
@@ -406,6 +406,23 @@ pub mod test {
     }
 
     #[test]
+    fn loop_leave() {
+        all_runtest(
+            r#"
+            > : test 10 0 do i . 43 emit i 5 = if leave then 10 0 do 42 emit i 5 = if leave then loop cr loop ;
+            < ok.
+            > test
+            < 0 +******
+            < 1 +******
+            < 2 +******
+            < 3 +******
+            < 4 +******
+            < 5 +ok.
+            "#,
+        )
+    }
+
+    #[test]
     fn execute() {
         all_runtest(
             r#"


### PR DESCRIPTION
This PR fixes the behavior of `leave`, which didn't previously work
when there was code between the `leave` and the `loop`.