### PR TITLE
fix(d1): put back missing `serial-trace` feature

### DIFF
--- a/justfile
+++ b/justfile
@@ -130,30 +130,33 @@ fmt:
     {{ _cargo }} fmt --package {{ _mn_pkg }}
 
 # build a Mnemos binary for the Allwinner D1
-build-d1 board='mq-pro': (_get-cargo-command "objcopy" "cargo-binutils")
+build-d1 board='mq-pro' *CARGO_ARGS='': (_get-cargo-command "objcopy" "cargo-binutils")
     {{ _cargo }} build \
         --profile {{ profile }} \
         --package {{ _d1_pkg }} \
-        --bin {{ board }}
+        --bin {{ board }} \
+        {{ CARGO_ARGS }}
     {{ _cargo }} objcopy \
         --profile {{ profile }} \
         --package {{ _d1_pkg }} \
         --bin {{ board }} \
+        {{ CARGO_ARGS }} \
         -- \
         -O binary {{ _d1_bin_path }}/mnemos-{{ board }}.bin
 
 # flash an Allwinner D1 using xfel
-flash-d1 board='mq-pro': (build-d1 board)
+flash-d1 board='mq-pro' *CARGO_ARGS='': (build-d1 board CARGO_ARGS)
     xfel ddr d1
     xfel write {{ _d1_start_addr }} {{ _d1_bin_path }}/mnemos-{{ board }}.bin
     xfel exec {{ _d1_start_addr }}
 
 # build a MnemOS binary for the ESP32-C3
-build-c3 board:
+build-c3 board *CARGO_ARGS='':
     {{ _cargo }} build \
         --profile {{ profile }} \
         --package {{ _espbuddy_pkg }} \
-        --bin {{ board }}
+        --bin {{ board }} \
+        {{ CARGO_ARGS }}
 
 # flash an ESP32-C3 with the MnemOS WiFi Buddy firmware
 flash-c3 board *espflash-args: (_get-cargo-command "espflash" "cargo-espflash") (build-c3 board)

--- a/platforms/allwinner-d1/Cargo.toml
+++ b/platforms/allwinner-d1/Cargo.toml
@@ -28,13 +28,14 @@ name = "mq-pro"
 test = false
 bench = false
 
-
 [features]
-default = ["i2c_puppet", "sharp-display"]
+default = ["i2c_puppet", "sharp-display", "serial-trace"]
 # enable i2c_puppet driver
 i2c_puppet = ["mnemos-beepy"]
 # enable the SHARP Memory Display driver
 sharp-display = []
+# enable `mnemos-trace-proto` serial tracing.
+serial-trace = ["mnemos/serial-trace"]
 
 [build-dependencies]
 d1-config = { path = "./d1-config" }

--- a/platforms/allwinner-d1/board-configs/lichee-rv.toml
+++ b/platforms/allwinner-d1/board-configs/lichee-rv.toml
@@ -17,6 +17,9 @@ enabled = true
 [services.sermux_hello]
 enabled = true
 
+[services.sermux_trace]
+enabled = true
+
 [platform.i2c]
 enabled = true
 mapping = "TWI2"

--- a/platforms/allwinner-d1/board-configs/mq-pro.toml
+++ b/platforms/allwinner-d1/board-configs/mq-pro.toml
@@ -17,6 +17,9 @@ enabled = true
 [services.sermux_hello]
 enabled = true
 
+[services.sermux_trace]
+enabled = true
+
 [platform.i2c]
 enabled = true
 mapping = "TWI0"


### PR DESCRIPTION
Looks like the feature flag was lost in #271, so the D1 binaries no
longer emit traceproto output. I believe this happened when combining
the `mnemos-d1` crate (which used to enable the feature) with the
`mnemos-d1-core` crate (which didn't enable the feature).

This commit puts it back. :)

I've also modified the Just recipes for building D1 images to allow
passing additional args to Cargo. This way, users of the Just recipes
can now pass `--no-default-features --features ...` to pick which features
are enabled when building. This was necessary for testing what happened
when the board config had a `serial-trace` section but the feature flag was
disabled. But, passing extra cargo args may also be useful in other 
situations.