### PR TITLE
feat(d1): allocate DMA channels from the DMAC

### DIFF
--- a/platforms/allwinner-d1/src/dmac/mod.rs
+++ b/platforms/allwinner-d1/src/dmac/mod.rs
@@ -126,7 +126,7 @@ impl Dmac {
                 }
             }
 
-            // Will write-back and high bits
+            // Will write-back any high bits
             w
         });
 

--- a/platforms/allwinner-d1/src/drivers/spim.rs
+++ b/platforms/allwinner-d1/src/drivers/spim.rs
@@ -10,7 +10,7 @@ use crate::dmac::{
     descriptor::{
         AddressMode, BModeSel, BlockSize, DataWidth, DescriptorConfig, DestDrqType, SrcDrqType,
     },
-    Channel, ChannelMode,
+    ChannelMode, Dmac,
 };
 use d1_pac::{GPIO, SPI_DBI};
 use kernel::{
@@ -104,17 +104,22 @@ impl RegisteredDriver for SpiSender {
 pub struct SpiSender;
 pub struct SpiSenderServer;
 
+#[derive(Debug)]
+pub enum RegistrationError {
+    Registry(registry::RegistrationError),
+    NoDmaChannels,
+}
+
 impl SpiSenderServer {
-    pub async fn register(
-        kernel: &'static Kernel,
-        queued: usize,
-    ) -> Result<(), registry::RegistrationError> {
+    pub async fn register(kernel: &'static Kernel, queued: usize) -> Result<(), RegistrationError> {
         let reqs = kernel
             .registry()
             .bind_konly::<SpiSender>(queued)
-            .await?
+            .await
+            .map_err(RegistrationError::Registry)?
             .into_request_stream(queued)
             .await;
+        let mut chan = Dmac::allocate_channel().ok_or(RegistrationError::NoDmaChannels)?;
         kernel
             .spawn(async move {
                 let spi = unsafe { &*SPI_DBI::PTR };
@@ -167,26 +172,12 @@ impl SpiSenderServer {
                     };
                     let descriptor = d_cfg.try_into().map_err(drop)?;
 
-                    // pre-register wait future to ensure the waker is in place before
-                    // starting the DMA transfer.
-                    let wait = SPI1_TX_DONE.subscribe().await;
-
                     // start the DMA transfer.
-                    let mut chan;
                     unsafe {
-                        chan = Channel::summon_channel(1);
                         chan.set_channel_modes(ChannelMode::Wait, ChannelMode::Wait);
-                        chan.start_descriptor(NonNull::from(&descriptor));
+                        chan.run_descriptor(NonNull::from(&descriptor)).await;
                     }
 
-                    // wait for the DMA transfer to complete.
-                    wait.await
-                        .expect("SPI1_TX_DONE WaitCell should never be closed");
-
-                    // stop the DMA transfer.
-                    unsafe {
-                        chan.stop_dma();
-                    }
                     reply
                         .reply_konly(msg.reply_with_body(|req| {
                             let SpiSenderRequest::Send(payload) = req;

--- a/platforms/allwinner-d1/src/drivers/uart.rs
+++ b/platforms/allwinner-d1/src/drivers/uart.rs
@@ -13,7 +13,7 @@ use crate::dmac::{
     descriptor::{
         AddressMode, BModeSel, BlockSize, DataWidth, DescriptorConfig, DestDrqType, SrcDrqType,
     },
-    Channel, ChannelMode,
+    Channel, ChannelMode, Dmac,
 };
 use kernel::{
     comms::bbq::{new_bidi_channel, BidiHandle, Consumer, GrantW, SpscProducer},
@@ -49,6 +49,12 @@ static UART_RX: AtomicPtr<SpscProducer> = AtomicPtr::new(null_mut());
 
 pub struct D1Uart {
     _x: (),
+}
+
+#[derive(Debug)]
+pub enum RegistrationError {
+    Registry(registry::RegistrationError),
+    NoDmaChannels,
 }
 
 impl D1Uart {
@@ -132,23 +138,12 @@ impl D1Uart {
             };
             let descriptor = d_cfg.try_into().unwrap();
 
-            // pre-register wait future to ensure the waker is in place before
-            // starting the DMA transfer.
-            let wait = TX_DONE.subscribe().await;
-
             // start the DMA transfer.
             unsafe {
                 tx_channel.set_channel_modes(ChannelMode::Wait, ChannelMode::Handshake);
-                tx_channel.start_descriptor(NonNull::from(&descriptor));
+                tx_channel.run_descriptor(NonNull::from(&descriptor)).await;
             }
 
-            // wait for the DMA transfer to complete.
-            wait.await.expect("UART TX_DONE WaitCell is never closed!");
-
-            // stop the DMA transfer.
-            unsafe {
-                tx_channel.stop_dma();
-            }
             rx.release(len);
         }
     }
@@ -177,18 +172,18 @@ impl D1Uart {
         k: &'static Kernel,
         cap_in: usize,
         cap_out: usize,
-        tx_channel: Channel,
-    ) -> Result<(), registry::RegistrationError> {
-        assert_eq!(tx_channel.channel_index(), 0);
-
+    ) -> Result<(), RegistrationError> {
+        let tx_channel = Dmac::allocate_channel().ok_or(RegistrationError::NoDmaChannels)?;
         let (fifo_a, fifo_b) = new_bidi_channel(cap_in, cap_out).await;
 
         let reqs = k
             .registry()
             .bind_konly::<SimpleSerialService>(4)
-            .await?
+            .await
+            .map_err(RegistrationError::Registry)?
             .into_request_stream(4)
             .await;
+
         let _server_hdl = k.spawn(D1Uart::serial_server(fifo_b, reqs)).await;
 
         let (prod, cons) = fifo_a.split();

--- a/platforms/allwinner-d1/src/drivers/uart.rs
+++ b/platforms/allwinner-d1/src/drivers/uart.rs
@@ -13,7 +13,7 @@ use crate::dmac::{
     descriptor::{
         AddressMode, BModeSel, BlockSize, DataWidth, DescriptorConfig, DestDrqType, SrcDrqType,
     },
-    Channel, ChannelMode, Dmac,
+    Channel, ChannelMode,
 };
 use kernel::{
     comms::bbq::{new_bidi_channel, BidiHandle, Consumer, GrantW, SpscProducer},
@@ -172,8 +172,8 @@ impl D1Uart {
         k: &'static Kernel,
         cap_in: usize,
         cap_out: usize,
+        tx_channel: Channel,
     ) -> Result<(), RegistrationError> {
-        let tx_channel = Dmac::allocate_channel().ok_or(RegistrationError::NoDmaChannels)?;
         let (fifo_a, fifo_b) = new_bidi_channel(cap_in, cap_out).await;
 
         let reqs = k


### PR DESCRIPTION
Currently, the assignment of D1 DMAC channels to drivers is somewhat ad-hoc. We hard-code channel 0 as belonging to the UART, and channel 1 as belonging to the SPI_DBI driver, with the interrupt handler for DMAC IRQs specifically dispatching those channel's IRQs to those drivers manually. 

There are some issues with this. The exclusive use of DMA channels is not enforced by the current API, because you can (unsafely) `summon_channel` whenever you want and use a DMA channel that someone else is already using. Furthermore, adding new drivers that also use DMA channels requires hard-coding those additional channel IRQs in the interrupt handler, which must then be kept in sync with the channels actually used by the driver. Also, when a driver wants to wait asynchronously on a DMA transfer, it has to ensure that the DMAC ISR will wake its hard-coded `WaitCell`, and the driver code is responsible for manually pre-registering its waker with that `WaitCell` before actually starting the DMA request. This is unfortunate, and it would be nicer if there was an `async fn` for running DMA transfers that the driver could call without having to repeat all of that code.

This branch improves the way we use the D1's DMAC. In particular, rather than hard-coding specific driver-provided `WaitCell`s to correspond to specific DMA channels, we now have the `Dmac` struct track which channels are in use, and allow drivers to allocate any channel from the DMAC. It will provide them with the next available channel if any are not already claimed. The DMAC now owns a `WaitCell` for each DMA channel, which is used to provide an async `Channel::run_descriptor` method. This method handles pre-registering the waker, starting the DMA request, and ensuring the task is woken, and stops the DMA transfer when it's complete.

The allocation of channels by the DMAC means that adding new drivers that also use DMA is easier: we don't need to track who owns which channel. If we don't run a specific driver based on config, any DMA channels it would use are now available to other drivers, rather than being hardcoded. This way, we can have more than 16 driver implementations that use DMA, as long as we don't enable them all at once.

In a follow-up, I'm also going to add dynamic allocation of DMA channels. Currently, DMA channels are still allocated permanently, and drivers allocate them as soon as they're created and hold onto the channel forever. However, we can modify the `Channel` type to also indicate to the DMAC that it's free when the `Channel` is dropped, allowing it to be reallocated (potentially by a different driver). If all 16 DMA channels are in use at the same time, a driver could then _wait_ until one becomes available. If drivers then make more short-lived claims on DMA channels, rather than holding one channel for their entire lifetime, this would thenallow us to have more than 16 driver implementations which use DMA, or allow driver implementations to freely use multiple DMA channels at the same time, without having to worry about running out of channels.