### PR TITLE
feat(D1): DMAC Driver 2: Electric Boogaloo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5086,6 +5086,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mnemos-bitslab"
+version = "0.1.0"
+dependencies = [
+ "portable-atomic",
+ "proptest",
+]
+
+[[package]]
 name = "mnemos-config"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5116,6 +5116,7 @@ dependencies = [
  "miette",
  "mnemos",
  "mnemos-beepy",
+ "mnemos-bitslab",
  "mnemos-config",
  "riscv",
  "riscv-rt",

--- a/platforms/allwinner-d1/Cargo.toml
+++ b/platforms/allwinner-d1/Cargo.toml
@@ -48,6 +48,7 @@ miette = "5.10.0"
 serde = { version = "1.0.178", features = ["derive"], default-features = false }
 d1-config = { path = "./d1-config" }
 mnemos-config = { path = "../../source/config" }
+mnemos-bitslab = { path = "../../source/bitslab" }
 
 d1-pac = "0.0.31"
 critical-section = "1.1.1"

--- a/platforms/allwinner-d1/src/dmac/descriptor.rs
+++ b/platforms/allwinner-d1/src/dmac/descriptor.rs
@@ -1,3 +1,6 @@
+//! DMAC [`Descriptor`]s configure DMA transfers initiated using the DMAC.
+// Most of the code in this module still needs documentation...
+#![allow(missing_docs)]
 // Unusual groupings are used in binary literals in this file in order to
 // separate the bits by which field they represent, rather than by their byte.
 #![allow(clippy::unusual_byte_groupings)]

--- a/platforms/allwinner-d1/src/dmac/mod.rs
+++ b/platforms/allwinner-d1/src/dmac/mod.rs
@@ -330,6 +330,10 @@ impl Dmac {
         });
     }
 
+    /// Cancel *all* currently active DMA transfers.
+    ///
+    /// This is generally used when shutting down the system, such as in panic
+    /// and exception handlers.
     pub(crate) unsafe fn cancel_all() {
         for (i, channel) in DMAC_STATE.channels.iter().enumerate() {
             channel.waker.close();
@@ -463,7 +467,7 @@ impl Channel {
     /// [`Channel::start_descriptor`], it is possible to manipulate the channel
     /// register block while a transfer is in progress. I don't know what
     /// happens if you do this, but it's probably bad.
-    pub unsafe fn desc_addr_reg(&self) -> &Reg<DMAC_DESC_ADDR_SPEC> {
+    unsafe fn desc_addr_reg(&self) -> &Reg<DMAC_DESC_ADDR_SPEC> {
         let dmac = &*DMAC::PTR;
         match self.idx {
             0 => &dmac.dmac_desc_addr0,
@@ -505,7 +509,7 @@ impl Channel {
     /// [`Channel::start_descriptor`], it is possible to manipulate the channel
     /// register block while a transfer is in progress. I don't know what
     /// happens if you do this, but it's probably bad.
-    pub unsafe fn en_reg(&self) -> &Reg<DMAC_EN_SPEC> {
+    unsafe fn en_reg(&self) -> &Reg<DMAC_EN_SPEC> {
         let dmac = &*DMAC::PTR;
         match self.idx {
             0 => &dmac.dmac_en0,
@@ -547,7 +551,7 @@ impl Channel {
     /// [`Channel::start_descriptor`], it is possible to manipulate the channel
     /// register block while a transfer is in progress. I don't know what
     /// happens if you do this, but it's probably bad.
-    pub unsafe fn mode_reg(&self) -> &Reg<DMAC_MODE_SPEC> {
+    unsafe fn mode_reg(&self) -> &Reg<DMAC_MODE_SPEC> {
         let dmac = &*DMAC::PTR;
         match self.idx {
             0 => &dmac.dmac_mode0,
@@ -586,7 +590,7 @@ impl Channel {
     /// The caller must not initiate another transfer on this channel until the
     /// transfer started using `start_descriptor` completes. I don't know what
     /// happens if you do this, but I'm sure it's bad.
-    pub unsafe fn start_descriptor(&mut self, desc: NonNull<Descriptor>) {
+    unsafe fn start_descriptor(&mut self, desc: NonNull<Descriptor>) {
         fence(Ordering::SeqCst); //////
 
         let desc_addr = desc.as_ptr() as usize;
@@ -612,7 +616,7 @@ impl Channel {
     /// This is actually pretty safe. AFAICT, calling `stop_dma` on a channel
     /// with no transfer currently in flight seems fine, actually. But, this
     /// does a raw MMIO register write, so.
-    pub unsafe fn stop_dma(&mut self) {
+    unsafe fn stop_dma(&mut self) {
         self.en_reg().write(|w| w.dma_en().disabled());
         fence(Ordering::SeqCst); //////
     }

--- a/platforms/allwinner-d1/src/dmac/mod.rs
+++ b/platforms/allwinner-d1/src/dmac/mod.rs
@@ -217,20 +217,16 @@ impl Dmac {
     /// dropped, the descriptor and its associated memory region may also be
     /// dropped safely.
     ///
-    /// Of course, the transfer may still have completed partially, and if we
+    /// Of course, the transfer may still have completed partially. If we
     /// were writing to a device, the device may be unhappy to have only gotten
-    /// some of the data it wanted. Cancelling an incomplete transfer may result
-    /// in, for example, writing out half of a string to the UART, or only part
-    /// of a structured message over SPI, and so on. But, at least we don't have
-    /// abandoned DMA transfers running around in random parts of the heap you
-    /// probably wanted to use for normal stuff like having strings, or whatever
-    /// it is that people do on the computer.
-    ///
-    /// If the DMA transfer was a read rather than a write, cancelling a partial
-    /// transfer will have no ill effects whatsoever.[^1]
-    ///
-    /// [^1]: Unless you actually wanted to have the data you were reading, but
-    ///     then you probably wouldn't have cancelled it.
+    /// some of the data it wanted. If we were reading from a device, reads may
+    /// have side effects and incomplete reads may leave the device in a weird
+    /// state. Cancelling an incomplete transfer may result in, for example,
+    /// writing out half of a string to the UART, or only part  of a structured
+    /// message over SPI, and so on. But, at least we don't have abandoned DMA
+    /// transfers running around in random parts of the heap you probably wanted
+    /// to use for normal stuff like having strings, or whatever it is that
+    /// people do on the computer.
     pub async unsafe fn transfer(
         &self,
         src: ChannelMode,
@@ -397,20 +393,15 @@ impl Channel {
     /// dropped, the descriptor and its associated memory region may also be
     /// dropped safely.
     ///
-    /// Of course, the transfer may still have completed partially, and if we
     /// were writing to a device, the device may be unhappy to have only gotten
-    /// some of the data it wanted. Cancelling an incomplete transfer may result
-    /// in, for example, writing out half of a string to the UART, or only part
-    /// of a structured message over SPI, and so on. But, at least we don't have
-    /// abandoned DMA transfers running around in random parts of the heap you
-    /// probably wanted to use for normal stuff like having strings, or whatever
-    /// it is that people do on the computer.
-    ///
-    /// If the DMA transfer was a read rather than a write, cancelling a partial
-    /// transfer will have no ill effects whatsoever.[^1]
-    ///
-    /// [^1]: Unless you actually wanted to have the data you were reading, but
-    ///     then you probably wouldn't have cancelled it.
+    /// some of the data it wanted. If we were reading from a device, reads may
+    /// have side effects and incomplete reads may leave the device in a weird
+    /// state. Cancelling an incomplete transfer may result in, for example,
+    /// writing out half of a string to the UART, or only part  of a structured
+    /// message over SPI, and so on. But, at least we don't have abandoned DMA
+    /// transfers running around in random parts of the heap you probably wanted
+    /// to use for normal stuff like having strings, or whatever it is that
+    /// people do on the computer.
     pub async unsafe fn transfer(&mut self, desc: NonNull<Descriptor>) {
         /// Drop guard ensuring that if a `transfer` future is cancelled
         /// before it completes, the in-flight DMA transfer on that channel is dropped.

--- a/platforms/allwinner-d1/src/dmac/mod.rs
+++ b/platforms/allwinner-d1/src/dmac/mod.rs
@@ -71,7 +71,7 @@ pub enum ChannelMode {
     /// In this mode, the DMAC will wait for a configurable number of clock
     /// cycles before automatically starting the next transfer.
     ///
-    /// The Allwinner documentationh for the D1 describes this mode as follows:
+    /// The Allwinner documentation for the D1 describes this mode as follows:
     ///
     /// > * When the DMAC detects a valid external request signal, the DMAC
     /// >   starts to operate the peripheral device. The internal DRQ always

--- a/platforms/allwinner-d1/src/lib.rs
+++ b/platforms/allwinner-d1/src/lib.rs
@@ -202,25 +202,15 @@ impl D1 {
         };
 
         // Initialize SPI stuff
-        k.initialize({
-            let chan = dmac
-                .allocate_channel()
-                .expect("failed to allocate DMA channel for SPI_DBI!");
-            async move {
-                // Register a new SpiSenderServer
-                SpiSenderServer::register(k, chan, 4).await.unwrap();
-            }
+        k.initialize(async move {
+            // Register a new SpiSenderServer
+            SpiSenderServer::register(k, dmac, 4).await.unwrap();
         })
         .unwrap();
 
         // Initialize SimpleSerial driver
-        k.initialize({
-            let tx_channel = dmac
-                .allocate_channel()
-                .expect("failed to allocate DMA channel for UART!");
-            async move {
-                D1Uart::register(k, 4096, 4096, tx_channel).await.unwrap();
-            }
+        k.initialize(async move {
+            D1Uart::register(k, dmac, 4096, 4096).await.unwrap();
         })
         .unwrap();
 

--- a/source/bitslab/Cargo.toml
+++ b/source/bitslab/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mnemos-bitslab"
+version = "0.1.0"
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+portable-atomic = { version = "1", default-features = false }
+
+[dev-dependencies]
+proptest = "1"

--- a/source/bitslab/src/index.rs
+++ b/source/bitslab/src/index.rs
@@ -1,0 +1,84 @@
+use portable_atomic::{AtomicU16, Ordering::*};
+
+/// An allocator for up to 16 unique indices.
+pub struct IndexAlloc16(AtomicU16);
+
+impl IndexAlloc16 {
+    /// Returns a new allocator for up to 16 unique indices.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(AtomicU16::new(0))
+    }
+
+    /// Allocate an index from the pool.
+    ///
+    /// If this method returns [`Some`], the returned [`u8`] index will not be
+    /// returned again until after it has been [`free`](Self::free)d.
+    #[must_use]
+    pub fn allocate(&self) -> Option<u8> {
+        let mut bitmap = self.0.load(Acquire);
+        loop {
+            let idx = find_zero(bitmap)?;
+            let new_bitmap = bitmap | (1 << idx);
+            match self
+                .0
+                .compare_exchange_weak(bitmap, new_bitmap, AcqRel, Acquire)
+            {
+                Ok(_) => return Some(idx),
+                Err(actual) => bitmap = actual,
+            }
+        }
+    }
+
+    /// Release an index back to the pool.
+    ///
+    /// The freed index may now be returned by a subsequent call to [`allocate`](Self::allocate).
+    #[inline]
+    pub fn free(&self, index: u8) {
+        self.0.fetch_and(!(1 << index), Release);
+    }
+
+    /// Returns `true` if all indices in the allocator have been allocated.
+    #[must_use]
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.load(Acquire) == u16::MAX
+    }
+
+    /// Returns `true` if none of this allocator's indices have been allocated.
+    #[must_use]
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        self.0.load(Acquire) == 0
+    }
+}
+
+fn find_zero(u: u16) -> Option<u8> {
+    let trailing_ones = u.trailing_ones();
+    if trailing_ones == 16 {
+        None
+    } else {
+        Some(trailing_ones as u8)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::{prop_assert_eq, proptest};
+
+    proptest! {
+        #[test]
+        fn find_zero_works(u: u16) {
+            let mut found_zero = None;
+            for i in 0..u16::BITS {
+                if u & (1 << i) == 0 {
+                    found_zero = Some(i as u8);
+                    break;
+                }
+            }
+
+            prop_assert_eq!(find_zero(u), found_zero)
+        }
+    }
+}

--- a/source/bitslab/src/index.rs
+++ b/source/bitslab/src/index.rs
@@ -30,26 +30,192 @@ impl IndexAlloc16 {
         }
     }
 
+    /// The *total* number of indices in this allocator.
+    pub const CAPACITY: u8 = 16;
+
     /// Release an index back to the pool.
     ///
-    /// The freed index may now be returned by a subsequent call to [`allocate`](Self::allocate).
+    /// The freed index may now be returned by a subsequent call to
+    /// [`allocate`](Self::allocate).
     #[inline]
     pub fn free(&self, index: u8) {
         self.0.fetch_and(!(1 << index), Release);
     }
 
-    /// Returns `true` if all indices in the allocator have been allocated.
+    /// Returns `true` if *all* indices in the allocator have been allocated.
+    ///
+    /// This is the inverse of [`any_free`](Self::any_free).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mnemos_bitslab::index::IndexAlloc16;
+    ///
+    /// let alloc = IndexAlloc16::new();
+    /// assert!(!alloc.all_allocated());
+    ///
+    /// // allocate all but one index
+    /// for _ in 0..15 {
+    ///     alloc.allocate().expect("should have free indices");
+    /// assert!(!alloc.all_allocated());
+    /// }
+    ///
+    /// // allocate the last index.
+    /// let last = alloc.allocate().expect("should have one more index remaining");
+    /// assert!(alloc.all_allocated());
+    ///
+    /// // freeing the index should make it available again
+    /// alloc.free(last);
+    /// assert!(!alloc.all_allocated());
+    /// ```
     #[must_use]
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub fn all_allocated(&self) -> bool {
         self.0.load(Acquire) == u16::MAX
     }
 
-    /// Returns `true` if none of this allocator's indices have been allocated.
+    /// Returns `true` if *none* of this allocator's indices have been
+    /// allocated.
+    ///
+    /// This is the inverse of [`any_allocated`](Self::any_allocated).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mnemos_bitslab::index::IndexAlloc16;
+    ///
+    /// let alloc = IndexAlloc16::new();
+    /// assert!(alloc.all_free());
+    ///
+    /// let idx = alloc.allocate().expect("a fresh allocator should have indices!");
+    /// assert!(!alloc.all_free());
+    ///
+    /// // free the last index. now, `all_free` will return `true` again.
+    /// alloc.free(idx);
+    /// assert!(alloc.all_free());
+    /// ```
     #[must_use]
     #[inline]
-    pub fn is_full(&self) -> bool {
+    pub fn all_free(&self) -> bool {
         self.0.load(Acquire) == 0
+    }
+
+    /// Returns `true` if *any* index in the allocator has been allocated.
+    ///
+    /// This is the inverse of [`all_free`](Self::all_free).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mnemos_bitslab::index::IndexAlloc16;
+    ///
+    /// let alloc = IndexAlloc16::new();
+    /// assert!(!alloc.any_allocated());
+    ///
+    /// // allocate all indices
+    /// for _ in 0..16 {
+    ///     alloc.allocate().expect("should have free indices");
+    ///     assert!(alloc.any_allocated());
+    /// }
+    ///
+    /// // free all but one index.
+    /// for i in 0..15 {
+    ///     alloc.free(i);
+    ///     assert!(alloc.any_allocated());
+    /// }
+    ///
+    /// // free the last index. now, `any_allocated` will return `false`.
+    /// alloc.free(15);
+    /// assert!(!alloc.any_allocated());
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn any_allocated(&self) -> bool {
+        self.0.load(Acquire) != 0
+    }
+
+    /// Returns `true` if *any* index in the allocator is available.
+    ///
+    /// This is the inverse of [`all_allocated`](Self::all_allocated).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mnemos_bitslab::index::IndexAlloc16;
+    ///
+    /// let alloc = IndexAlloc16::new();
+    /// assert!(alloc.any_free());
+    ///
+    /// // allocate all but one index
+    /// for _ in 0..15 {
+    ///     alloc.allocate().expect("should have free indices");
+    ///     assert!(alloc.any_free());
+    /// }
+    ///
+    /// // allocate the last index.
+    /// let last = alloc.allocate().expect("should have one more index remaining");
+    /// assert!(!alloc.any_free());
+    ///
+    /// // freeing the index should make it available again
+    /// alloc.free(last);
+    /// assert!(alloc.any_free());
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn any_free(&self) -> bool {
+        self.0.load(Acquire) != u16::MAX
+    }
+
+    /// Returns the current number of free indices in the allocator.
+    ///
+    /// This will always be [`Self::CAPACITY`] or less.
+    ///
+    /// ```
+    /// use mnemos_bitslab::index::IndexAlloc16;
+    ///
+    /// let alloc = IndexAlloc16::new();
+    /// assert_eq!(alloc.free_count(), 16);
+    ///
+    /// let idx1 = alloc.allocate().expect("all indices should be free");
+    /// assert_eq!(alloc.free_count(), 15);
+    ///
+    /// let idx2 = alloc.allocate().expect("15 indices should be free");
+    /// assert_eq!(alloc.free_count(), 14);
+    ///
+    /// alloc.free(idx1);
+    /// assert_eq!(alloc.free_count(), 15);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn free_count(&self) -> u8 {
+        self.0.load(Acquire).count_zeros() as u8
+    }
+
+    /// Returns the current number of allocated indices in the allocator.
+    ///
+    /// This will always be [`Self::CAPACITY`] or less.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mnemos_bitslab::index::IndexAlloc16;
+    ///
+    /// let alloc = IndexAlloc16::new();
+    /// assert_eq!(alloc.allocated_count(), 0);
+    ///
+    /// let idx1 = alloc.allocate().expect("all indices should be free");
+    /// assert_eq!(alloc.allocated_count(), 1);
+    ///
+    /// let idx2 = alloc.allocate().expect("15 indices should be free");
+    /// assert_eq!(alloc.allocated_count(), 2);
+    ///
+    /// alloc.free(idx1);
+    /// assert_eq!(alloc.allocated_count(), 1);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn allocated_count(&self) -> u8 {
+        self.0.load(Acquire).count_ones() as u8
     }
 }
 

--- a/source/bitslab/src/lib.rs
+++ b/source/bitslab/src/lib.rs
@@ -1,0 +1,2 @@
+#![cfg_attr(not(test), no_std)]
+pub mod index;


### PR DESCRIPTION
This branch kinda rewrites a bunch of the DMAC code. Now, DMA channels
are capable of being dynamically allocated on demand using a cool atomic
bitset thingy, and released back to the DMAC pool when they're no longer
in use. This will allow us to have multiple drivers that consume
basically as many DMA channels as they want to, rather than having a
fixed assignment of DMA channels to drivers which has to be maintained
by manually updating the DMAC IRQ handler every time we add a new driver
that wants to do a DMA. A channel can be allocated from the pool once
and used for multiple transfers, if a driver needs to make a bunch of
transfers in sequence and doesn't want to have to round trip through the
channel pool, but they can also be grabbed for oneshot transfers and
immediately released.

I also fixed the cancel safety of the async `Channel::transfer`
(formerly `Channel::run_descriptor`) method, which would previously
leave the transfer running if the future is dropped. This means that if
a caller assumed dropping the transfer future meant that the transfer
descriptor's buffer could be freed, the transfer might complete later
and trample memory that has been reallocated. THAT SEEMS KINDA BAD LOL.
So, now, dropping a `Channel::transfer` future will cancel the transfer
if it hasn't finished yet, allowing fun stuff like attaching a timeout
to a transfer if you really want to. Of course, the transfer may still
have completed partially, and if we were writing to a device, the device
may be unhappy to have only gotten some of the data it wanted. But, at
least we don't have abandoned DMA transfers running around in random
parts of the heap you probably wanted to use for normal stuff like
having strings, or whatever it is that people do on the computer. So
that's better.

Unfortunately, while we can easily make the DMA transfers `Drop`-safe,
we can't really make them `mem::forget`-safe without passing the DMA
buffer into the future and leaking it if it gets forgetted. This is
probably a good idea but would require a nice higher-level interface
around constructing DMA descriptors from buffer-shaped memory regions,
which I didn't want to do tonight. So, the DMA transfer APIs are still
`unsafe` and maybe we can add a nicer thing on top later. In the
meantime, probably don't `mem::forget` DMA transfers. Honestly there is
no reason for normal people to do that so I don't feel super bad about
it.