### PR TITLE
feat(D1): add builders for DMAC descriptors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5133,6 +5133,8 @@ dependencies = [
  "mnemos",
  "mnemos-bitslab",
  "mycelium-bitfield 0.1.3 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "proptest",
+ "proptest-derive",
  "riscv",
  "riscv-rt",
  "serde",
@@ -6333,6 +6335,17 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5132,6 +5132,7 @@ dependencies = [
  "futures",
  "mnemos",
  "mnemos-bitslab",
+ "mycelium-bitfield 0.1.3 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
  "riscv",
  "riscv-rt",
  "serde",

--- a/platforms/allwinner-d1/Cargo.toml
+++ b/platforms/allwinner-d1/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/tosc-rs/mnemos"
 homepage = "https://mnemos.dev"
 readme = "./README.md"
 license = "MIT OR Apache-2.0"
-forced-target = "riscv64imac-unknown-none-elf"
+default-target = "riscv64imac-unknown-none-elf"
 
 [lib]
 test = false

--- a/platforms/allwinner-d1/d1-core/Cargo.toml
+++ b/platforms/allwinner-d1/d1-core/Cargo.toml
@@ -43,3 +43,7 @@ version = "0.7.1"
 version = "0.3.21"
 features = ["async-await"]
 default-features = false
+
+[dev-dependencies]
+proptest = "1"
+proptest-derive = "0.4.0"

--- a/platforms/allwinner-d1/d1-core/Cargo.toml
+++ b/platforms/allwinner-d1/d1-core/Cargo.toml
@@ -17,6 +17,7 @@ sharp-display = []
 [dependencies]
 serde = { version = "1.0.178", features = ["derive"], default-features = false }
 mnemos-bitslab = { path = "../../../source/bitslab" }
+mycelium-bitfield = "0.1.3"
 
 d1-pac = "0.0.31"
 critical-section = "1.1.1"

--- a/platforms/allwinner-d1/d1-core/proptest-regressions/dmac/descriptor.txt
+++ b/platforms/allwinner-d1/d1-core/proptest-regressions/dmac/descriptor.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 4f86fc0f074d90d51a18ecfed5bace9a7d75c234378f2ff334584ffb761abe86 # shrinks to cfg = ArbitraryConfig { src_drq_type: Sram, src_block_size: Byte1, src_addr_mode: LinearMode, src_data_width: Bit8, dest_drq_type: Sram, dest_block_size: Byte1, dest_addr_mode: LinearMode, dest_data_width: Bit16, bmode_sel: Normal }

--- a/platforms/allwinner-d1/d1-core/src/dmac/descriptor.rs
+++ b/platforms/allwinner-d1/d1-core/src/dmac/descriptor.rs
@@ -547,13 +547,16 @@ impl DescriptorBuilder<*const (), *mut ()> {
 impl Descriptor {
     const END_LINK: u32 = 0xFFFF_F800;
 
-    /// Maximum value for the `byte_counter` argument to
-    /// [`DescriptorBuilder::build`] --- byte counters must be 25 bits wide or
-    /// less.
+    /// Maximum length for arguments to [`DescriptorBuilder::source_slice`] and
+    /// [`DescriptorBuilder::dest_slice`], and to the `len` argument to
+    /// [`DescriptorBuilder::try_build`] --- byte counters must be 25 bits wide
+    /// or less.
     pub const MAX_LEN: u32 = (1 << 25) - 1;
 
-    /// Maximum value for the `source` and `destination` arguments to
-    /// [`DescriptorBuilder::build`] --- addresses must be 34 bits wide or less.
+    /// Highest allowable address for arguments to
+    /// [`DescriptorBuilder::source_slice`], [`DescriptorBuilder::dest_slice`],
+    /// [`DescriptorBuilder::source_reg`], and [`DescriptorBuilder::dest_reg`]
+    /// --- addresses must be 34 bits wide or less.
     pub const ADDR_MAX: u64 = (1 << 34) - 1;
 
     /// Maximum value for the `link` address passed to

--- a/platforms/allwinner-d1/d1-core/src/dmac/descriptor.rs
+++ b/platforms/allwinner-d1/d1-core/src/dmac/descriptor.rs
@@ -269,7 +269,7 @@ impl DescriptorBuilder {
         }
         if let Some(link) = self.link {
             if (link as usize & 0b11) != 0 {
-                return Err("link address's lowest two bits must be unset");
+                return Err("linked descriptors must be at least 4-byte aligned");
             }
         }
 

--- a/platforms/allwinner-d1/d1-core/src/dmac/descriptor.rs
+++ b/platforms/allwinner-d1/d1-core/src/dmac/descriptor.rs
@@ -366,8 +366,7 @@ impl Descriptor {
 
         // We already verified above the low bits of `link` are clear,
         // no need to re-mask them.
-        let link = addr as u32 | ((addr >> 32) as u32) & 0b11;
-        Ok(link as u32)
+        Ok(addr as u32 | ((addr >> 32) as u32) & 0b11)
     }
 }
 

--- a/platforms/allwinner-d1/d1-core/src/dmac/descriptor.rs
+++ b/platforms/allwinner-d1/d1-core/src/dmac/descriptor.rs
@@ -16,6 +16,15 @@ pub struct Descriptor {
     link: u32,
 }
 
+mycelium_bitfield::bitfield! {
+    struct Parameter<u32> {
+        const WAIT_CYCLES = 8;
+        const _RESERVED0 = 8;
+        const SRC_HIGH = 2;
+
+    }
+}
+
 // TODO: THIS COULD PROBABLY BE A BITFIELD LIBRARY
 pub struct DescriptorConfig {
     pub source: *const (),
@@ -39,100 +48,141 @@ pub struct DescriptorConfig {
     pub src_drq_type: SrcDrqType,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy)]
-#[repr(u8)]
-pub enum SrcDrqType {
-    Sram = 0,
-    Dram = 1,
-    OwaRx = 2,
-    I2sPcm0Rx = 3,
-    I2sPcm1Rx = 4,
-    I2sPcm2Rx = 5,
-    AudioCodec = 7,
-    Dmic = 8,
-    GpADC = 12,
-    TpADC = 13,
-    Uart0Rx = 14,
-    Uart1Rx = 15,
-    Uart2Rx = 16,
-    Uart3Rx = 17,
-    Uart4Rx = 18,
-    Uart5Rx = 19,
-    Spi0Rx = 22,
-    Spi1Rx = 23,
-    Usb0Ep1 = 30,
-    Usb0Ep2 = 31,
-    Usb0Ep3 = 32,
-    Usb0Ep4 = 33,
-    Usb0Ep5 = 34,
-    Twi0 = 43,
-    Twi1 = 44,
-    Twi2 = 45,
-    Twi3 = 46,
+mycelium_bitfield::bitfield! {
+    pub struct Configuration<u32> {
+        /// DMA source DRQ type.
+        pub const SRC_DRQ_TYPE: SrcDrqType;
+
+        /// DMA source block size.
+        pub const SRC_BLOCK_SIZE: BlockSize;
+
+        /// DMA source address mode.
+        pub const SRC_ADDR_MODE: AddressMode;
+
+        /// DMA source data width.
+        pub const SRC_DATA_WIDTH: DataWidth;
+
+        const _RESERVED_0 = 4;
+
+        /// DMA destination DRQ type
+        pub const DEST_DRQ_TYPE: DestDrqType;
+
+        /// DMA destination block size.
+        pub const DEST_BLOCK_SIZE: BlockSize;
+
+        /// DMA destination address mode.
+        pub const DEST_ADDR_MODE: AddressMode;
+
+        /// DMA destination data width.
+        pub const DEST_DATA_WIDTH: DataWidth;
+
+        const _RESERVED_1 = 3;
+
+        /// BMODE select
+        pub const BMODE_SEL: BModeSel;
+    }
 }
 
-#[derive(Eq, PartialEq, Clone, Copy)]
-#[repr(u8)]
-pub enum DestDrqType {
-    Sram = 0,
-    Dram = 1,
-    OwaTx = 2,
-    I2sPcm0Tx = 3,
-    I2sPcm1Tx = 4,
-    I2sPcm2Tx = 5,
-    AudioCodec = 7,
-    IrTx = 13,
-    Uart0Tx = 14,
-    Uart1Tx = 15,
-    Uart2Tx = 16,
-    Uart3Tx = 17,
-    Uart4Tx = 18,
-    Uart5Tx = 19,
-    Spi0Tx = 22,
-    Spi1Tx = 23,
-    Usb0Ep1 = 30,
-    Usb0Ep2 = 31,
-    Usb0Ep3 = 32,
-    Usb0Ep4 = 33,
-    Usb0Ep5 = 34,
-    Ledc = 42,
-    Twi0 = 43,
-    Twi1 = 44,
-    Twi2 = 45,
-    Twi3 = 46,
+mycelium_bitfield::enum_from_bits! {
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum SrcDrqType<u8> {
+        Sram = 0,
+        Dram = 1,
+        OwaRx = 2,
+        I2sPcm0Rx = 3,
+        I2sPcm1Rx = 4,
+        I2sPcm2Rx = 5,
+        AudioCodec = 7,
+        Dmic = 8,
+        GpADC = 12,
+        TpADC = 13,
+        Uart0Rx = 14,
+        Uart1Rx = 15,
+        Uart2Rx = 16,
+        Uart3Rx = 17,
+        Uart4Rx = 18,
+        Uart5Rx = 19,
+        Spi0Rx = 22,
+        Spi1Rx = 23,
+        Usb0Ep1 = 30,
+        Usb0Ep2 = 31,
+        Usb0Ep3 = 32,
+        Usb0Ep4 = 33,
+        Usb0Ep5 = 34,
+        Twi0 = 43,
+        Twi1 = 44,
+        Twi2 = 45,
+        Twi3 = 46,
+    }
+}
+
+mycelium_bitfield::enum_from_bits! {
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum DestDrqType<u8> {
+        Sram = 0,
+        Dram = 1,
+        OwaTx = 2,
+        I2sPcm0Tx = 3,
+        I2sPcm1Tx = 4,
+        I2sPcm2Tx = 5,
+        AudioCodec = 7,
+        IrTx = 13,
+        Uart0Tx = 14,
+        Uart1Tx = 15,
+        Uart2Tx = 16,
+        Uart3Tx = 17,
+        Uart4Tx = 18,
+        Uart5Tx = 19,
+        Spi0Tx = 22,
+        Spi1Tx = 23,
+        Usb0Ep1 = 30,
+        Usb0Ep2 = 31,
+        Usb0Ep3 = 32,
+        Usb0Ep4 = 33,
+        Usb0Ep5 = 34,
+        Ledc = 42,
+        Twi0 = 43,
+        Twi1 = 44,
+        Twi2 = 45,
+        Twi3 = 46,
+}
 }
 
 // TODO: Verify bits or bytes?
-#[derive(Eq, PartialEq, Clone, Copy)]
-#[repr(u8)]
-pub enum BlockSize {
-    Byte1 = 0b00,
-    Byte4 = 0b01,
-    Byte8 = 0b10,
-    Byte16 = 0b11,
+mycelium_bitfield::enum_from_bits! {
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum BlockSize<u8> {
+        Byte1 = 0b00,
+        Byte4 = 0b01,
+        Byte8 = 0b10,
+        Byte16 = 0b11,
+    }
 }
 
-#[derive(Eq, PartialEq, Clone, Copy)]
-#[repr(u8)]
-pub enum AddressMode {
-    LinearMode = 0,
-    IoMode = 1,
+mycelium_bitfield::enum_from_bits! {
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum AddressMode<u8> {
+        LinearMode = 0,
+        IoMode = 1,
+    }
 }
 
-#[derive(Eq, PartialEq, Clone, Copy)]
-#[repr(u8)]
-pub enum DataWidth {
-    Bit8 = 0b00,
-    Bit16 = 0b01,
-    Bit32 = 0b10,
-    Bit64 = 0b11,
+mycelium_bitfield::enum_from_bits! {
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum DataWidth<u8> {
+        Bit8 = 0b00,
+        Bit16 = 0b01,
+        Bit32 = 0b10,
+        Bit64 = 0b11,
+    }
 }
 
-#[derive(Eq, PartialEq, Clone, Copy)]
-#[repr(u8)]
-pub enum BModeSel {
-    Normal,
-    BMode,
+mycelium_bitfield::enum_from_bits! {
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum BModeSel<u8> {
+        Normal = 0,
+        BMode = 1,
+    }
 }
 
 // Descriptor

--- a/platforms/allwinner-d1/d1-core/src/dmac/descriptor.rs
+++ b/platforms/allwinner-d1/d1-core/src/dmac/descriptor.rs
@@ -272,7 +272,18 @@ impl DescriptorBuilder {
         }
     }
 
-    pub fn build(
+    pub fn build<S, D>(
+        self,
+        source: &S,
+        destination: &mut D,
+        byte_counter: u32,
+    ) -> Result<Descriptor, InvalidDescriptor> {
+        let source = source as *const _ as *const ();
+        let destination = destination as *mut _ as *mut ();
+        self.build_raw(source, destination, byte_counter)
+    }
+
+    pub fn build_raw(
         self,
         source: *const (),
         destination: *mut (),

--- a/platforms/allwinner-d1/d1-core/src/dmac/descriptor.rs
+++ b/platforms/allwinner-d1/d1-core/src/dmac/descriptor.rs
@@ -31,41 +31,6 @@ pub struct DescriptorBuilder<S = (), D = ()> {
     dest: D,
 }
 
-mycelium_bitfield::bitfield! {
-    struct Cfg<u32> {
-        /// DMA source DRQ type.
-        const SRC_DRQ_TYPE: SrcDrqType;
-
-        /// DMA source block size.
-        const SRC_BLOCK_SIZE: BlockSize;
-
-        /// DMA source address mode.
-        const SRC_ADDR_MODE: AddressMode;
-
-        /// DMA source data width.
-        const SRC_DATA_WIDTH: DataWidth;
-
-        const _RESERVED_0 = 5;
-
-        /// DMA destination DRQ type
-        const DEST_DRQ_TYPE: DestDrqType;
-
-        /// DMA destination block size.
-        const DEST_BLOCK_SIZE: BlockSize;
-
-        /// DMA destination address mode.
-        const DEST_ADDR_MODE: AddressMode;
-
-        /// DMA destination data width.
-        const DEST_DATA_WIDTH: DataWidth;
-
-        const _RESERVED_1 = 3;
-
-        /// BMODE select
-        const BMODE_SEL: BModeSel;
-    }
-}
-
 mycelium_bitfield::enum_from_bits! {
     #[derive(Debug, Eq, PartialEq)]
     #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
@@ -171,6 +136,41 @@ mycelium_bitfield::enum_from_bits! {
     pub enum BModeSel<u8> {
         Normal = 0,
         BMode = 1,
+    }
+}
+
+mycelium_bitfield::bitfield! {
+    struct Cfg<u32> {
+        /// DMA source DRQ type.
+        const SRC_DRQ_TYPE: SrcDrqType;
+
+        /// DMA source block size.
+        const SRC_BLOCK_SIZE: BlockSize;
+
+        /// DMA source address mode.
+        const SRC_ADDR_MODE: AddressMode;
+
+        /// DMA source data width.
+        const SRC_DATA_WIDTH: DataWidth;
+
+        const _RESERVED_0 = 5;
+
+        /// DMA destination DRQ type
+        const DEST_DRQ_TYPE: DestDrqType;
+
+        /// DMA destination block size.
+        const DEST_BLOCK_SIZE: BlockSize;
+
+        /// DMA destination address mode.
+        const DEST_ADDR_MODE: AddressMode;
+
+        /// DMA destination data width.
+        const DEST_DATA_WIDTH: DataWidth;
+
+        const _RESERVED_1 = 3;
+
+        /// BMODE select
+        const BMODE_SEL: BModeSel;
     }
 }
 

--- a/platforms/allwinner-d1/d1-core/src/drivers/spim.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/spim.rs
@@ -182,8 +182,7 @@ impl SpiSenderServer {
                         let descriptor = descr_cfg
                             .source_slice(chunk)
                             .expect("slice should be a valid DMA source")
-                            .build()
-                            .expect("failed to build SPI1_TX DMA descriptor");
+                            .build();
 
                         // start the DMA transfer.
                         unsafe {

--- a/platforms/allwinner-d1/d1-core/src/drivers/uart.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/uart.rs
@@ -124,12 +124,12 @@ impl D1Uart {
         loop {
             let rx = cons.read_grant().await;
             let len = rx.len();
-            let thr_addr = unsafe { &*UART0::PTR }.thr() as *const _ as *mut ();
+            let thr = unsafe { &mut *((*UART0::PTR).thr() as *const _ as *mut u32) };
 
             let rx_sli: &[u8] = &rx;
 
             let descriptor = descr_cfg
-                .build(rx_sli.as_ptr().cast(), thr_addr, rx_sli.len() as u32)
+                .build(&rx_sli[0], thr, rx_sli.len() as u32)
                 .expect("failed to build UART0 DMA transfer descriptor");
 
             // start the DMA transfer.

--- a/platforms/allwinner-d1/d1-core/src/drivers/uart.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/uart.rs
@@ -124,12 +124,12 @@ impl D1Uart {
         loop {
             let rx = cons.read_grant().await;
             let len = rx.len();
-            let thr = unsafe { &mut *((*UART0::PTR).thr() as *const _ as *mut u32) };
+            let thr_addr = unsafe { &*UART0::PTR }.thr() as *const _ as *mut ();
 
             let rx_sli: &[u8] = &rx;
 
             let descriptor = descr_cfg
-                .build(&rx_sli[0], thr, rx_sli.len() as u32)
+                .build_raw(rx_sli.as_ptr().cast(), thr_addr, rx_sli.len() as u32)
                 .expect("failed to build UART0 DMA transfer descriptor");
 
             // start the DMA transfer.

--- a/platforms/allwinner-d1/d1-core/src/drivers/uart.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/uart.rs
@@ -147,8 +147,7 @@ impl D1Uart {
                 let descriptor = descr_cfg
                     .source_slice(chunk)
                     .expect("slice should be a valid DMA source operand")
-                    .build()
-                    .expect("failed to build UART0 DMA transfer descriptor");
+                    .build();
 
                 // start the DMA transfer.
                 unsafe { chan.transfer(NonNull::from(&descriptor)).await }


### PR DESCRIPTION
Currently, the DMAC descriptor configuration fields are bit-packed every
time a descriptor is constructed. However, the drivers which use DMA
always construct descriptors with the same configuration bitfields --
only the addresses and lengths change. We can make this more efficient
by constructing the config field once and copying it into each new
descriptor.

This branch replaces the existing `DescriptorConfig` struct with a
`DescriptorBuilder`, which is basically the same thing except it
actually constructs the bitfield as a single u32. I used
`mycelium-bitfield` to do this --- mostly for fun, but it's maybe a bit
more readable than the previous code? I dunno.