### PR TITLE
fix(mn): use correct "_any-deps" feature name

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@ crowtty = "run --bin crowtty --release --"
 melpomene = "run --bin melpomene --release --"
 melpo = "melpomene"
 forth3 = "run --bin f3repl --release --"
-mn = "run --package manganese --bin manganese --release --features=install-deps --"
+mn = "run --package manganese --bin manganese --release --features install-deps --"
 
 [build]
 # Currently needed for `tokio-console` support.

--- a/tools/manganese/Cargo.toml
+++ b/tools/manganese/Cargo.toml
@@ -24,13 +24,14 @@ install-deps = [
     "trunk",
 ]
 
-just = ["dep:just", "_any_deps"]
-cargo-nextest = ["dep:cargo-nextest", "_any_deps"]
-cargo-binutils = ["dep:cargo-binutils", "_any_deps"]
-cargo-espflash = ["dep:cargo-espflash", "_any_deps"]
+just = ["dep:just", "_any-deps"]
+trunk = ["dep:trunk", "_any-deps"]
+cargo-nextest = ["dep:cargo-nextest", "_any-deps"]
+cargo-binutils = ["dep:cargo-binutils", "_any-deps"]
+cargo-espflash = ["dep:cargo-espflash", "_any-deps"]
 
 # dummy feature that indicates any dependency is being installed.
-_any_deps = []
+_any-deps = []
 
 [dependencies]
 anyhow = "1"

--- a/tools/manganese/build.rs
+++ b/tools/manganese/build.rs
@@ -1,11 +1,11 @@
 fn main() -> anyhow::Result<()> {
-    #[cfg(feature = "_any_deps")]
+    #[cfg(feature = "_any-deps")]
     install_deps()?;
 
     Ok(())
 }
 
-#[cfg(feature = "_any_deps")]
+#[cfg(feature = "_any-deps")]
 fn install_deps() -> anyhow::Result<()> {
     use anyhow::{Context, Result};
     use std::{
@@ -40,7 +40,7 @@ fn install_deps() -> anyhow::Result<()> {
 
         if link.exists() {
             fs::remove_file(link).with_context(|| {
-                format!("failed to remove existing simlink at {}", link.display())
+                format!("failed to remove existing symlink at {}", link.display())
             })?;
         }
 
@@ -48,7 +48,7 @@ fn install_deps() -> anyhow::Result<()> {
             format!(
                 "failed to create symlink:\nsrc: {}\ndst: {}",
                 original.display(),
-                link.display()
+                link.display(),
             )
         })?;
 


### PR DESCRIPTION
Manganese uses a "private" feature flag called "_any-deps" to determine whether any bindep dependency feature flag is enabled. Unfortunately, some parts of the code mistakenly use the name "_any_deps" (with a second "_" instead of a "-") to refer to this feature, which is incorrect. This results in Manganese always emitting a warning that no deps were installed, even when this is not actually the case. Surprisingly, Rust doesn't warn you when you reference a feature flag that doesn't actually exist, which means we never caught this issue in development.

This branch fixes that by using the correct name for the feature flag everywhere.

Fixes #285