### PR TITLE
a bunch of tracing improvements

### DIFF
--- a/platforms/allwinner-d1/d1-core/src/drivers/sharp_display.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/sharp_display.rs
@@ -300,7 +300,11 @@ impl Draw {
             // Drop the mutex once we're done using the framebuffer data
             drop(c);
 
-            tracing::debug!(drawn, "Drew all dirty lines");
+            if drawn > 0 {
+                tracing::debug!(drawn, "Drew all dirty lines");
+            } else {
+                tracing::trace!("No dirty lines, didn't draw anything...");
+            }
 
             self.buf = self.spim.send_wait(self.buf).await.map_err(drop).unwrap();
 

--- a/platforms/allwinner-d1/d1-core/src/drivers/sharp_display.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/sharp_display.rs
@@ -87,6 +87,13 @@ impl SharpDisplay {
     ///
     /// Registration will also start the simulated display, meaning that the display
     /// window will appear.
+    #[tracing::instrument(
+        name = "SharpDisplay::register",
+        level = tracing::Level::INFO,
+        skip(kernel),
+        ret(Debug),
+        err(Debug),
+    )]
     pub async fn register(kernel: &'static Kernel) -> Result<(), RegistrationError> {
         // acquire a SPI client first, so that we don't register the display
         // service unless we can get a SPI client.

--- a/platforms/allwinner-d1/d1-core/src/drivers/spim.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/spim.rs
@@ -115,12 +115,15 @@ impl SpiSenderServer {
         dmac: Dmac,
         queued: usize,
     ) -> Result<(), registry::RegistrationError> {
+        tracing::info!(queued, "Starting SpiSenderServer");
+
         let reqs = kernel
             .registry()
             .bind_konly::<SpiSender>(queued)
             .await?
             .into_request_stream(queued)
             .await;
+
         kernel
             .spawn(async move {
                 let spi = unsafe { &*SPI_DBI::PTR };

--- a/platforms/allwinner-d1/d1-core/src/drivers/spim.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/spim.rs
@@ -103,6 +103,13 @@ pub struct SpiSender;
 pub struct SpiSenderServer;
 
 impl SpiSenderServer {
+    #[tracing::instrument(
+        name = "SpiSenderServer::register",
+        level = tracing::Level::INFO,
+        skip(kernel, dmac),
+        ret(Debug),
+        err(Debug),
+    )]
     pub async fn register(
         kernel: &'static Kernel,
         dmac: Dmac,
@@ -129,6 +136,7 @@ impl SpiSenderServer {
                         "SPI_TXD register should be a valid destination register for DMA transfers",
                     );
 
+                tracing::info!(?descr_cfg, "SpiSender worker task running",);
                 loop {
                     let Message { msg, reply } = reqs.next_request().await;
                     let SpiSenderRequest::Send(ref payload) = msg.body;

--- a/platforms/allwinner-d1/d1-core/src/drivers/twi.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/twi.rs
@@ -68,8 +68,9 @@ use kernel::{
         messages::{OpKind, Transfer},
         Addr, I2cService, Transaction,
     },
-    tracing, Kernel,
+    Kernel,
 };
+use tracing::Level;
 
 /// A TWI mapped to the Raspberry Pi header's I²C0 pins.
 pub struct I2c0 {
@@ -299,6 +300,12 @@ impl I2c0 {
         }
     }
 
+    #[tracing::instrument(
+        name = "I2c0::register",
+        level = Level::INFO,
+        skip(kernel, self),
+        err(Debug),
+    )]
     pub async fn register(
         self,
         kernel: &'static Kernel,
@@ -312,7 +319,7 @@ impl I2c0 {
             .await;
 
         kernel.spawn(self.run(rx)).await;
-        tracing::info!("TWI driver task spawned");
+        tracing::info!("TWI driver task started");
 
         Ok(())
     }

--- a/platforms/allwinner-d1/src/lib.rs
+++ b/platforms/allwinner-d1/src/lib.rs
@@ -194,6 +194,8 @@ impl D1 {
                 .unwrap()
         };
 
+        k.initialize_default_services(service_settings);
+
         // Initialize SPI stuff
         k.initialize(async move {
             // Register a new SpiSenderServer
@@ -221,8 +223,6 @@ impl D1 {
             .unwrap();
             i2c0_int
         });
-
-        k.initialize_default_services(service_settings);
 
         Self {
             kernel: k,

--- a/platforms/allwinner-d1/src/lib.rs
+++ b/platforms/allwinner-d1/src/lib.rs
@@ -205,7 +205,7 @@ impl D1 {
 
         // Initialize SimpleSerial driver
         k.initialize(async move {
-            D1Uart::register(k, dmac, 4096, 4096).await.unwrap();
+            D1Uart::register(k, dmac, Default::default()).await.unwrap();
         })
         .unwrap();
 

--- a/platforms/beepy/src/i2c_puppet.rs
+++ b/platforms/beepy/src/i2c_puppet.rs
@@ -338,7 +338,13 @@ impl I2cPuppetServer {
     ///   [`None`], the driver will only poll the `i2c_puppet` device when
     ///   [`settings.poll_interval`](I2cPuppetSettings#structfield.poll_interval)
     ///   elapses.
-    #[instrument(level = Level::DEBUG, skip(kernel, irq_waker))]
+    #[instrument(
+        name = "I2cPuppetServer::register",
+        level = Level::INFO,
+        skip(kernel, irq_waker),
+        ret(Debug),
+        err(Debug),
+    )]
     pub async fn register(
         kernel: &'static Kernel,
         settings: I2cPuppetSettings,

--- a/platforms/esp32c3-buddy/src/lib.rs
+++ b/platforms/esp32c3-buddy/src/lib.rs
@@ -37,30 +37,26 @@ pub fn init() -> &'static Kernel {
 }
 
 pub fn spawn_daemons(k: &'static Kernel) {
-    // Initialize the SerialMuxServer
-    let sermux_up = k
-        .initialize(services::serial_mux::SerialMuxServer::register(
-            k,
-            Default::default(),
-        ))
-        .expect("failed to spawn SerialMuxService initialization");
-
-    // Initialize Serial Mux daemons.
+    // initialize tracing first, so we can trace the boot process.
     k.initialize(async move {
         use kernel::serial_trace;
-        sermux_up
-            .await
-            .expect("SerialMuxService initialization should not be cancelled")
-            .expect("SerialMuxService initialization failed");
-
-        k.spawn(daemons::sermux::hello(k, Default::default())).await;
-
         let trace_settings = serial_trace::SerialTraceSettings::default()
             // our heap is only 32KB, so allocate a much smaller trace buffer.
             .with_tracebuf_capacity(1024);
         serial_trace::SerialSubscriber::start(k, trace_settings).await;
     })
-    .expect("failed to spawn default serial mux service initialization");
+    .expect("failed to spawn serial tracing daemon");
+
+    // Initialize the SerialMuxServer
+    k.initialize(services::serial_mux::SerialMuxServer::register(
+        k,
+        Default::default(),
+    ))
+    .expect("failed to spawn SerialMuxService initialization");
+
+    // Initialize Serial Mux daemons.
+    k.initialize(daemons::sermux::hello(k, Default::default()))
+        .expect("failed to spawn default serial mux service initialization");
 }
 
 pub fn spawn_serial(

--- a/source/kernel/src/registry/mod.rs
+++ b/source/kernel/src/registry/mod.rs
@@ -12,7 +12,7 @@ use portable_atomic::{AtomicU32, Ordering};
 use postcard::experimental::max_size::MaxSize;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use spitebuf::EnqueueError;
-use tracing::{self, debug, info, warn, Level};
+use tracing::{self, debug, info, trace, warn, Level};
 pub use uuid::{uuid, Uuid};
 
 use crate::comms::{
@@ -979,7 +979,7 @@ impl<RD: RegisteredDriver> ReplyTo<RD> {
         self,
         envelope: Envelope<Result<RD::Response, RD::Error>>,
     ) -> Result<(), ReplyError> {
-        debug!(
+        trace!(
             service_id = envelope.service_id.0,
             client_id = envelope.client_id.0,
             response_id = envelope.request_id.id(),
@@ -1009,7 +1009,7 @@ where
         uuid_source: Uuid,
         envelope: Envelope<Result<RD::Response, RD::Error>>,
     ) -> Result<(), ReplyError> {
-        debug!(
+        trace!(
             service_id = envelope.service_id.0,
             client_id = envelope.client_id.0,
             response_id = envelope.request_id.id(),
@@ -1086,7 +1086,7 @@ impl<RD: RegisteredDriver> KernelHandle<RD> {
             })
             .await
             .map_err(|_| SendError::Closed)?;
-        debug!(
+        trace!(
             service_id = self.service_id.0,
             client_id = self.client_id.0,
             request_id = request_id.id(),

--- a/source/kernel/src/registry/mod.rs
+++ b/source/kernel/src/registry/mod.rs
@@ -12,7 +12,7 @@ use portable_atomic::{AtomicU32, Ordering};
 use postcard::experimental::max_size::MaxSize;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use spitebuf::EnqueueError;
-use tracing::{self, debug, info};
+use tracing::{self, debug, info, warn, Level};
 pub use uuid::{uuid, Uuid};
 
 use crate::comms::{
@@ -266,7 +266,7 @@ pub enum UserHandlerError {
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum RegistrationError {
-    UuidAlreadyRegistered,
+    UuidAlreadyRegistered(Uuid),
     RegistryFull,
 }
 
@@ -476,9 +476,10 @@ impl Registry {
     /// with [Registry::register] which allows for userspace access.
     #[tracing::instrument(
         name = "Registry::register_konly",
-        level = "debug",
+        level = Level::INFO,
         skip(self, registration),
         fields(svc = %any::type_name::<RD>()),
+        err(Display),
     )]
     pub async fn register_konly<RD: RegisteredDriver>(
         &self,
@@ -509,9 +510,10 @@ impl Registry {
     /// serializable.
     #[tracing::instrument(
         name = "Registry::register",
-        level = "debug",
+        level = Level::INFO,
         skip(self, registration),
         fields(svc = %any::type_name::<RD>()),
+        err(Display),
     )]
     pub async fn register<RD>(
         &self,
@@ -537,7 +539,7 @@ impl Registry {
         })
         .await?;
 
-        info!(svc = %any::type_name::<RD>(), uuid = ?RD::UUID, service_id, "Registered");
+        info!(uuid = ?RD::UUID, service_id, "Registered");
 
         Ok(())
     }
@@ -573,7 +575,7 @@ impl Registry {
     /// [rejected]: listener::Handshake::reject
     #[tracing::instrument(
         name = "Registry::try_connect",
-        level = "debug",
+        level = Level::DEBUG,
         skip(self, hello),
         fields(svc = %any::type_name::<RD>()),
     )]
@@ -639,7 +641,14 @@ impl Registry {
             client_id: ClientId(client_id),
             request_ctr: 0,
         });
-        info!(svc = %any::type_name::<RD>(), uuid = ?RD::UUID, service_id = service_id.0, client_id, "Got KernelHandle from Registry");
+
+        info!(
+            svc = %any::type_name::<RD>(),
+            uuid = ?RD::UUID,
+            service_id = service_id.0,
+            client_id,
+            "Got KernelHandle from Registry",
+        );
 
         res
     }
@@ -672,7 +681,7 @@ impl Registry {
     /// [rejected]: listener::Handshake::reject
     #[tracing::instrument(
         name = "Registry::connect",
-        level = "debug",
+        level = Level::DEBUG,
         skip(self, hello),
         fields(svc = %any::type_name::<RD>()),
     )]
@@ -687,7 +696,7 @@ impl Registry {
                 Ok(handle) => return Ok(handle),
                 Err(ConnectError::NotFound(h)) if !is_full => {
                     hello = Some(h);
-                    tracing::debug!("no service found; waiting for one to be added...");
+                    debug!("no service found; waiting for one to be added...");
                     // wait for a service to be added to the registry
                     is_full = self.service_added.wait().await.is_err();
                 }
@@ -715,7 +724,7 @@ impl Registry {
     /// [rejected]: listener::Handshake::reject
     #[tracing::instrument(
         name = "Registry::connect_userspace",
-        level = "debug",
+        level = Level::DEBUG,
         skip(self),
         fields(svc = %any::type_name::<RD>()),
     )]
@@ -736,7 +745,7 @@ impl Registry {
             match self.try_connect_userspace(scheduler, user_hello).await {
                 Ok(handle) => return Ok(handle),
                 Err(UserConnectError::NotFound) if !is_full => {
-                    tracing::debug!("no service found; waiting for one to be added...");
+                    debug!("no service found; waiting for one to be added...");
                     // wait for a service to be added to the registry
                     is_full = self.service_added.wait().await.is_err();
                 }
@@ -756,7 +765,7 @@ impl Registry {
     /// retrieved via a call to [`Registry::try_connect_userspace`].
     #[tracing::instrument(
         name = "Registry::try_connect_userspace",
-        level = "debug",
+        level = Level::DEBUG,
         skip(self, scheduler),
         fields(svc = %any::type_name::<RD>()),
     )]
@@ -841,11 +850,11 @@ impl Registry {
         {
             let mut items = self.items.write().await;
             if items.as_slice().iter().any(|i| i.key == item.key) {
-                return Err(RegistrationError::UuidAlreadyRegistered);
+                return Err(RegistrationError::UuidAlreadyRegistered(item.key));
             }
 
             items.try_push(item).map_err(|_| {
-                tracing::warn!("failed to insert new registry item; the registry is full!");
+                warn!("failed to insert new registry item; the registry is full!");
                 // close the "service added" waitcell, because no new services will
                 // ever be added.
                 self.service_added.close();
@@ -860,7 +869,7 @@ impl Registry {
 
     fn get<RD: RegisteredDriver>(items: &FixedVec<RegistryItem>) -> Option<&RegistryItem> {
         let Some(item) = items.as_slice().iter().find(|i| i.key == RD::UUID) else {
-            tracing::debug!(
+            debug!(
                 svc = %any::type_name::<RD>(),
                 uuid = ?RD::UUID,
                 "No service for this UUID exists in the registry!"
@@ -871,7 +880,7 @@ impl Registry {
         let expected_type_id = RD::type_id().type_of();
         let actual_type_id = item.value.req_resp_tuple_id;
         if expected_type_id != actual_type_id {
-            tracing::warn!(
+            warn!(
                 svc = %any::type_name::<RD>(),
                 uuid = ?RD::UUID,
                 type_id.expected = ?expected_type_id,
@@ -974,6 +983,7 @@ impl<RD: RegisteredDriver> ReplyTo<RD> {
             service_id = envelope.service_id.0,
             client_id = envelope.client_id.0,
             response_id = envelope.request_id.id(),
+            svc = %any::type_name::<RD>(),
             "Replying KOnly",
         );
         match self {
@@ -1003,6 +1013,7 @@ where
             service_id = envelope.service_id.0,
             client_id = envelope.client_id.0,
             response_id = envelope.request_id.id(),
+            svc = %any::type_name::<RD>(),
             "Replying",
         );
         match self {
@@ -1079,6 +1090,7 @@ impl<RD: RegisteredDriver> KernelHandle<RD> {
             service_id = self.service_id.0,
             client_id = self.client_id.0,
             request_id = request_id.id(),
+            svc = %any::type_name::<RD>(),
             "Sent Request"
         );
         Ok(())
@@ -1392,6 +1404,19 @@ where
                 "the {} service is not exposed to userspace",
                 any::type_name::<D>()
             ),
+        }
+    }
+}
+
+// RegistrationError
+
+impl fmt::Display for RegistrationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RegistryFull => "the registry is full".fmt(f),
+            Self::UuidAlreadyRegistered(uuid) => {
+                write!(f, "a service with UUID {uuid} has already been registered")
+            }
         }
     }
 }

--- a/source/kernel/src/serial_trace.rs
+++ b/source/kernel/src/serial_trace.rs
@@ -53,10 +53,6 @@ impl SerialSubscriber {
         SHARED
             .max_level
             .store(level_to_u8(settings.initial_level), Ordering::Release);
-        // acquire sermux port 3
-        let port = serial_mux::PortHandle::open(k, settings.port, settings.sendbuf_capacity)
-            .await
-            .expect("cannot initialize serial tracing, cannot open port 3!");
 
         let (tx, rx) = bbq::new_spsc_channel(settings.tracebuf_capacity).await;
         let (isr_tx, isr_rx) = bbq::new_spsc_channel(settings.tracebuf_capacity).await;
@@ -70,7 +66,14 @@ impl SerialSubscriber {
         };
 
         // spawn a worker to read from the channel and write to the serial port.
-        k.spawn(Self::worker(&SHARED, rx, isr_rx, port, k)).await;
+        k.spawn(async move {
+            // acquire sermux port 3
+            let port = serial_mux::PortHandle::open(k, settings.port, settings.sendbuf_capacity)
+                .await
+                .expect("cannot initialize serial tracing, cannot open port 3!");
+            Self::worker(&SHARED, rx, isr_rx, port, k).await
+        })
+        .await;
 
         subscriber
     }
@@ -362,7 +365,7 @@ impl Subscriber for SerialSubscriber {
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct SerialTraceSettings {
     /// Should the serial trace be enabled?

--- a/source/kernel/src/serial_trace.rs
+++ b/source/kernel/src/serial_trace.rs
@@ -472,7 +472,7 @@ impl SerialTraceSettings {
     pub const DEFAULT_PORT: u16 = serial_mux::WellKnown::BinaryTracing as u16;
     pub const DEFAULT_SENDBUF_CAPACITY: usize = BIGMSG_GRANT_SZ * 4;
     pub const DEFAULT_TRACEBUF_CAPACITY: usize = Self::DEFAULT_SENDBUF_CAPACITY * 4;
-    pub const DEFAULT_INITIAL_LEVEL: LevelFilter = LevelFilter::OFF;
+    pub const DEFAULT_INITIAL_LEVEL: LevelFilter = LevelFilter::INFO;
 
     const fn default_port() -> u16 {
         Self::DEFAULT_PORT

--- a/source/kernel/src/services/forth_spawnulator.rs
+++ b/source/kernel/src/services/forth_spawnulator.rs
@@ -143,21 +143,21 @@ impl SpawnulatorServer {
     /// used to spawn new `Forth` VMs.
     #[tracing::instrument(
         name = "SpawnulatorServer::register",
-        level = tracing::Level::DEBUG,
-        skip(kernel),
-        ret(Debug),
+        level = tracing::Level::INFO,
+        skip(kernel, settings),
+        err(Debug),
     )]
     pub async fn register(
         kernel: &'static Kernel,
         settings: SpawnulatorSettings,
     ) -> Result<(), registry::RegistrationError> {
+        tracing::info!(?settings, "Who spawns the spawnulator?");
         let vms = kernel
             .registry()
             .bind_konly::<SpawnulatorService>(settings.capacity)
             .await?
             .into_request_stream(settings.capacity)
             .await;
-        tracing::debug!("who spawns the spawnulator?");
         kernel
             .spawn(SpawnulatorServer::spawnulate(kernel, vms))
             .await;

--- a/source/kernel/src/services/keyboard/mux.rs
+++ b/source/kernel/src/services/keyboard/mux.rs
@@ -163,14 +163,17 @@ impl KeyboardMuxServer {
     /// serial mux port.
     #[tracing::instrument(
         name = "KeyboardMuxServer::register",
-        level = Level::DEBUG,
-        skip(kernel),
+        level = Level::INFO,
+        skip(kernel, settings),
         err(Debug),
+        ret(Debug),
     )]
     pub async fn register(
         kernel: &'static Kernel,
         settings: KeyboardMuxSettings,
     ) -> Result<(), RegistrationError> {
+        tracing::info!(?settings, "Registering keyboard mux");
+
         let key_rx = kernel
             .registry()
             .bind_konly::<KeyboardMuxService>(settings.buffer_capacity)


### PR DESCRIPTION
This branch makes some improvements to our current `tracing` diagnostics. In particular, I wanted to improve our ability to trace early kernel initialization. I've changed the kernel to initialize the `tracing` subscriber much earlier, without waiting for the Serial Mux service to actually start. This way, traces we emit before sermux comes up get buffered and are sent over serial when it comes up and crowtty connects. I've also changed the default `tracing` level when no `crowtty` has connected from `OFF` to `INFO`, so that we can actually record high-level traces from the boot process.

Also, I've improved some of the existing tracing diagnostics, and added new ones.

Here's what the new tracing looks like:
![image](https://github.com/tosc-rs/mnemos/assets/2796466/043b1ca6-d27d-4ac2-b30b-39883135e37c)
