### PR TITLE
fix(x86_64): fix subscriber emitting `enter` instead of `exit`

### DIFF
--- a/platforms/x86_64/core/src/trace.rs
+++ b/platforms/x86_64/core/src/trace.rs
@@ -87,7 +87,7 @@ where
     }
 
     fn exit(&self, span: &span::Id) {
-        with_serial(|serial| serial.enter(span));
+        with_serial(|serial| serial.exit(span));
     }
 
     fn record_follows_from(&self, _: &span::Id, _: &span::Id) {


### PR DESCRIPTION
#290 Quick fix for this issue