### PR TITLE
feat(d1): add smhc driver

### DIFF
--- a/platforms/allwinner-d1/d1-core/src/ccu.rs
+++ b/platforms/allwinner-d1/d1-core/src/ccu.rs
@@ -262,21 +262,13 @@ macro_rules! impl_bgr {
             impl BusGatingResetRegister for $MODULE {
                 fn gating(ccu: &mut CCU, gating: BusGating) {
                     ccu.$reg.modify(|_, w| {
-                        if gating == BusGating::Mask {
-                            w.$gating().clear_bit()
-                        } else {
-                            w.$gating().set_bit()
-                        }
+                        w.$gating().bit(gating == BusGating::Pass)
                     });
                 }
 
                 fn reset(ccu: &mut CCU, reset: BusReset) {
                     ccu.$reg.modify(|_, w| {
-                        if reset == BusReset::Assert {
-                            w.$reset().clear_bit()
-                        } else {
-                            w.$reset().set_bit()
-                        }
+                        w.$reset().bit(reset == BusReset::Deassert)
                     });
                 }
             }

--- a/platforms/allwinner-d1/d1-core/src/dmac/mod.rs
+++ b/platforms/allwinner-d1/d1-core/src/dmac/mod.rs
@@ -36,7 +36,7 @@ pub mod descriptor;
 /// This struct is constructed using [`Dmac::new`], which initializes the DMA
 /// controller and returns a `Dmac`. Since this struct is essentially a token
 /// representing that the DMAC has been initialized, it may be freely copied
-/// into any driver that wishes to perform DMA oeprations.
+/// into any driver that wishes to perform DMA operations.
 #[derive(Copy, Clone)]
 pub struct Dmac {
     // this struct is essentially used as a "yes, the DMAC is initialized now" token...
@@ -89,7 +89,7 @@ pub enum ChannelMode {
     /// transfer completes, and waits for the peripheral to pull the DMA
     /// Active signal low before starting the next transfer.
     ///
-    /// The Allwinner documentationh for the D1 describes this mode as follows:
+    /// The Allwinner documentation for the D1 describes this mode as follows:
     ///
     /// > * When the DMAC detects a valid external request signal, the DMAC
     /// >   starts to operate the peripheral device. The internal DRQ always
@@ -222,7 +222,7 @@ impl Dmac {
     /// some of the data it wanted. If we were reading from a device, reads may
     /// have side effects and incomplete reads may leave the device in a weird
     /// state. Cancelling an incomplete transfer may result in, for example,
-    /// writing out half of a string to the UART, or only part  of a structured
+    /// writing out half of a string to the UART, or only part of a structured
     /// message over SPI, and so on. But, at least we don't have abandoned DMA
     /// transfers running around in random parts of the heap you probably wanted
     /// to use for normal stuff like having strings, or whatever it is that
@@ -398,6 +398,7 @@ impl Channel {
     /// dropped, the descriptor and its associated memory region may also be
     /// dropped safely.
     ///
+    /// Of course, the transfer may still have completed partially. If we
     /// were writing to a device, the device may be unhappy to have only gotten
     /// some of the data it wanted. If we were reading from a device, reads may
     /// have side effects and incomplete reads may leave the device in a weird

--- a/platforms/allwinner-d1/d1-core/src/drivers/mod.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "sharp-display")]
 pub mod sharp_display;
+pub mod smhc;
 pub mod spim;
 pub mod twi;
 pub mod uart;

--- a/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
@@ -511,12 +511,13 @@ impl Smhc {
                 ErrorKind::Other => sdmmc::Error::Other,
             })
         } else if long_resp {
-            Ok(sdmmc::Response::Long([
+            let rsp: [u32; 4] = [
                 self.smhc.smhc_resp0.read().bits(),
                 self.smhc.smhc_resp1.read().bits(),
                 self.smhc.smhc_resp2.read().bits(),
                 self.smhc.smhc_resp3.read().bits(),
-            ]))
+            ];
+            Ok(sdmmc::Response::Long(unsafe { core::mem::transmute(rsp) }))
         } else {
             Ok(sdmmc::Response::Short {
                 value: self.smhc.smhc_resp0.read().bits(),

--- a/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
@@ -296,6 +296,18 @@ impl Smhc {
         let long_resp = params.rsp_type == sdmmc::ResponseType::Long;
         let resp_rcv = params.rsp_type != sdmmc::ResponseType::None;
 
+        // Do any required configuration
+        match params.options {
+            sdmmc::HardwareOptions::None => (),
+            sdmmc::HardwareOptions::SetBusWidth(width) => {
+                self.smhc.smhc_ctype.write(|w| match width {
+                    sdmmc::BusWidth::Single => w.card_wid().b1(),
+                    sdmmc::BusWidth::Quad => w.card_wid().b4(),
+                    sdmmc::BusWidth::Octo => w.card_wid().b8(),
+                });
+            }
+        }
+
         // Set the argument to be sent
         self.smhc
             .smhc_cmdarg

--- a/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
@@ -141,11 +141,11 @@ impl Smhc {
         smhc.smhc_clkdiv.write(|w| w.cclk_enb().off());
 
         ccu.disable_module(&mut smhc);
-        // Set module clock rate to 200 MHz
+        // Set module clock rate to 100 MHz
         // TODO: ccu should provide a higher-level abstraction for this
         ccu.borrow_raw().smhc0_clk.write(|w| {
             w.clk_src_sel().pll_peri_1x();
-            w.factor_n().variant(d1_pac::ccu::smhc0_clk::FACTOR_N_A::N1);
+            w.factor_n().variant(d1_pac::ccu::smhc0_clk::FACTOR_N_A::N2);
             w.factor_m().variant(2);
             w.clk_gating().set_bit();
             w

--- a/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
@@ -25,7 +25,6 @@ use kernel::{
     tracing, Kernel,
 };
 
-/// TODO
 pub struct Smhc {
     isr: &'static IsrData,
     smhc: &'static smhc::RegisterBlock,
@@ -33,7 +32,7 @@ pub struct Smhc {
     num: u8,
 }
 
-/// TODO
+/// Data used by a SMHC interrupt.
 struct IsrData {
     data: UnsafeCell<SmhcData>,
 }
@@ -75,7 +74,7 @@ enum SmhcOp {
     },
 }
 
-/// TODO
+/// SMHC state machine
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[allow(dead_code)]
 enum State {
@@ -90,7 +89,7 @@ enum State {
     WaitForAutoStop,
 }
 
-/// TODO
+/// The different errors that can occur in this module.
 #[derive(Debug, Copy, Clone)]
 #[non_exhaustive]
 pub enum ErrorKind {
@@ -127,7 +126,8 @@ impl Smhc {
     /// Initialize SMHC0 for SD cards.
     ///
     /// # Safety
-    /// TODO
+    /// - The `SMHC0` register block must not be concurrently written to.
+    /// - This function should be called only while running on an Allwinner D1.
     pub unsafe fn smhc0(mut smhc: SMHC0, ccu: &mut Ccu, gpio: &mut GPIO) -> Self {
         // Configure default pin mapping for TF (micro SD) card socket.
         // This is valid for the Lichee RV SOM and Mango Pi MQ Pro.

--- a/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
@@ -1,0 +1,208 @@
+//! Driver for the Allwinner D1's SMHC peripheral.
+//!
+//! The D1 contains three separate SD/MMC Host Controllers: [`SMHC0`], [`SMHC1`] and [`SMHC2`].
+//! - [`SMHC0`] controls *Secure Digital* memory devices (SD cards)
+//! - [`SMHC1`] controls *Secure Digital I/O* devices (SDIO)
+//! - [`SMHC2`] controls *MultiMedia Card* devices (MMC)
+//!
+//! Each SMHC also has an internal DMA controller that can be used for offloading
+//! the transfer and reception of large amounts of data to/from the device.
+use core::{
+    cell::UnsafeCell,
+    ops::{Deref, DerefMut},
+    task::{Poll, Waker},
+};
+
+use crate::ccu::{BusGatingResetRegister, Ccu};
+use d1_pac::{smhc, Interrupt, GPIO, SMHC0, SMHC1, SMHC2};
+use kernel::{
+    comms::kchannel::{KChannel, KConsumer},
+    mnemos_alloc::containers::FixedVec,
+    registry, Kernel,
+};
+
+/// TODO
+pub struct Smhc {
+    isr: &'static IsrData,
+    smhc: &'static smhc::RegisterBlock,
+    int: (Interrupt, fn()),
+}
+
+/// TODO
+struct IsrData {
+    data: UnsafeCell<SmhcData>,
+}
+unsafe impl Sync for IsrData {}
+
+struct SmhcDataGuard<'a> {
+    smhc: &'a smhc::RegisterBlock,
+    data: &'a mut SmhcData,
+}
+
+struct SmhcData {
+    state: State,
+    op: SmhcOp,
+    err: Option<ErrorKind>,
+    waker: Option<Waker>,
+}
+
+static SMHC0_ISR: IsrData = IsrData {
+    data: UnsafeCell::new(SmhcData {
+        state: State::Idle,
+        op: SmhcOp::None,
+        err: None,
+        waker: None,
+    }),
+};
+
+enum SmhcOp {
+    // TODO
+    None,
+}
+
+/// TODO
+#[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    /// A transmit bit error, end bit error, or CMD index error has occurred.
+    Response,
+    /// Invalid CRC in response.
+    ResponseCrc,
+    /// When receiving data, this means that the received data has data CRC error.
+    /// When transmitting data, this means that the received CRC status taken is negative.
+    DataCrc,
+    /// Did not receive a response in time.
+    ResponseTimeout,
+    /// Did not receive data in time.
+    DataTimeout,
+    /// Data starvation detected.
+    DataStarvationTimeout,
+    /// FIFO underrun or overflow.
+    FifoUnderrunOverflow,
+    /// Command busy and illegal write. TODO: understand this + add better explanation
+    CommandBusyIllegalWrite,
+    /// When receiving data, this means that the host controller found an error start bit.
+    /// When transmitting data, this means that the busy signal is cleared after the last block.
+    DataStart,
+    /// When receiving data, this means that we did not receive a valid data end bit.
+    /// When transmitting data, this means that we did not receive the CRC status token.
+    DataEnd,
+    /// An error occurred in the internal DMA controller.
+    Dma,
+    /// A different error occurred. The original error may contain more information.
+    Other,
+}
+
+/// TODO
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[allow(dead_code)]
+enum State {
+    Idle,
+    // TODO
+}
+
+impl Smhc {
+    /// Initialize SMHC0 for SD cards.
+    ///
+    /// # Safety
+    /// TODO
+    pub unsafe fn new(mut smhc: SMHC0, ccu: &mut Ccu, gpio: &mut GPIO) -> Self {
+        // Configure default pin mapping for TF (micro SD) card socket.
+        // This is valid for the Lichee RV SOM and Mango Pi MQ Pro.
+        gpio.pf_cfg0.modify(|_, w| {
+            w.pf0_select().sdc0_d1();
+            w.pf1_select().sdc0_d0();
+            w.pf2_select().sdc0_clk();
+            w.pf3_select().sdc0_cmd();
+            w.pf4_select().sdc0_d3();
+            w.pf5_select().sdc0_d2();
+            w
+        });
+
+        // Make sure the card clock is turned off before changing the module clock
+        smhc.smhc_clkdiv.write(|w| w.cclk_enb().off());
+
+        ccu.disable_module(&mut smhc);
+        // Set module clock rate to 200 MHz
+        // TODO: ccu should provide a higher-level abstraction for this
+        ccu.borrow_raw().smhc0_clk.write(|w| {
+            w.clk_src_sel().pll_peri_1x();
+            w.factor_n().variant(d1_pac::ccu::smhc0_clk::FACTOR_N_A::N1);
+            w.factor_m().variant(2);
+            w.clk_gating().set_bit();
+            w
+        });
+        ccu.enable_module(&mut smhc);
+
+        Self::init(
+            unsafe { &*SMHC0::ptr() },
+            Interrupt::SMHC0,
+            Self::handle_smhc0_interrupt,
+        )
+    }
+
+    /// This assumes the GPIO pin mappings are already configured.
+    unsafe fn init(smhc: &'static smhc::RegisterBlock, int: Interrupt, isr: fn()) -> Self {
+        // Closure to change the card clock
+        let prg_clk = || {
+            smhc.smhc_cmd.write(|w| {
+                w.wait_pre_over().wait();
+                w.prg_clk().change();
+                w.cmd_load().set_bit();
+                w
+            });
+
+            while smhc.smhc_cmd.read().cmd_load().bit_is_set() {
+                core::hint::spin_loop()
+            }
+
+            smhc.smhc_rintsts.write(|w| unsafe { w.bits(0xFFFFFFFF) });
+        };
+
+        // Reset the SD/MMC controller
+        smhc.smhc_ctrl.modify(|_, w| w.soft_rst().reset());
+        while smhc.smhc_ctrl.read().soft_rst().is_reset() {
+            core::hint::spin_loop();
+        }
+
+        // Reset the FIFO
+        smhc.smhc_ctrl.modify(|_, w| w.fifo_rst().reset());
+        while smhc.smhc_ctrl.read().fifo_rst().is_reset() {
+            core::hint::spin_loop();
+        }
+
+        // Global interrupt disable
+        smhc.smhc_ctrl.modify(|_, w| w.ine_enb().disable());
+
+        prg_clk();
+
+        // Set card clock = module clock / 2
+        smhc.smhc_clkdiv.modify(|_, w| w.cclk_div().variant(1));
+
+        // Set the sample delay to 0 (also done in Linux and Allwinner BSP)
+        smhc.smhc_smap_dl.write(|w| {
+            w.samp_dl_sw().variant(0);
+            w.samp_dl_sw_en().set_bit()
+        });
+
+        // Enable the card clock
+        smhc.smhc_clkdiv.modify(|_, w| w.cclk_enb().on());
+
+        prg_clk();
+
+        // Default bus width after power up or idle is 1-bit
+        smhc.smhc_ctype.write(|w| w.card_wid().b1());
+        // Blocksize is fixed to 512 bytes
+        smhc.smhc_blksiz.write(|w| unsafe { w.bits(0x200) });
+
+        Self {
+            smhc,
+            isr: &SMHC0_ISR,
+            int: (int, isr),
+        }
+    }
+
+    fn handle_smhc0_interrupt() {
+        todo!()
+    }
+}

--- a/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
@@ -19,7 +19,7 @@ use kernel::{
     comms::kchannel::{KChannel, KConsumer},
     mnemos_alloc::containers::FixedVec,
     registry,
-    services::sdmmc::{messages::Transfer, SdmmcService, Transaction},
+    services::sdmmc::{Command, Request, SdmmcService},
     tracing, Kernel,
 };
 
@@ -232,10 +232,10 @@ impl Smhc {
         }
     }
 
-    #[tracing::instrument(level = tracing::Level::DEBUG, skip(self, txn))]
-    async fn transaction(&self, txn: KConsumer<Transfer>) {
-        todo!()
-    }
+    // #[tracing::instrument(level = tracing::Level::DEBUG, skip(self, txn))]
+    // async fn transaction(&self, txn: KConsumer<Transfer>) {
+    //     todo!()
+    // }
 }
 
 impl IsrData {

--- a/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
@@ -756,30 +756,30 @@ mod idmac {
             const _RESERVED_0 = 1;
 
             /// Disable interrupts on completion.
-            const CUR_TXRX_OVER_INT_DIS = 1;
+            const CUR_TXRX_OVER_INT_DIS: bool;
 
-            /// When set to 1, this bit indicates that the buffers this descriptor points to
-            /// are the last data buffer.
-            const LAST_FLAG = 1;
+            /// When set to 1, this bit indicates that the buffer this descriptor points to
+            /// is the last data buffer.
+            const LAST: bool;
 
             /// When set to 1, this bit indicates that this descriptor contains
             /// the first buffer of data. It must be set to 1 in the first DES.
-            const FIRST_FLAG = 1;
+            const FIRST: bool;
 
             /// When set to 1, this bit indicates that the second address in the descriptor
             /// is the next descriptor address. It must be set to 1.
-            const CHAIN_MOD = 1;
+            const CHAIN_MOD: bool;
 
             /// Bits 29:5 are reserved.
             const _RESERVED_1 = 25;
 
             /// When some errors happen in transfer, this bit will be set to 1 by the IDMAC.
-            const ERR_FLAG = 1;
+            const ERR: bool;
 
             /// When set to 1, this bit indicates that the descriptor is owned by the IDMAC.
             /// When this bit is reset, it indicates that the descriptor is owned by the host.
             /// This bit is cleared when the transfer is over.
-            const DES_OWN_FLAG = 1;
+            const DES_OWN: bool;
         }
     }
 
@@ -806,21 +806,21 @@ mod idmac {
 
         pub fn disable_irq(self, val: bool) -> Self {
             Self {
-                cfg: self.cfg.with(Cfg::CUR_TXRX_OVER_INT_DIS, val as u32),
+                cfg: self.cfg.with(Cfg::CUR_TXRX_OVER_INT_DIS, val),
                 ..self
             }
         }
 
         pub fn first(self, val: bool) -> Self {
             Self {
-                cfg: self.cfg.with(Cfg::FIRST_FLAG, val as u32),
+                cfg: self.cfg.with(Cfg::FIRST, val),
                 ..self
             }
         }
 
         pub fn last(self, val: bool) -> Self {
             Self {
-                cfg: self.cfg.with(Cfg::LAST_FLAG, val as u32),
+                cfg: self.cfg.with(Cfg::LAST, val),
                 ..self
             }
         }
@@ -865,7 +865,7 @@ mod idmac {
             let buff_addr = (self.buff.as_mut_ptr() as *mut _ as u32) >> 2;
 
             Descriptor {
-                configuration: self.cfg.with(Cfg::CHAIN_MOD, 1).with(Cfg::DES_OWN_FLAG, 1),
+                configuration: self.cfg.with(Cfg::CHAIN_MOD, true).with(Cfg::DES_OWN, true),
                 buff_size,
                 buff_addr,
                 next_desc: self.link,

--- a/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
@@ -207,11 +207,7 @@ impl Smhc {
             core::hint::spin_loop();
         }
 
-        // Reset the FIFO
-        smhc.smhc_ctrl.modify(|_, w| w.fifo_rst().reset());
-        while smhc.smhc_ctrl.read().fifo_rst().is_reset() {
-            core::hint::spin_loop();
-        }
+        Self::reset_fifo(smhc);
 
         // Global interrupt disable
         smhc.smhc_ctrl.modify(|_, w| w.ine_enb().disable());
@@ -242,6 +238,14 @@ impl Smhc {
             smhc,
             isr: &SMHC0_ISR,
             int: (int, isr),
+        }
+    }
+
+    #[inline(always)]
+    fn reset_fifo(regs: &smhc::RegisterBlock) {
+        regs.smhc_ctrl.modify(|_, w| w.fifo_rst().reset());
+        while regs.smhc_ctrl.read().fifo_rst().is_reset() {
+            core::hint::spin_loop();
         }
     }
 
@@ -292,11 +296,7 @@ impl Smhc {
             w
         });
 
-        // Reset the FIFO
-        self.smhc.smhc_ctrl.modify(|_, w| w.fifo_rst().reset());
-        while self.smhc.smhc_ctrl.read().fifo_rst().is_reset() {
-            core::hint::spin_loop();
-        }
+        Self::reset_fifo(self.smhc);
     }
 
     pub fn handle_smhc0_interrupt() {

--- a/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
@@ -186,6 +186,22 @@ impl Smhc {
         )
     }
 
+    /// Initialize SMHC1 for SDIO cards.
+    ///
+    /// # Safety
+    /// TODO
+    pub unsafe fn smhc1(_smhc: SMHC1, _ccu: &mut Ccu, _gpio: &mut GPIO) -> Self {
+        todo!()
+    }
+
+    /// Initialize SMHC2 for MMC cards.
+    ///
+    /// # Safety
+    /// TODO
+    pub unsafe fn smhc2(_smhc: SMHC2, _ccu: &mut Ccu, _gpio: &mut GPIO) -> Self {
+        todo!()
+    }
+
     /// This assumes the GPIO pin mappings and module clock are already configured.
     unsafe fn init(smhc: &'static smhc::RegisterBlock, int: Interrupt, isr: fn()) -> Self {
         // Closure to change the card clock
@@ -306,6 +322,12 @@ impl Smhc {
         Self::reset_fifo(self.smhc);
     }
 
+    /// Returns the interrupt and ISR for this SMHC.
+    pub fn interrupt(&self) -> (Interrupt, fn()) {
+        self.int
+    }
+
+    /// Handle an interrupt for SMHC0
     pub fn handle_smhc0_interrupt() {
         let _isr = kernel::isr::Isr::enter();
         let smhc = unsafe { &*SMHC0::ptr() };

--- a/platforms/allwinner-d1/src/lib.rs
+++ b/platforms/allwinner-d1/src/lib.rs
@@ -52,7 +52,7 @@ pub fn kernel_entry(config: mnemos_config::MnemosConfig<PlatformConfig>) -> ! {
 
     let uart = unsafe { uart::kernel_uart(&mut ccu, &mut p.GPIO, p.UART0) };
     let spim = unsafe { spim::kernel_spim1(p.SPI_DBI, &mut ccu, &mut p.GPIO) };
-    let smhc0 = unsafe { Smhc::new(p.SMHC0, &mut ccu, &mut p.GPIO) };
+    let smhc0 = unsafe { Smhc::smhc0(p.SMHC0, &mut ccu, &mut p.GPIO) };
 
     let i2c0 = match config.platform.i2c {
         d1_config::I2cConfiguration { enabled: false, .. } => None,
@@ -185,8 +185,8 @@ pub fn kernel_entry(config: mnemos_config::MnemosConfig<PlatformConfig>) -> ! {
                 .await
                 .expect("can't set wide bus mode");
 
-            let buffer = FixedVec::new(512).await;
-            match sdcard.read(80, 1, buffer).await {
+            let buffer = FixedVec::new(16 * 512).await;
+            match sdcard.read(2048, 16, buffer).await {
                 Ok(buffer) => {
                     let tmp = &buffer.as_slice()[0..16];
                     tracing::info!("Read data from SD card: {tmp:?}")

--- a/platforms/allwinner-d1/src/lib.rs
+++ b/platforms/allwinner-d1/src/lib.rs
@@ -8,6 +8,7 @@ use self::{
     ccu::Ccu,
     dmac::Dmac,
     drivers::{
+        smhc::Smhc,
         spim::{self, SpiSenderServer},
         twi,
         uart::{self, D1Uart, Uart},
@@ -50,6 +51,7 @@ pub fn kernel_entry(config: mnemos_config::MnemosConfig<PlatformConfig>) -> ! {
 
     let uart = unsafe { uart::kernel_uart(&mut ccu, &mut p.GPIO, p.UART0) };
     let spim = unsafe { spim::kernel_spim1(p.SPI_DBI, &mut ccu, &mut p.GPIO) };
+    let smhc0 = unsafe { Smhc::new(p.SMHC0, &mut ccu, &mut p.GPIO) };
 
     let i2c0 = match config.platform.i2c {
         d1_config::I2cConfiguration { enabled: false, .. } => None,
@@ -79,6 +81,7 @@ pub fn kernel_entry(config: mnemos_config::MnemosConfig<PlatformConfig>) -> ! {
         dmac,
         uart,
         spim,
+        smhc0,
         plic,
         i2c0,
         config.kernel,
@@ -183,6 +186,7 @@ impl D1 {
         dmac: Dmac,
         uart: Uart,
         spim: spim::Spim1,
+        smhc: Smhc,
         plic: Plic,
         i2c0: Option<twi::I2c0>,
         kernel_settings: KernelSettings,
@@ -223,6 +227,12 @@ impl D1 {
             .unwrap();
             i2c0_int
         });
+
+        // Initialize SMHC driver
+        k.initialize(async {
+            smhc.register(k, 4).await.unwrap();
+        })
+        .unwrap();
 
         Self {
             kernel: k,
@@ -320,9 +330,11 @@ impl D1 {
             plic.register(Interrupt::TIMER1, Self::timer1_int);
             plic.register(Interrupt::DMAC_NS, Dmac::handle_interrupt);
             plic.register(Interrupt::UART0, D1Uart::handle_uart0_int);
+            plic.register(Interrupt::SMHC0, Smhc::handle_smhc0_interrupt);
 
             plic.activate(Interrupt::DMAC_NS, Priority::P1).unwrap();
             plic.activate(Interrupt::UART0, Priority::P1).unwrap();
+            plic.activate(Interrupt::SMHC0, Priority::P1).unwrap();
 
             if let Some((i2c0_int, i2c0_isr)) = i2c0_int {
                 plic.register(i2c0_int, i2c0_isr);

--- a/source/kernel/src/registry/mod.rs
+++ b/source/kernel/src/registry/mod.rs
@@ -44,6 +44,7 @@ pub mod known_uuids {
         pub const KEYBOARD: Uuid = uuid!("524d77b1-499c-440b-bd62-e63c0918efb5");
         pub const KEYBOARD_MUX: Uuid = uuid!("70861d1c-9f01-4e9b-89e6-ede77d8f26d8");
         pub const EMB_DISPLAY_V2: Uuid = uuid!("aa6a2af8-afd8-40e3-83c2-2c501c698aa8");
+        pub const SDMMC: Uuid = uuid!("9f4f8244-c986-4212-982e-d35890260de4");
     }
 
     // In case you need to iterate over every UUID

--- a/source/kernel/src/services/mod.rs
+++ b/source/kernel/src/services/mod.rs
@@ -21,7 +21,7 @@
 pub mod emb_display;
 pub mod forth_spawnulator;
 pub mod i2c;
-pub mod sdmmc;
 pub mod keyboard;
+pub mod sdmmc;
 pub mod serial_mux;
 pub mod simple_serial;

--- a/source/kernel/src/services/mod.rs
+++ b/source/kernel/src/services/mod.rs
@@ -21,6 +21,7 @@
 pub mod emb_display;
 pub mod forth_spawnulator;
 pub mod i2c;
+pub mod sdmmc;
 pub mod keyboard;
 pub mod serial_mux;
 pub mod simple_serial;

--- a/source/kernel/src/services/sdmmc.rs
+++ b/source/kernel/src/services/sdmmc.rs
@@ -120,7 +120,7 @@ pub enum Response {
         data: Option<FixedVec<u8>>,
     },
     /// The 128-bit value from the 136-bit response.
-    Long([u32; 4]),
+    Long(u128),
 }
 
 /// Errors returned by the [`SdmmcService`]
@@ -348,15 +348,7 @@ impl SdCardClient {
             .await?
         {
             Response::Short { .. } => Err(Error::Response),
-            Response::Long(value) => {
-                tracing::trace!("CMD2 response: {value:?}");
-                union CidResponse {
-                    value: [u32; 4],
-                    cid: u128,
-                }
-                let rsp = CidResponse { value };
-                Ok(CardIdentification(unsafe { rsp.cid }))
-            }
+            Response::Long(value) => Ok(CardIdentification(value)),
         }
     }
 

--- a/source/kernel/src/services/sdmmc.rs
+++ b/source/kernel/src/services/sdmmc.rs
@@ -349,8 +349,12 @@ impl SdCardClient {
             Response::Short { .. } => Err(Error::Response),
             Response::Long(value) => {
                 tracing::trace!("CMD2 response: {value:?}");
-                // TODO: map [u32; 4] value to u128
-                Ok(CardIdentification(0))
+                let mut bytes = [0u8; 16];
+                bytes[0..4].copy_from_slice(&value[0].to_le_bytes());
+                bytes[4..8].copy_from_slice(&value[1].to_le_bytes());
+                bytes[8..12].copy_from_slice(&value[2].to_le_bytes());
+                bytes[12..16].copy_from_slice(&value[3].to_le_bytes());
+                Ok(CardIdentification(u128::from_le_bytes(bytes)))
             }
         }
     }

--- a/source/kernel/src/services/sdmmc.rs
+++ b/source/kernel/src/services/sdmmc.rs
@@ -283,16 +283,17 @@ impl SdCardClient {
         // TODO: limit the number of attempts
         let ocr = loop {
             // Go to *APP* mode before sending application command
-            let _ = self.cmd(Command {
-                index: 55,
-                argument: 0,
-                options: HardwareOptions::None,
-                kind: CommandKind::Control,
-                rsp_type: ResponseType::Short,
-                rsp_crc: true,
-                buffer: None,
-            })
-            .await?;
+            let _ = self
+                .cmd(Command {
+                    index: 55,
+                    argument: 0,
+                    options: HardwareOptions::None,
+                    kind: CommandKind::Control,
+                    rsp_type: ResponseType::Short,
+                    rsp_crc: true,
+                    buffer: None,
+                })
+                .await?;
 
             let mut op_cond_arg = OCR_VOLTAGE_MASK & 0x00ff8000;
             if card_type != CardType::SD1 {
@@ -400,16 +401,17 @@ impl SdCardClient {
     /// Use 4 data lanes
     pub async fn set_wide_bus(&mut self, rca: RelativeCardAddress) -> Result<CardStatus, Error> {
         // Go to *APP* mode before sending application command
-        let _ = self.cmd(Command {
-            index: 55,
-            argument: rca.0,
-            options: HardwareOptions::None,
-            kind: CommandKind::Control,
-            rsp_type: ResponseType::Short,
-            rsp_crc: true,
-            buffer: None,
-        })
-        .await?;
+        let _ = self
+            .cmd(Command {
+                index: 55,
+                argument: rca.0,
+                options: HardwareOptions::None,
+                kind: CommandKind::Control,
+                rsp_type: ResponseType::Short,
+                rsp_crc: true,
+                buffer: None,
+            })
+            .await?;
 
         match self
             .cmd(Command {

--- a/source/kernel/src/services/sdmmc.rs
+++ b/source/kernel/src/services/sdmmc.rs
@@ -27,7 +27,7 @@ impl RegisteredDriver for SdmmcService {
     type Response = Transaction;
     type Error = core::convert::Infallible;
 
-    const UUID: Uuid = known_uuids::kernel::I2C;
+    const UUID: Uuid = known_uuids::kernel::SDMMC;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/source/kernel/src/services/sdmmc.rs
+++ b/source/kernel/src/services/sdmmc.rs
@@ -1,0 +1,59 @@
+//! SD/MMC Driver Service
+//!
+//! TODO
+// TODO: #![warn(missing_docs)]
+use self::messages::*;
+use crate::{
+    comms::{
+        kchannel::{KChannel, KConsumer, KProducer},
+        oneshot::{self, Reusable},
+    },
+    mnemos_alloc::containers::FixedVec,
+    registry::{known_uuids, Envelope, KernelHandle, RegisteredDriver},
+    Kernel,
+};
+use core::{convert::Infallible, fmt, time::Duration};
+use uuid::Uuid;
+
+////////////////////////////////////////////////////////////////////////////////
+// Service Definition
+////////////////////////////////////////////////////////////////////////////////
+
+/// [Service](crate::services) definition for SD/MMC protocol drivers.
+pub struct SdmmcService;
+
+impl RegisteredDriver for SdmmcService {
+    type Request = StartTransaction;
+    type Response = Transaction;
+    type Error = core::convert::Infallible;
+
+    const UUID: Uuid = known_uuids::kernel::I2C;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Message and Error Types
+////////////////////////////////////////////////////////////////////////////////
+
+/// TODO
+#[must_use]
+pub struct Transaction {
+    tx: KProducer<Transfer>,
+    rsp_rx: Reusable<Result<FixedVec<u8>, () /* TODO */>>,
+    ended: bool,
+}
+
+pub mod messages {
+    use super::*;
+
+    pub struct StartTransaction {}
+    pub struct Transfer {}
+}
+////////////////////////////////////////////////////////////////////////////////
+// Client Definition
+////////////////////////////////////////////////////////////////////////////////
+
+/// A client for the [`SdmmcService`].
+pub struct SdmmcClient {
+    handle: KernelHandle<SdmmcService>,
+    reply: Reusable<Envelope<Result<Transaction, Infallible>>>,
+}

--- a/source/kernel/src/services/sdmmc.rs
+++ b/source/kernel/src/services/sdmmc.rs
@@ -1,8 +1,11 @@
 //! SD/MMC Driver Service
 //!
-//! TODO
-// TODO: #![warn(missing_docs)]
-use self::messages::*;
+//! Driver for SD memory cards, SDIO cards and (e)MMC cards.
+//! This kernel driver will implement the actual protocol
+//! (which commands to send and how to interpret the response),
+//! while the platform driver will implement the device specific part
+//! (how to send and receive the data).
+#![warn(missing_docs)]
 use crate::{
     comms::{
         kchannel::{KChannel, KConsumer, KProducer},
@@ -23,8 +26,8 @@ use uuid::Uuid;
 pub struct SdmmcService;
 
 impl RegisteredDriver for SdmmcService {
-    type Request = StartTransaction;
-    type Response = Transaction;
+    type Request = Command;
+    type Response = Response;
     type Error = core::convert::Infallible;
 
     const UUID: Uuid = known_uuids::kernel::SDMMC;
@@ -34,26 +37,68 @@ impl RegisteredDriver for SdmmcService {
 // Message and Error Types
 ////////////////////////////////////////////////////////////////////////////////
 
+/// Control or data command.
+/// This is the same for SD and MMC (?), but the content should be different.
+/// For data command, should also contain the buffers to read/write?
+pub struct Command {
+    /// The numeric value of the command
+    command: u8,
+    /// Argument value that should be sent on the control line
+    argument: u32,
+    /// The type of command
+    cmd_type: CommandType,
+    /// The expected length of the response
+    rsp_size: ResponseLength,
+    /// Will the card respond with a CRC that needs to be checked
+    crc: bool,
+    /// Incoming or outgoing data
+    buffer: Option<FixedVec<u8>>,
+}
+
 /// TODO
+pub enum CommandType {
+    Control,
+    Read,
+    Write,
+}
+
+/// TODO
+pub enum ResponseLength {
+    /// 48-bits
+    Short,
+    /// 136-bits
+    Long,
+}
+
+/// Response returned by the card, can be short or long, depending on command.
+/// For read command, you can find the data in previous buffer?
 #[must_use]
-pub struct Transaction {
-    tx: KProducer<Transfer>,
-    rsp_rx: Reusable<Result<FixedVec<u8>, () /* TODO */>>,
-    ended: bool,
+pub struct Response {
 }
 
-pub mod messages {
-    use super::*;
-
-    pub struct StartTransaction {}
-    pub struct Transfer {}
+/// TODO
+#[derive(Debug, Eq, PartialEq)]
+pub enum Error {
 }
+
 ////////////////////////////////////////////////////////////////////////////////
 // Client Definition
 ////////////////////////////////////////////////////////////////////////////////
 
-/// A client for the [`SdmmcService`].
-pub struct SdmmcClient {
+/// A client for SD memory cards using the [`SdmmcService`].
+pub struct SdCardClient {
     handle: KernelHandle<SdmmcService>,
-    reply: Reusable<Envelope<Result<Transaction, Infallible>>>,
+    reply: Reusable<Envelope<Result<Response, Error>>>,
+}
+
+/// A client for SDIO cards using the [`SdmmcService`].
+pub struct SdioClient {
+    handle: KernelHandle<SdmmcService>,
+    reply: Reusable<Envelope<Result<Response, Error>>>,
+}
+
+/// A client for MMC cards using the [`SdmmcService`].
+pub struct MmcClient {
+    handle: KernelHandle<SdmmcService>,
+    reply: Reusable<Envelope<Result<Response, Error>>>,
 }

--- a/source/kernel/src/services/sdmmc.rs
+++ b/source/kernel/src/services/sdmmc.rs
@@ -349,12 +349,12 @@ impl SdCardClient {
             Response::Short { .. } => Err(Error::Response),
             Response::Long(value) => {
                 tracing::trace!("CMD2 response: {value:?}");
-                let mut bytes = [0u8; 16];
-                bytes[0..4].copy_from_slice(&value[0].to_le_bytes());
-                bytes[4..8].copy_from_slice(&value[1].to_le_bytes());
-                bytes[8..12].copy_from_slice(&value[2].to_le_bytes());
-                bytes[12..16].copy_from_slice(&value[3].to_le_bytes());
-                Ok(CardIdentification(u128::from_le_bytes(bytes)))
+                union CidResponse {
+                    value: [u32; 4],
+                    cid: u128,
+                }
+                let rsp = CidResponse { value };
+                Ok(CardIdentification(unsafe { rsp.cid }))
             }
         }
     }

--- a/source/kernel/src/services/sdmmc.rs
+++ b/source/kernel/src/services/sdmmc.rs
@@ -74,7 +74,7 @@ pub enum BusWidth {
     Octo,
 }
 
-/// TODO
+/// Hardware configuration that should be applied as part of the command
 #[derive(Debug, Eq, PartialEq)]
 pub enum HardwareOptions {
     /// No change in configuration
@@ -83,7 +83,7 @@ pub enum HardwareOptions {
     SetBusWidth(BusWidth),
 }
 
-/// TODO
+/// The different types of commands that can be sent to the card
 #[derive(Debug, Eq, PartialEq)]
 pub enum CommandKind {
     /// Command without data transfer
@@ -94,7 +94,7 @@ pub enum CommandKind {
     Write(usize),
 }
 
-/// TODO
+/// The different types of responses that can be sent by the card
 #[derive(Debug, Eq, PartialEq)]
 pub enum ResponseType {
     /// No Response
@@ -119,22 +119,23 @@ pub enum Response {
         data: Option<FixedVec<u8>>,
     },
     /// The 128-bit value from the 136-bit response.
-    // TODO: make this `u128`?
     Long([u32; 4]),
 }
 
-/// TODO
+/// Errors returned by the [`SdmmcService`]
 #[derive(Debug, Eq, PartialEq)]
 pub enum Error {
-    /// TODO
+    /// The service is currently busy and cannot handle the request
     Busy,
-    /// TODO
+    /// Invalid or unexpected response was received
     Response,
-    /// TODO
+    /// Invalid or unexpected data was received
     Data,
-    /// TODO
+    /// The provided buffer does not meet the requirements
+    Buffer,
+    /// A timeout occurred
     Timeout,
-    /// TODO
+    /// A different error has occurred
     Other,
 }
 
@@ -442,7 +443,7 @@ impl SdCardClient {
     ) -> Result<FixedVec<u8>, Error> {
         // The provider buffer should have space for the requested amount of data
         if buf.capacity() < 512 * blocks {
-            return Err(Error::Data);
+            return Err(Error::Buffer);
         }
 
         match self

--- a/source/kernel/src/services/sdmmc.rs
+++ b/source/kernel/src/services/sdmmc.rs
@@ -94,7 +94,11 @@ pub enum ResponseType {
 #[must_use]
 pub enum Response {
     /// The 32-bit value from the 48-bit response.
-    Short(u32),
+    /// Potentially also includes the data vector if this was a read command.
+    Short {
+        value: u32,
+        data: Option<FixedVec<u8>>,
+    },
     /// The 128-bit value from the 136-bit response.
     // TODO: make this `u128`?
     Long([u32; 4]),

--- a/source/kernel/src/services/sdmmc.rs
+++ b/source/kernel/src/services/sdmmc.rs
@@ -12,6 +12,7 @@ use crate::{
     registry::{self, known_uuids, Envelope, KernelHandle, RegisteredDriver},
     Kernel,
 };
+use maitake::time::{self, Duration};
 use uuid::Uuid;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -322,7 +323,7 @@ impl SdCardClient {
                 Response::Long(_) => return Err(Error::Response),
             }
 
-            // TODO: wait some time (e.g., 1ms?)
+            time::sleep(Duration::from_millis(1)).await;
         };
 
         if (ocr & OCR_HCS) == OCR_HCS {


### PR DESCRIPTION
This PR adds support for SD card interaction on the Allwinner D1 platform.
It is split in an `sdmmc` kernel service and a driver for the SD/MMC host controller peripheral.
Currently only SD card support is implemented, but this should allow for adding MMC and SDIO support later.
The interface between the kernel service and the driver aims to work on the specification/protocol level
and not contain any Allwinner D1 details, which should make it suitable for other platforms as well.

This PR also improves the `BusGatingResetRegister` trait in `platforms/allwinner-d1/d1-core/src/ccu.rs`