### PR TITLE
chore(CI): temporarily pin `cargo-nextest` to v0.9.61

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,9 @@ jobs:
     - name: install rust toolchain
       run: rustup show
     - name: install nextest
-      uses: taiki-e/install-action@nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest@0.9.61
     - uses: actions/checkout@v2
     - uses: extractions/setup-just@v1
     - name: just test


### PR DESCRIPTION
v0.9.63 of `cargo-nextest` introduced a regression (https://github.com/guppy-rs/guppy/issues/157#issuecomment-1830490526) that breaks Nextest when a workspace includes a package with binary dependencies. This broke our CI builds.

This PR temporarily pins the `cargo-nextest` version on CI to v0.9.61 (as v0.9.62 was yanked). Hopefully when this is fixed upstream, we can resume using the latest version.