### PR TITLE
docs: update Oranda, fix syntax highlighting

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692734709,
-        "narHash": "sha256-SCFnyHCyYjwEmgUsHDDuU0TsbVMKeU1vwkR+r7uS2Rg=",
+        "lastModified": 1705496572,
+        "narHash": "sha256-rPIe9G5EBLXdBdn9ilGc0nq082lzQd0xGGe092R/5QE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b85ed9dcbf187b909ef7964774f8847d554fab3b",
+        "rev": "842d9d80cfd4560648c785f8a4e6f3b096790e19",
         "type": "github"
       },
       "original": {
@@ -83,17 +83,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1692983693,
-        "narHash": "sha256-HyvHvW0+RrNlGOKNCY6E8wL/fOUDw00RGGzUfWeCzxY=",
-        "owner": "hawkw",
+        "lastModified": 1704371180,
+        "narHash": "sha256-fydrZu9x/DvcoQvIyjqEq7D7ov90X1zc95T+mXkCHOI=",
+        "owner": "axodotdev",
         "repo": "oranda",
-        "rev": "8e5eff3d1f9c4e3642d8c327032d4072d2ca4a00",
+        "rev": "2bdd78b540be3915a00cfecfe04289a49fe46731",
         "type": "github"
       },
       "original": {
-        "owner": "hawkw",
+        "owner": "axodotdev",
         "repo": "oranda",
-        "rev": "8e5eff3d1f9c4e3642d8c327032d4072d2ca4a00",
         "type": "github"
       }
     },
@@ -132,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693015707,
-        "narHash": "sha256-SFr93DYn502sVT9nB5U8/cKg1INyEk/jCeq8tHioz7Y=",
+        "lastModified": 1705630663,
+        "narHash": "sha256-f+kcR17ZtwMyCEtNAfpD0Mv6qObNKoJ41l+6deoaXi8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e90223633068a44f0fb62374e0fa360ccc987292",
+        "rev": "47cac072a313d9cce884b9ea418d2bf712fa23dd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,10 +6,7 @@
     # (not available in stable nixpkgs yet).
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     oranda = {
-      # use my fork of Oranda until upstream merges PR
-      # https://github.com/axodotdev/oranda/pull/609 (this is necessary to fix
-      # the flake)
-      url = "github:hawkw/oranda?rev=8e5eff3d1f9c4e3642d8c327032d4072d2ca4a00";
+      url = "github:axodotdev/oranda";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-utils = {
@@ -35,7 +32,8 @@
         # use the Rust toolchain specified in the project's rust-toolchain.toml
         rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile
           ./rust-toolchain.toml;
-      in {
+      in
+      {
         devShell = with pkgs;
           mkShell rec {
             name = "mnemos-dev";

--- a/platforms/allwinner-d1/README.md
+++ b/platforms/allwinner-d1/README.md
@@ -44,7 +44,7 @@ The simplest way to build a MnemOS image for an Allwinner D1 board is to use the
 The `just build-d1` recipe takes an optional argument to select which bin target
 is built; by default, the `mq-pro` bin target is selected. For example:
 
-```console
+```shell
 $ just build-d1             # builds MnemOS for the MangoPi MQ Pro
 $ just build-d1 mq-pro      # also builds MnemOS for the MQ Pro
 $ just build-d1 lichee-rv   # builds MnemOS for the Lichee RV
@@ -53,7 +53,7 @@ $ just build-d1 lichee-rv   # builds MnemOS for the Lichee RV
 Alternatively, Allwinner D1 images can be built manually using Cargo. To build
 using Cargo, run the following commands:
 
-```console
+```shell
 # set which board binary to build
 $ export BOARD="mq-pro" # or "lichee-rv"
 
@@ -82,7 +82,7 @@ none is provided.
 
 For example, running `just flash-d1 mq-pro` should print output like this:
 
-```console
+```shell
 $ just flash-d1 mq-pro
        Found cargo objcopy
    Compiling mnemos-d1 v0.1.0 (/home/eliza/Code/mnemos/platforms/allwinner-d1/boards)

--- a/platforms/esp32c3-buddy/README.md
+++ b/platforms/esp32c3-buddy/README.md
@@ -37,7 +37,7 @@ pin assignment to match the target devboard before calling into shared code:
 The `just build-c3` recipe takes a required argument to select which bin target
 is built. For example:
 
-```console
+```shell
 $ just build-c3 qtpy   # builds MnemOS for the Adafruit QT Py ESP32-C3
 $ just build-c3 xiao   # builds MnemOS for the Seeedstudio XIAO ESP32-C3
 ```
@@ -45,7 +45,7 @@ $ just build-c3 xiao   # builds MnemOS for the Seeedstudio XIAO ESP32-C3
 Alternatively, Allwinner D1 images can be built manually using Cargo. To build
 using Cargo, run:
 
-```console
+```shell
 # builds MnemOS for the Adafruit QT Py ESP32-C3
 $ cargo build -p mnemos-esp32c3-buddy --bin qtpy --release
 # builds MnemOS for the Seeedstudio XIAO ESP32-C3
@@ -61,7 +61,7 @@ anywhere in the MnemOS repository.
 
 Like `just build-c3`, the target board must be provided:
 
-```console
+```shell
 $ just flash-c3 qtpy   # build and flash the Adafruit QT Py ESP32-C3
 $ just flash-c3 xiao   # build and flash the Seeedstudio XIAO ESP32-C3
 ```
@@ -74,7 +74,7 @@ $ just flash-c3 xiao   # build and flash the Seeedstudio XIAO ESP32-C3
 
 If everything worked successfully, you should see output similar to this:
 
-```console
+```shell
 $ just flash-c3 qtpy
        Found cargo-espflash
 cargo build --package mnemos-esp32c3-buddy --bin qtpy --release
@@ -98,7 +98,7 @@ App/part. size:    209,760/4,128,768 bytes, 5.08%
 
 Alternatively, the board can be flashed manually using [`cargo-espflash`]. For
 example:
-```console
+```shell
 $ cargo espflash flash \
     --package mnemos-esp32c3-buddy \
     --bin qtpy \ # or 'xiao'

--- a/platforms/x86_64/README.md
+++ b/platforms/x86_64/README.md
@@ -48,7 +48,7 @@ MnemOS can boot using either legacy [BIOS] or [UEFI] (using [`ovmf-prebuilt`]).
 The `--boot` argument can be passed to `just run-x86` to determine which boot
 method is used:
 
-```console
+```shell
 $ just run-x86 --boot uefi # boots using UEFI
 $ just run-x86 --boot bios # boots using legacy BIOS
 ```

--- a/scripts/install-ci-deps.sh
+++ b/scripts/install-ci-deps.sh
@@ -10,7 +10,7 @@ curl \
     --proto '=https' \
     --tlsv1.2 \
     -LsSf \
-    https://github.com/axodotdev/oranda/releases/download/v0.3.1/oranda-installer.sh \
+    https://github.com/axodotdev/oranda/releases/download/v0.6.1/oranda-installer.sh \
     | sh
 
 # Install just

--- a/tools/manganese/README.md
+++ b/tools/manganese/README.md
@@ -29,7 +29,7 @@ yes, this is a wildly deranged idea. i'm so smart.
 invoking `cargo mn` without a subcommand will print a list of available
 commands, which will look sort of like this:
 
-```console
+```shell
 $ cargo mn
    Compiling manganese v0.1.0 (/home/eliza/Code/mnemos/tools/manganese)
     Finished release [optimized + debuginfo] target(s) in 3.99s


### PR DESCRIPTION
- **chore: update Oranda**

  This commit updates Oranda from v0.3.1 to v0.6.1. I don't believe any of
  the new Oranda features are particularly relevant to us, but there are
  some nice bugfixes, including axodotdev/oranda#654, which fixes
  unreadable CSS colors for mdBook draft chapters in the Oranda CSS themes
  which we use.

  Also, since axodotdev/oranda#609 has merged upstream, we can change the
  Nix flake to depend on upstream Oranda rather than my fork.

- **docs: change "console" markdown syntax to "shell"**

  Oranda doesn't know how to highlight "console", it does know how to
  highlight "shell":

  ```
    esp32c3-buddy ⚠ >o_o< WARNING: Found syntax highlight language annotation `console` which is not currently supported. The annotated block will be shown as plaintext. Please file an issue https://github.com/axodotdev/oranda/issues/new to let us know you'd like to see it supported.
    esp32c3-buddy ⚠ >o_o< WARNING: Found syntax highlight language annotation `console` which is not currently supported. The annotated block will be shown as plaintext. Please file an issue https://github.com/axodotdev/oranda/issues/new to let us know you'd like to see it supported.
    esp32c3-buddy ⚠ >o_o< WARNING: Found syntax highlight language annotation `console` which is not currently supported. The annotated block will be shown as plaintext. Please file an issue https://github.com/axodotdev/oranda/issues/new to let us know you'd like to see it supported.
    esp32c3-buddy ⚠ >o_o< WARNING: Found syntax highlight language annotation `console` which is not currently supported. The annotated block will be shown as plaintext. Please file an issue https://github.com/axodotdev/oranda/issues/new to let us know you'd like to see it supported.
    esp32c3-buddy ⚠ >o_o< WARNING: Found syntax highlight language annotation `console` which is not currently supported. The annotated block will be shown as plaintext. Please file an issue https://github.com/axodotdev/oranda/issues/new to let us know you'd like to see it supported.
    ```

  GitHub's Markdown renderer treats these as equivalent, so switching the
  code blocks currently marked as "console" to "shell" results in much
  nicer syntax highlighting in the Oranda site without changing the way
  the READMEs look on GitHub.
