### PR TITLE
chore: update Rust to `nightly-2024-01-20`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,9 +1361,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 [[package]]
 name = "cordyceps"
 version = "0.3.2"
-source = "git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064"
+source = "git+https://github.com/hawkw/mycelium.git?rev=1de8ba11f7a66b379aa532e647b2948d448bf2e9#1de8ba11f7a66b379aa532e647b2948d448bf2e9"
 dependencies = [
- "loom",
+ "loom 0.7.1",
  "tracing 0.1.37",
 ]
 
@@ -1372,7 +1372,7 @@ name = "cordyceps"
 version = "0.3.2"
 source = "git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489"
 dependencies = [
- "loom",
+ "loom 0.5.6",
  "tracing 0.1.37",
 ]
 
@@ -4678,6 +4678,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e045d70ddfbc984eacfa964ded019534e8f6cbf36f6410aee0ed5cefa5a9175"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
+ "tracing 0.1.37",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4722,14 +4735,27 @@ dependencies = [
 [[package]]
 name = "maitake"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064"
+source = "git+https://github.com/hawkw/mycelium.git?rev=1de8ba11f7a66b379aa532e647b2948d448bf2e9#1de8ba11f7a66b379aa532e647b2948d448bf2e9"
 dependencies = [
- "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
- "mycelium-bitfield 0.1.3 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
- "mycelium-util 0.1.0 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=1de8ba11f7a66b379aa532e647b2948d448bf2e9)",
+ "maitake-sync",
+ "mycelium-bitfield 0.1.5",
+ "mycelium-util 0.1.0 (git+https://github.com/hawkw/mycelium.git?rev=1de8ba11f7a66b379aa532e647b2948d448bf2e9)",
  "pin-project",
  "portable-atomic",
  "tracing 0.1.37",
+]
+
+[[package]]
+name = "maitake-sync"
+version = "0.1.0"
+source = "git+https://github.com/hawkw/mycelium.git?rev=1de8ba11f7a66b379aa532e647b2948d448bf2e9#1de8ba11f7a66b379aa532e647b2948d448bf2e9"
+dependencies = [
+ "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=1de8ba11f7a66b379aa532e647b2948d448bf2e9)",
+ "loom 0.7.1",
+ "mycelium-bitfield 0.1.5",
+ "pin-project",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -5036,8 +5062,8 @@ dependencies = [
  "mnemos-abi",
  "mnemos-alloc",
  "mnemos-trace-proto",
- "mycelium-bitfield 0.1.3 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
- "mycelium-util 0.1.0 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "mycelium-bitfield 0.1.5",
+ "mycelium-util 0.1.0 (git+https://github.com/hawkw/mycelium.git?rev=1de8ba11f7a66b379aa532e647b2948d448bf2e9)",
  "portable-atomic",
  "postcard 1.0.6",
  "profont",
@@ -5066,7 +5092,7 @@ dependencies = [
 name = "mnemos-alloc"
 version = "0.1.0"
 dependencies = [
- "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=1de8ba11f7a66b379aa532e647b2948d448bf2e9)",
  "heapless",
  "linked_list_allocator",
  "maitake",
@@ -5080,7 +5106,7 @@ dependencies = [
  "bbq10kbd",
  "futures",
  "mnemos",
- "mycelium-bitfield 0.1.3 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "mycelium-bitfield 0.1.5",
  "tracing 0.1.37",
  "uuid 1.4.1",
 ]
@@ -5132,7 +5158,7 @@ dependencies = [
  "futures",
  "mnemos",
  "mnemos-bitslab",
- "mycelium-bitfield 0.1.3 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "mycelium-bitfield 0.1.5",
  "proptest",
  "proptest-derive",
  "riscv",
@@ -5161,7 +5187,7 @@ dependencies = [
 name = "mnemos-std"
 version = "0.1.0"
 dependencies = [
- "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=1de8ba11f7a66b379aa532e647b2948d448bf2e9)",
  "futures-util",
  "heapless",
  "maitake",
@@ -5246,12 +5272,12 @@ dependencies = [
 [[package]]
 name = "mycelium-bitfield"
 version = "0.1.3"
-source = "git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064"
+source = "git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489"
 
 [[package]]
 name = "mycelium-bitfield"
-version = "0.1.3"
-source = "git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489"
+version = "0.1.5"
+source = "git+https://github.com/hawkw/mycelium.git?rev=1de8ba11f7a66b379aa532e647b2948d448bf2e9#1de8ba11f7a66b379aa532e647b2948d448bf2e9"
 
 [[package]]
 name = "mycelium-trace"
@@ -5268,11 +5294,12 @@ dependencies = [
 [[package]]
 name = "mycelium-util"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064"
+source = "git+https://github.com/hawkw/mycelium.git?rev=1de8ba11f7a66b379aa532e647b2948d448bf2e9#1de8ba11f7a66b379aa532e647b2948d448bf2e9"
 dependencies = [
- "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
- "loom",
- "mycelium-bitfield 0.1.3 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=1de8ba11f7a66b379aa532e647b2948d448bf2e9)",
+ "loom 0.7.1",
+ "maitake-sync",
+ "mycelium-bitfield 0.1.5",
  "tracing 0.2.0",
 ]
 
@@ -5282,8 +5309,8 @@ version = "0.1.0"
 source = "git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489"
 dependencies = [
  "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium)",
- "loom",
- "mycelium-bitfield 0.1.3 (git+https://github.com/hawkw/mycelium)",
+ "loom 0.5.6",
+ "mycelium-bitfield 0.1.3",
  "tracing 0.2.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,11 +143,11 @@ debug = "line-tables-only"
 
 [patch.crates-io.maitake]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "101a4abaa19afdd131b334a16d92c9fb4909c064"
+rev = "1de8ba11f7a66b379aa532e647b2948d448bf2e9"
 
 [patch.crates-io.mycelium-util]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "101a4abaa19afdd131b334a16d92c9fb4909c064"
+rev = "1de8ba11f7a66b379aa532e647b2948d448bf2e9"
 
 # Use the `mycelium-bitfield` crate from the Mycelium monorepo rather than
 # crates.io.
@@ -158,11 +158,11 @@ rev = "101a4abaa19afdd131b334a16d92c9fb4909c064"
 # having both a Git dep and a crates.io dep seems unfortunate.
 [patch.crates-io.mycelium-bitfield]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "101a4abaa19afdd131b334a16d92c9fb4909c064"
+rev = "1de8ba11f7a66b379aa532e647b2948d448bf2e9"
 
 [patch.crates-io.cordyceps]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "101a4abaa19afdd131b334a16d92c9fb4909c064"
+rev = "1de8ba11f7a66b379aa532e647b2948d448bf2e9"
 
 [patch.crates-io.bbq10kbd]
 git = "https://github.com/hawkw/bbq10kbd"

--- a/flake.lock
+++ b/flake.lock
@@ -60,11 +60,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705496572,
-        "narHash": "sha256-rPIe9G5EBLXdBdn9ilGc0nq082lzQd0xGGe092R/5QE=",
+        "lastModified": 1705677747,
+        "narHash": "sha256-eyM3okYtMgYDgmYukoUzrmuoY4xl4FUujnsv/P6I/zI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "842d9d80cfd4560648c785f8a4e6f3b096790e19",
+        "rev": "bbe7d8f876fbbe7c959c90ba2ae2852220573261",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705630663,
-        "narHash": "sha256-f+kcR17ZtwMyCEtNAfpD0Mv6qObNKoJ41l+6deoaXi8=",
+        "lastModified": 1705803528,
+        "narHash": "sha256-nChqKQPRXxmGBEkHse39LjNpkNKk4U1xPQ4a4oYlUdw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "47cac072a313d9cce884b9ea418d2bf712fa23dd",
+        "rev": "bd7e8f4e122e11c934a576abc04327764f9bf19b",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2024-01-15"
+channel = "nightly-2024-01-20"
 profile = "minimal"
 components = [
     "clippy",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-08-08"
+channel = "nightly-2024-01-15"
 profile = "minimal"
 components = [
     "clippy",

--- a/source/kernel/src/lib.rs
+++ b/source/kernel/src/lib.rs
@@ -70,7 +70,6 @@
 #![cfg_attr(not(test), no_std)]
 #![allow(clippy::missing_safety_doc)]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(async_fn_in_trait)] // needed for `embedded-hal-async`
 
 extern crate alloc;
 


### PR DESCRIPTION
This branch updates our Rust toolchain to `nightly-2024-01-20`. To build
on this nightly, I've removed a no-longer-necessary feature flag, and
updated our `mycelium` deps to
hawkw/mycelium@1de8ba11f7a66b379aa532e647b2948d448bf2e9, which includes
fixes for a bunch of new warnings added on recent Rust toolchains.