### PR TITLE
use `enum_from_bits`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,9 +1361,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 [[package]]
 name = "cordyceps"
 version = "0.3.2"
-source = "git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064"
+source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 dependencies = [
- "loom",
+ "loom 0.7.1",
  "tracing 0.1.37",
 ]
 
@@ -1372,7 +1372,7 @@ name = "cordyceps"
 version = "0.3.2"
 source = "git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489"
 dependencies = [
- "loom",
+ "loom 0.5.6",
  "tracing 0.1.37",
 ]
 
@@ -4678,6 +4678,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e045d70ddfbc984eacfa964ded019534e8f6cbf36f6410aee0ed5cefa5a9175"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
+ "tracing 0.1.37",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4722,14 +4735,27 @@ dependencies = [
 [[package]]
 name = "maitake"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064"
+source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 dependencies = [
- "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
- "mycelium-bitfield 0.1.3 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
- "mycelium-util 0.1.0 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e)",
+ "maitake-sync",
+ "mycelium-bitfield 0.1.5",
+ "mycelium-util 0.1.0 (git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e)",
  "pin-project",
  "portable-atomic",
  "tracing 0.1.37",
+]
+
+[[package]]
+name = "maitake-sync"
+version = "0.1.1"
+source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+dependencies = [
+ "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e)",
+ "loom 0.7.1",
+ "mycelium-bitfield 0.1.5",
+ "pin-project",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -5036,8 +5062,8 @@ dependencies = [
  "mnemos-abi",
  "mnemos-alloc",
  "mnemos-trace-proto",
- "mycelium-bitfield 0.1.3 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
- "mycelium-util 0.1.0 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "mycelium-bitfield 0.1.5",
+ "mycelium-util 0.1.0 (git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e)",
  "portable-atomic",
  "postcard 1.0.6",
  "profont",
@@ -5066,7 +5092,7 @@ dependencies = [
 name = "mnemos-alloc"
 version = "0.1.0"
 dependencies = [
- "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e)",
  "heapless",
  "linked_list_allocator",
  "maitake",
@@ -5080,7 +5106,7 @@ dependencies = [
  "bbq10kbd",
  "futures",
  "mnemos",
- "mycelium-bitfield 0.1.3 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "mycelium-bitfield 0.1.5",
  "tracing 0.1.37",
  "uuid 1.4.1",
 ]
@@ -5132,7 +5158,7 @@ dependencies = [
  "futures",
  "mnemos",
  "mnemos-bitslab",
- "mycelium-bitfield 0.1.3 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "mycelium-bitfield 0.1.5",
  "proptest",
  "proptest-derive",
  "riscv",
@@ -5161,7 +5187,7 @@ dependencies = [
 name = "mnemos-std"
 version = "0.1.0"
 dependencies = [
- "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e)",
  "futures-util",
  "heapless",
  "maitake",
@@ -5246,12 +5272,12 @@ dependencies = [
 [[package]]
 name = "mycelium-bitfield"
 version = "0.1.3"
-source = "git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064"
+source = "git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489"
 
 [[package]]
 name = "mycelium-bitfield"
-version = "0.1.3"
-source = "git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489"
+version = "0.1.5"
+source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 
 [[package]]
 name = "mycelium-trace"
@@ -5268,11 +5294,12 @@ dependencies = [
 [[package]]
 name = "mycelium-util"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064"
+source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 dependencies = [
- "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
- "loom",
- "mycelium-bitfield 0.1.3 (git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064)",
+ "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e)",
+ "loom 0.7.1",
+ "maitake-sync",
+ "mycelium-bitfield 0.1.5",
  "tracing 0.2.0",
 ]
 
@@ -5282,8 +5309,8 @@ version = "0.1.0"
 source = "git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489"
 dependencies = [
  "cordyceps 0.3.2 (git+https://github.com/hawkw/mycelium)",
- "loom",
- "mycelium-bitfield 0.1.3 (git+https://github.com/hawkw/mycelium)",
+ "loom 0.5.6",
+ "mycelium-bitfield 0.1.3",
  "tracing 0.2.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,11 +143,11 @@ debug = "line-tables-only"
 
 [patch.crates-io.maitake]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "101a4abaa19afdd131b334a16d92c9fb4909c064"
+rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 
 [patch.crates-io.mycelium-util]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "101a4abaa19afdd131b334a16d92c9fb4909c064"
+rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 
 # Use the `mycelium-bitfield` crate from the Mycelium monorepo rather than
 # crates.io.
@@ -158,11 +158,11 @@ rev = "101a4abaa19afdd131b334a16d92c9fb4909c064"
 # having both a Git dep and a crates.io dep seems unfortunate.
 [patch.crates-io.mycelium-bitfield]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "101a4abaa19afdd131b334a16d92c9fb4909c064"
+rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 
 [patch.crates-io.cordyceps]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "101a4abaa19afdd131b334a16d92c9fb4909c064"
+rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 
 [patch.crates-io.bbq10kbd]
 git = "https://github.com/hawkw/bbq10kbd"

--- a/platforms/allwinner-d1/d1-core/Cargo.toml
+++ b/platforms/allwinner-d1/d1-core/Cargo.toml
@@ -17,7 +17,7 @@ sharp-display = []
 [dependencies]
 serde = { version = "1.0.178", features = ["derive"], default-features = false }
 mnemos-bitslab = { path = "../../../source/bitslab" }
-mycelium-bitfield = "0.1.3"
+mycelium-bitfield = "0.1.5"
 
 d1-pac = "0.0.31"
 critical-section = "1.1.1"

--- a/platforms/allwinner-d1/d1-core/src/drivers/twi.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/twi.rs
@@ -679,52 +679,9 @@ impl TwiData {
 
 unsafe impl Sync for IsrData {}
 
-// TODO(eliza): this ought to go in `mycelium-bitfield` eventually
-macro_rules! enum_try_from {
-    (
-        $(#[$meta:meta])* $vis:vis enum $name:ident<$repr:ty> {
-            $(
-                $(#[$var_meta:meta])*
-                $variant:ident = $value:expr
-            ),* $(,)?
-        }
-    ) => {
-        $(#[$meta])*
-        #[repr($repr)]
-        $vis enum $name {
-            $(
-                $(#[$var_meta])*
-                $variant = $value
-            ),*
-        }
-
-
-        impl core::convert::TryFrom<$repr> for $name {
-            type Error = &'static str;
-
-            fn try_from(value: $repr) -> Result<Self, Self::Error> {
-                match value {
-                    $(
-                        $value => Ok(Self::$variant),
-                    )*
-                    _ => Err(concat!(
-                        "invalid value for ",
-                        stringify!($name),
-                        ": expected one of [",
-                        $(
-                            stringify!($value),
-                            ", ",
-                        )* "]")
-                    ),
-                }
-            }
-        }
-    };
-}
-
-enum_try_from! {
+mycelium_bitfield::enum_from_bits! {
     /// Values of the `TWI_STAT` register.
-    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+    #[derive(Debug, Eq, PartialEq)]
     enum Status<u8> {
         /// 0x00: Bus error
         BusError = 0x00,

--- a/platforms/beepy/Cargo.toml
+++ b/platforms/beepy/Cargo.toml
@@ -38,4 +38,4 @@ features = ["async-await"]
 default-features = false
 
 [dependencies.mycelium-bitfield]
-version = "0.1.2"
+version = "0.1.5"

--- a/source/kernel/Cargo.toml
+++ b/source/kernel/Cargo.toml
@@ -132,7 +132,7 @@ default-features = false
 version = "0.6.1"
 
 [dependencies.mycelium-bitfield]
-version = "0.1.2"
+version = "0.1.5"
 
 [build-dependencies]
 vergen = { version = "8.0.0", features = ["cargo", "git", "gitcl", "rustc",] }


### PR DESCRIPTION
There's a comment in the TWI driver on a sui generis "generate
`FromBits` for enums" macro saying "this should be in the
`mycelium-bitfield` crate". It is now in that crate, so we should
just use that.