### PR TITLE
chore(ci): run Miri on our pinned nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,20 +113,20 @@ jobs:
   # (test-host forth3) - run miri tests
   test-host-miri:
     runs-on: ubuntu-latest
-    name: cargo miri test (host)
+    name: cargo miri test --package forth3 (host)
     needs: check
     # TODO(eliza): only run this if forth3 changed?
     # needs: changed_paths
     # if: needs.changed_paths.outputs.should_skip != 'true'
     steps:
-    - name: install rust toolchain and miri
+    - name: install Miri etc
       run: |
-        rustup toolchain install nightly --component miri
-        cargo +nightly miri setup
+        rustup component add miri
+        cargo miri setup
     - uses: actions/checkout@v3
     - name: cargo miri test (forth3)
       run: |
-        cargo +nightly miri test \
+        cargo miri test \
           --package forth3 \
           --all-features
 


### PR DESCRIPTION
Currently, the CI Miri test job installs the latest nightly and runs Miri tests on that nightly. Since mnemOS already only builds on nightly, though, we should be using the pinned toolchain revision instead. This commit changes our Miri job to run on the nightly in `rust-toolchain.toml`.

Fixes #313