### PR TITLE
fix pomelo URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ using WebAssembly. A hosted version of Pomelo can be found at
 [`platforms/allwinner-d1/README.md`]: ./platforms/allwinner-d1/README.md
 [Melpomene]: ./platforms/melpomene
 [Pomelo]: https://github.com/tosc-rs/mnemos/tree/main/platforms/pomelo
-[mlem]: https://anatol.versteht.es/mlem/
+[mlem]: https://web.versteht.es/mlem/
 [`just` recipe]: ./justfile
 [`manganese`]: ./tools/manganese/
 


### PR DESCRIPTION
the URL where pomelo is deployed has changed. Updated README to reflect this