### PR TITLE
fix(scripts): confirm script should default to Y

### DIFF
--- a/scripts/_util.sh
+++ b/scripts/_util.sh
@@ -38,7 +38,7 @@ status() {
 # Prompt the user to confirm an action
 #
 # Args:
-#    $1: message to display to the user along with the `[y/N]` prompt
+#    $1: message to display to the user along with the `[Y/n]` prompt
 #
 # Returns:
 #    0 if the user confirmed, 1 otherwise
@@ -46,14 +46,15 @@ confirm() {
     while read -r -p "$1 [Y/n] " input
     do
         case "$input" in
-            [yY][eE][sS]|[yY])
+            # empty string counts as 'yes'
+            [yY][eE][sS]|[yY]|""|" "|"\n")
                 return 0
                 ;;
             [nN][oO]|[nN])
                 return 1
                 ;;
             *)
-                err "invalid input $input"
+                err "invalid input '$input'"
                 ;;
         esac
     done


### PR DESCRIPTION
The `confirm` helper function used in our build scripts prints "[Y/n]", which suggests that "yes" is the default option. However, if you press enter, it just says "invalid input" and retries, which is not what it claims to do. This commit fixes that.

For example, a test script like:

```bash
#!/usr/bin/env bash

source scripts/_util.sh

if confirm "test"; then
    echo "ok you confirmed"
else
    echo "you didn't confirm"
fi
```

will now default to "yes" if you just press enter:
```console
$ ./test/sh
test [Y/n]
ok you confirmed
```