### PR TITLE
docs: fix dead links to d1 platform directories

### DIFF
--- a/platforms/README.md
+++ b/platforms/README.md
@@ -4,10 +4,7 @@ This directory contains code for running MnemOS on the supported hardware and si
 
 ## Folder Layout
 
-* [`allwinner-d1/`] - MnemOS for the Allwinner D1 RISC-V SoC
-  - [`allwinner-d1/boards/`]: Platform implementations for supported D1
-        single-board computers.
-  - [`allwinner-d1/core/`]: MnemOS core for all Allwinner D1 boards
+* [`allwinner-d1/`] - MnemOS for the Allwinner D1 RISC-V SoC. See [here](allwinner-d1#getting-started-with-mnemos-on-the-d1) for list of supported boards and how to get started.
 * [`esp32c3-buddy/`] - MnemOS ESP32-C3 WiFi Buddy firmware
 * [`melpomene/`] - Melpomene is a desktop simulator for MnemOS development
 * [`pomelo/`] - Pomelo is a web/wasm simulator for MnemOS development
@@ -17,8 +14,6 @@ This directory contains code for running MnemOS on the supported hardware and si
   - [`x86_64/core/`] - MnemOS core kernel for x86_64
 
 [`allwinner-d1/`]: ./allwinner-d1/
-[`allwinner-d1/boards/`]: ./allwinner-d1/boards/
-[`allwinner-d1/core/`]: ./allwinner-d1/core/
 [`esp32c3-buddy/`]: ./esp32c3-buddy/
 [`melpomene/`]: ./melpomene
 [`pomelo/`]: ./pomelo


### PR DESCRIPTION
From what I understand, after the `alwinner-d1` directory got restructured there's no single best directory to point readers to see list of supported boards, so it's probably easier to just link to README instead.

fixes #320 