### PR TITLE
style: use core `ready`, `poll_fn`, and `pin!`

### DIFF
--- a/platforms/allwinner-d1/d1-core/src/dmac/mod.rs
+++ b/platforms/allwinner-d1/d1-core/src/dmac/mod.rs
@@ -2,6 +2,7 @@
 #![warn(missing_docs)]
 use core::{
     fmt,
+    pin::pin,
     ptr::NonNull,
     sync::atomic::{fence, Ordering},
 };
@@ -261,8 +262,7 @@ impl Dmac {
 
         loop {
             // if no channel was available, register our waker and try again.
-            let wait = STATE.claim_wait.wait();
-            futures::pin_mut!(wait);
+            let mut wait = pin!(STATE.claim_wait.wait());
             // ensure the `WaitQueue` entry is registered before we actually
             // check the claim state.
             let _ = wait.as_mut().subscribe();

--- a/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/smhc.rs
@@ -12,6 +12,7 @@
 //! the transfer and reception of large amounts of data to/from the device.
 use core::{
     cell::UnsafeCell,
+    future,
     ops::{Deref, DerefMut},
     task::{Poll, Waker},
 };
@@ -553,7 +554,7 @@ impl Drop for SmhcDataGuard<'_> {
 impl SmhcDataGuard<'_> {
     async fn wait_for_irq(&mut self) {
         let mut waiting = false;
-        futures::future::poll_fn(|cx| {
+        future::poll_fn(|cx| {
             if waiting {
                 self.smhc.smhc_ctrl.modify(|_, w| w.ine_enb().disable());
                 return Poll::Ready(());

--- a/platforms/allwinner-d1/d1-core/src/drivers/twi.rs
+++ b/platforms/allwinner-d1/d1-core/src/drivers/twi.rs
@@ -53,6 +53,7 @@
 //! [linux-driver]: https://github.com/torvalds/linux/blob/995b406c7e972fab181a4bb57f3b95e59b8e5bf3/drivers/i2c/busses/i2c-mv64xxx.c
 use core::{
     cell::UnsafeCell,
+    future,
     ops::{Deref, DerefMut},
     task::{Poll, Waker},
 };
@@ -431,7 +432,7 @@ impl Drop for TwiDataGuard<'_> {
 impl TwiDataGuard<'_> {
     async fn wait_for_irq(&mut self) {
         let mut waiting = false;
-        futures::future::poll_fn(|cx| {
+        future::poll_fn(|cx| {
             if waiting {
                 self.twi.twi_cntr.modify(|_r, w| w.int_en().low());
                 return Poll::Ready(());

--- a/source/forth3/src/testutil/mod.rs
+++ b/source/forth3/src/testutil/mod.rs
@@ -101,7 +101,7 @@ pub fn async_blockon_runtest(contents: &str) {
 
     struct TestAsyncDispatcher;
     impl<'forth> AsyncBuiltins<'forth, ()> for TestAsyncDispatcher {
-        type Future = futures::future::Ready<Result<(), Error>>;
+        type Future = core::future::Ready<Result<(), Error>>;
         const BUILTINS: &'static [AsyncBuiltinEntry<()>] = &[];
         fn dispatch_async(&self, _id: &FaStr, _forth: &'forth mut Forth<()>) -> Self::Future {
             unreachable!("no async builtins should be called in this test")


### PR DESCRIPTION
Currently, we use the `future::ready` and `future::poll_fn` functions and the `pin_mut!` macro from the `futures` crate. The equivalent APIs in libcore have stabilized, so we can use them instead.

Because we use a bunch of other stuff from `futures` --- in particular, `futures::select!` --- this doesn't allow us to reduce our dependency footprint by removing dependencies on `futures`. But, IMO, it feels like sligly better style to use the standard library versions of common APIs when it's possible to do so.

Also, I think the `core::pin::pin!` macro has a somewhat nicer API than `futures::pin_mut!` since it allows pinning the expression on the left-hand side of a `let` binding directly, rather than having to assign the value to a name and *then* pin it:

```rust
// Personally, I think this:
let mut pinned_fut = core::pin::pin!(future::ready());
pinned_fut.await;

// ...looks nicer than this:
let pinned_fut = future::ready();
pin_mut!(pinned_fut);
pinned_fut.await;
```