### PR TITLE
tools: cargo-style logging for x86 bootimager

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,8 @@
-{
+i{
     "rust-analyzer.check.invocationLocation": "workspace",
     "rust-analyzer.cargo.buildScripts.invocationLocation": "workspace",
     "rust-analyzer.cargo.buildScripts.overrideCommand": [
         "cargo",
-        "mn",
         "clippy",
         "--quiet",
         "--message-format=json",
@@ -11,7 +10,6 @@
     ],
     "rust-analyzer.check.overrideCommand": [
         "cargo",
-        "mn",
         "clippy",
         "--quiet",
         "--message-format=json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4427,7 +4427,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.11",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing 0.1.40",
@@ -5695,7 +5695,10 @@ dependencies = [
  "bootloader-boot-config",
  "camino",
  "clap 4.5.15",
+ "heck 0.5.0",
  "ovmf-prebuilt",
+ "owo-colors 4.0.0",
+ "supports-color 3.0.0",
  "tracing 0.1.40",
  "tracing-subscriber",
 ]
@@ -8164,7 +8167,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.72",
@@ -9205,7 +9208,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+source scripts/_util.sh
+
+if confirm "test"; then 
+echo "ok you confirmed"
+else
+echo "you didn't confirm"
+fi

--- a/tools/x86_64-bootimager/Cargo.toml
+++ b/tools/x86_64-bootimager/Cargo.toml
@@ -8,12 +8,15 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 camino = "1"
+heck = "0.5"
 # cargo_metadata = "0.18.1"
 # used for UEFI booting in QEMU
 ovmf-prebuilt = "0.1.0-alpha.1"
+owo-colors = "4"
 clap = { version = "4.5", features = ["derive", "env"] }
 bootloader = "0.11"
 bootloader-boot-config = "0.11.3"
 # escargot = "0.5"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["fmt", "tracing-log"] }
+supports-color = "3"

--- a/tools/x86_64-bootimager/src/lib.rs
+++ b/tools/x86_64-bootimager/src/lib.rs
@@ -188,7 +188,6 @@ impl QemuOptions {
         cmd.arg("-drive")
             .arg(format!("format=raw,file={bootimage_path}"));
 
-
         if let BootMode::Uefi = boot_mode {
             cmd.arg("-bios").arg(ovmf_prebuilt::ovmf_pure_efi());
         }

--- a/tools/x86_64-bootimager/src/main.rs
+++ b/tools/x86_64-bootimager/src/main.rs
@@ -1,18 +1,14 @@
-use clap::{Args, Parser};
-use mnemos_x86_64_bootimager::{Builder, QemuOptions};
+use clap::Parser;
+use mnemos_x86_64_bootimager::{Builder, QemuOptions, output};
 
 fn main() -> anyhow::Result<()> {
-    use tracing_subscriber::prelude::*;
-
     let App {
         cmd,
         builder,
         output,
     } = App::parse();
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().without_time().pretty())
-        .with(output.trace_filter)
-        .init();
+    output.init()?;
+    tracing::info!("Assuming direct control over the build!");
 
     let bootimage_path = builder.build_bootimage()?;
     let mode = builder.bootloader.mode;
@@ -38,7 +34,7 @@ struct App {
     builder: Builder,
 
     #[clap(flatten)]
-    output: OutputOptions,
+    output: output::Options,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -51,18 +47,4 @@ enum Subcommand {
     /// This is the default subcommand.
     #[clap(alias = "run")]
     Qemu(QemuOptions),
-}
-
-#[derive(Clone, Debug, Args)]
-#[command(next_help_heading = "Output Options")]
-struct OutputOptions {
-    /// Tracing filter for the bootimage builder.
-    #[clap(
-        long = "trace",
-        alias = "log",
-        env = "RUST_LOG",
-        default_value = "info",
-        global = true
-    )]
-    trace_filter: tracing_subscriber::filter::Targets,
 }

--- a/tools/x86_64-bootimager/src/main.rs
+++ b/tools/x86_64-bootimager/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use mnemos_x86_64_bootimager::{Builder, QemuOptions, output};
+use mnemos_x86_64_bootimager::{output, Builder, QemuOptions};
 
 fn main() -> anyhow::Result<()> {
     let App {

--- a/tools/x86_64-bootimager/src/output.rs
+++ b/tools/x86_64-bootimager/src/output.rs
@@ -1,15 +1,14 @@
 use clap::Args;
 use heck::ToTitleCase;
+use std::fmt;
 use tracing::{field::Field, Event, Level, Subscriber};
 use tracing_subscriber::{
     field::Visit,
     fmt::{format::Writer, FmtContext, FormatEvent, FormatFields, FormattedFields},
     registry::LookupSpan,
 };
-use std::fmt;
 
 pub use owo_colors::{style, OwoColorize, Style};
-
 
 #[derive(Clone, Debug, Args)]
 #[command(next_help_heading = "Output Options")]

--- a/tools/x86_64-bootimager/src/output.rs
+++ b/tools/x86_64-bootimager/src/output.rs
@@ -1,0 +1,353 @@
+use clap::Args;
+use heck::ToTitleCase;
+use tracing::{field::Field, Event, Level, Subscriber};
+use tracing_subscriber::{
+    field::Visit,
+    fmt::{format::Writer, FmtContext, FormatEvent, FormatFields, FormattedFields},
+    registry::LookupSpan,
+};
+use std::fmt;
+
+pub use owo_colors::{style, OwoColorize, Style};
+
+
+#[derive(Clone, Debug, Args)]
+#[command(next_help_heading = "Output Options")]
+pub struct Options {
+    /// Tracing filter for the bootimage builder.
+    #[clap(
+        long = "trace",
+        alias = "log",
+        env = "RUST_LOG",
+        default_value = "info",
+        global = true
+    )]
+    trace_filter: tracing_subscriber::filter::Targets,
+
+    /// Whether to emit colors in output.
+    #[clap(
+            long,
+            env = "CARGO_TERM_COLORS",
+            default_value_t = ColorMode::Auto,
+            global = true,
+        )]
+    color: ColorMode,
+}
+
+pub const CARGO_LOG_WIDTH: usize = 12;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum)]
+#[repr(u8)]
+#[clap(rename_all = "lower")]
+enum ColorMode {
+    /// Determine whether to color output based on whether or not stderr is a
+    /// TTY.
+    Auto = 0,
+    /// Always color output.
+    Always = 1,
+    /// Never color output.
+    Never = 2,
+}
+
+// === impl OutputOptions ===
+
+impl Options {
+    pub fn init(&self) -> anyhow::Result<()> {
+        use tracing_subscriber::prelude::*;
+        let fmt = tracing_subscriber::fmt::layer()
+            .event_format(CargoFormatter {
+                styles: Styles::new(self.color),
+            })
+            .with_writer(std::io::stderr);
+
+        tracing_subscriber::registry()
+            .with(fmt)
+            .with(self.trace_filter.clone())
+            .try_init()?;
+        Ok(())
+    }
+}
+
+// === impl ColorMode ===
+
+impl fmt::Display for ColorMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad(self.as_str())
+    }
+}
+
+impl ColorMode {
+    fn if_color(self, style: owo_colors::Style) -> owo_colors::Style {
+        if self.should_color_stderr() {
+            style
+        } else {
+            owo_colors::style()
+        }
+    }
+
+    fn as_str(&self) -> &'static str {
+        match self {
+            ColorMode::Auto => "auto",
+            ColorMode::Always => "always",
+            ColorMode::Never => "never",
+        }
+    }
+
+    fn should_color_stderr(self) -> bool {
+        match self {
+            ColorMode::Auto => supports_color::on(supports_color::Stream::Stderr)
+                .map(|c| c.has_basic)
+                .unwrap_or(false),
+            ColorMode::Always => true,
+            ColorMode::Never => false,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CargoFormatter {
+    styles: Styles,
+}
+
+struct Visitor<'styles, 'writer> {
+    level: Level,
+    writer: Writer<'writer>,
+    is_empty: bool,
+    styles: &'styles Styles,
+    did_cargo_format: bool,
+}
+
+#[derive(Debug)]
+struct Styles {
+    error: Style,
+    warn: Style,
+    info: Style,
+    debug: Style,
+    trace: Style,
+    pipes: Style,
+    bold: Style,
+}
+
+struct Prefixed<T> {
+    prefix: &'static str,
+    val: T,
+}
+
+impl<S, N> FormatEvent<S, N> for CargoFormatter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let metadata = event.metadata();
+        let level = metadata.level();
+
+        let include_spans = {
+            let mut visitor = self.visitor(*level, writer.by_ref());
+            event.record(&mut visitor);
+            !visitor.did_cargo_format && ctx.lookup_current().is_some()
+        };
+
+        writer.write_char('\n')?;
+
+        if include_spans {
+            writeln!(
+                writer,
+                "   {} {}{}",
+                "-->".style(self.styles.pipes),
+                metadata.file().unwrap_or_else(|| metadata.target()),
+                DisplayOpt(metadata.line().map(Prefixed::prefix(":"))),
+            )?;
+            ctx.visit_spans(|span| {
+                let exts = span.extensions();
+                let fields = exts
+                    .get::<FormattedFields<N>>()
+                    .map(|f| f.fields.as_str())
+                    .unwrap_or("");
+                writeln!(
+                    writer,
+                    "    {} {}{}{}",
+                    "|".style(self.styles.pipes),
+                    span.name().style(self.styles.bold),
+                    if fields.is_empty() { "" } else { ": " },
+                    fields
+                )
+            })?;
+
+            writer.write_char('\n')?;
+        }
+
+        Ok(())
+    }
+}
+
+impl CargoFormatter {
+    fn visitor<'styles, 'writer>(
+        &'styles self,
+        level: Level,
+        writer: Writer<'writer>,
+    ) -> Visitor<'styles, 'writer> {
+        Visitor {
+            level,
+            writer,
+            is_empty: true,
+            styles: &self.styles,
+            did_cargo_format: false,
+        }
+    }
+}
+
+// === impl Visitor ===
+
+impl<'styles, 'writer> Visitor<'styles, 'writer> {
+    const MESSAGE: &'static str = "message";
+    const INDENT: usize = 12;
+}
+
+impl<'styles, 'writer> Visit for Visitor<'styles, 'writer> {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        // If we're writing the first field of the event, either emit cargo
+        // formatting, or a level header.
+        if self.is_empty {
+            // If the level is `INFO` and it has a message that's
+            // shaped like a cargo log tag, emit the cargo tag followed by the
+            // rest of the message.
+            if self.level == Level::INFO && field.name() == Self::MESSAGE {
+                let message = format!("{value:?}");
+                if let Some((tag, message)) = message.as_str().split_once(' ') {
+                    if tag.len() <= Self::INDENT {
+                        let tag = tag.to_title_case();
+                        let style = match self.level {
+                            Level::DEBUG => self.styles.debug,
+                            _ => self.styles.info,
+                        };
+
+                        let _ = write!(
+                            self.writer,
+                            "{:>indent$} ",
+                            tag.style(style),
+                            indent = Self::INDENT
+                        );
+
+                        let _ = self.writer.write_str(message);
+                        self.is_empty = false;
+                        self.did_cargo_format = true;
+                        return;
+                    }
+                }
+            }
+
+            // Otherwise, emit a level tag.
+            let _ = match self.level {
+                Level::ERROR => write!(
+                    self.writer,
+                    "{}{} ",
+                    "error".style(self.styles.error),
+                    ":".style(self.styles.bold)
+                ),
+                Level::WARN => write!(
+                    self.writer,
+                    "{}{} ",
+                    "warning".style(self.styles.warn),
+                    ":".style(self.styles.bold),
+                ),
+                Level::INFO => write!(
+                    self.writer,
+                    "{}{} ",
+                    "info".style(self.styles.info),
+                    ":".style(self.styles.bold)
+                ),
+                Level::DEBUG => write!(
+                    self.writer,
+                    "{}{} ",
+                    "debug".style(self.styles.debug),
+                    ":".style(self.styles.bold)
+                ),
+                Level::TRACE => write!(
+                    self.writer,
+                    "{}{} ",
+                    "trace".style(self.styles.trace),
+                    ":".style(self.styles.bold)
+                ),
+            };
+        } else {
+            // If this is *not* the first field of the event, prefix it with a
+            // comma for the preceding field, instead of a cargo tag or level tag.
+            let _ = self.writer.write_str(", ");
+        }
+
+        if field.name() == Self::MESSAGE {
+            let _ = write!(self.writer, "{value:?}");
+        } else {
+            let _ = write!(
+                self.writer,
+                "{}{} {:?}",
+                field.name().style(self.styles.bold),
+                ":".style(self.styles.bold),
+                value
+            );
+        }
+
+        self.is_empty = false;
+    }
+}
+
+// === impl Styles ===
+
+impl Styles {
+    fn new(colors: ColorMode) -> Self {
+        Self {
+            error: colors.if_color(style().red().bold()),
+            warn: colors.if_color(style().yellow().bold()),
+            info: colors.if_color(style().green().bold()),
+            debug: colors.if_color(style().blue().bold()),
+            trace: colors.if_color(style().purple().bold()),
+            bold: colors.if_color(style().bold()),
+            pipes: colors.if_color(style().blue().bold()),
+        }
+    }
+}
+
+impl<T> Prefixed<T> {
+    fn prefix(prefix: &'static str) -> impl Fn(T) -> Prefixed<T> {
+        move |val| Prefixed { val, prefix }
+    }
+}
+
+impl<T> fmt::Display for Prefixed<T>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{}", self.prefix, self.val)
+    }
+}
+
+impl<T> fmt::Debug for Prefixed<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{:?}", self.prefix, self.val)
+    }
+}
+
+struct DisplayOpt<T>(Option<T>);
+
+impl<T> fmt::Display for DisplayOpt<T>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(ref val) = self.0 {
+            fmt::Display::fmt(val, f)?;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is super goofy but I thought it would be cool to have:

```console
eliza@theseus ~/Code/mnemos $ just run-x86
cargo run --package mnemos-x86_64 --target=x86_64-unknown-none --features=bootloader_api --
   Compiling memchr v2.7.4
   Compiling itoa v1.0.11
   Compiling ryu v1.0.18
   Compiling cfg-if v1.0.0
   Compiling time v0.3.36
   Compiling aho-corasick v1.1.3
   Compiling serde_json v1.0.122
   Compiling cargo_metadata v0.18.1
   Compiling regex-automata v0.4.7
   Compiling regex v1.10.6
   Compiling vergen v8.3.2
   Compiling mnemos v0.1.0 (/home/eliza/Code/mnemos/source/kernel)
   Compiling mnemos-x86_64 v0.1.0 (/home/eliza/Code/mnemos/platforms/x86_64/core)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.30s
     Running `cargo run --package mnemos-x86_64-bootimager -- --kernel-bin target/x86_64-unknown-none/debug/bootloader`
   Compiling cfg-if v1.0.0
   Compiling ryu v1.0.18
   Compiling itoa v1.0.11
   Compiling memchr v2.7.4
   Compiling polling v3.7.3
   Compiling polling v2.8.0
   Compiling getrandom v0.2.15
   Compiling tempfile v3.12.0
   Compiling thread_local v1.1.8
   Compiling uuid v1.10.0
   Compiling async-io v1.13.0
   Compiling tracing-subscriber v0.3.18
   Compiling async-io v2.3.3
   Compiling gpt v3.1.0
   Compiling serde_json v1.0.122
   Compiling async-signal v0.2.9
   Compiling async-process v1.8.1
   Compiling bootloader v0.11.7
   Compiling mnemos-x86_64-bootimager v0.1.0 (/home/eliza/Code/mnemos/tools/x86_64-bootimager)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 12.93s
     Running `target/debug/mnemos-x86_64-bootimager --kernel-bin target/x86_64-unknown-none/debug/bootloader`
    Assuming direct control over the build!
    Building boot image, boot_mode: UEFI, kernel: target/x86_64-unknown-none/debug/bootloader
    Finished bootable disk image [UEFI] in 119.41ms (/home/eliza/Code/mnemos/target/x86_64-unknown-none/debug/mnemos-x86_64-uefi.img)
     Booting mnemOS VM, qemu: qemu-system-x86_64, args: ["-cpu", "qemu64", "-smp", "cores=4"]
^X^Cqemu: terminating on signal 2
```
(everything after "Assuming direct control over the build!" is from the MnemOS tools)