### PR TITLE
Specify how to create a `Registration` in its doc comment.

### DIFF
--- a/source/kernel/src/registry/listener.rs
+++ b/source/kernel/src/registry/listener.rs
@@ -17,6 +17,8 @@ pub struct Listener<D: RegisteredDriver> {
 /// A registration for a [`RegisteredDriver`]. This type is provided to
 /// [`Registry::register`] in order to add the driver to the registry.
 ///
+/// Call [`Listener::new`] to get a `Listener`/`Registration` pair.
+///
 /// [`Registry::register`]: crate::registry::Registry::register
 #[must_use = "a `Registration` does nothing if not registered with a `Registry`"]
 pub struct Registration<D: RegisteredDriver> {


### PR DESCRIPTION
As a brand new reader of the mnemos kernel docs, this was a bit difficult to discover. I started at `Registry::register`, and saw that it requires a `Registration`. But `Registration` has no constructor, and its docs didn't mention how one is created.