### PR TITLE
all platforms: update Mycelium dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,7 +1475,7 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 [[package]]
 name = "cordyceps"
 version = "0.3.2"
-source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5#ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 dependencies = [
  "loom 0.7.2",
  "tracing 0.1.40",
@@ -4121,9 +4121,10 @@ dependencies = [
 [[package]]
 name = "hal-core"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5#ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 dependencies = [
  "embedded-graphics-core 0.3.3",
+ "maitake-sync",
  "mycelium-util",
  "tracing 0.2.0",
 ]
@@ -4131,10 +4132,11 @@ dependencies = [
 [[package]]
 name = "hal-x86_64"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5#ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 dependencies = [
  "acpi",
  "hal-core",
+ "maitake",
  "mycelium-trace",
  "mycelium-util",
  "mycotest",
@@ -5167,7 +5169,7 @@ dependencies = [
 [[package]]
 name = "maitake"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5#ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 dependencies = [
  "cordyceps",
  "maitake-sync",
@@ -5180,14 +5182,16 @@ dependencies = [
 
 [[package]]
 name = "maitake-sync"
-version = "0.1.1"
-source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+version = "0.1.2"
+source = "git+https://github.com/hawkw/mycelium?rev=ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5#ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 dependencies = [
  "cordyceps",
  "loom 0.7.2",
+ "mutex-traits",
  "mycelium-bitfield",
  "pin-project",
  "portable-atomic",
+ "tracing 0.1.40",
 ]
 
 [[package]]
@@ -5746,9 +5750,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutex-traits"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd54cb762feb1788c74f5d3387983864d2365ca1819043d2addb76db80169102"
+
+[[package]]
 name = "mycelium-alloc"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5#ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 dependencies = [
  "hal-core",
  "mycelium-util",
@@ -5758,15 +5768,16 @@ dependencies = [
 [[package]]
 name = "mycelium-bitfield"
 version = "0.1.5"
-source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5#ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 
 [[package]]
 name = "mycelium-trace"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5#ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 dependencies = [
  "embedded-graphics 0.7.1",
  "hal-core",
+ "maitake",
  "mycelium-util",
  "tracing 0.2.0",
  "tracing-core 0.2.0",
@@ -5775,7 +5786,7 @@ dependencies = [
 [[package]]
 name = "mycelium-util"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5#ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 dependencies = [
  "cordyceps",
  "loom 0.7.2",
@@ -5787,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "mycotest"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5#ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 dependencies = [
  "tracing 0.1.40",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,7 +1475,7 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 [[package]]
 name = "cordyceps"
 version = "0.3.2"
-source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 dependencies = [
  "loom 0.7.2",
  "tracing 0.1.40",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "hal-core"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 dependencies = [
  "embedded-graphics-core 0.3.3",
  "mycelium-util",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "hal-x86_64"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 dependencies = [
  "acpi",
  "hal-core",
@@ -5167,7 +5167,7 @@ dependencies = [
 [[package]]
 name = "maitake"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 dependencies = [
  "cordyceps",
  "maitake-sync",
@@ -5181,7 +5181,7 @@ dependencies = [
 [[package]]
 name = "maitake-sync"
 version = "0.1.1"
-source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 dependencies = [
  "cordyceps",
  "loom 0.7.2",
@@ -5748,7 +5748,7 @@ dependencies = [
 [[package]]
 name = "mycelium-alloc"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 dependencies = [
  "hal-core",
  "mycelium-util",
@@ -5758,12 +5758,12 @@ dependencies = [
 [[package]]
 name = "mycelium-bitfield"
 version = "0.1.5"
-source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 
 [[package]]
 name = "mycelium-trace"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 dependencies = [
  "embedded-graphics 0.7.1",
  "hal-core",
@@ -5775,7 +5775,7 @@ dependencies = [
 [[package]]
 name = "mycelium-util"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 dependencies = [
  "cordyceps",
  "loom 0.7.2",
@@ -5787,7 +5787,7 @@ dependencies = [
 [[package]]
 name = "mycotest"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/mycelium.git?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+source = "git+https://github.com/hawkw/mycelium?rev=13d0722429ef201f38e4ea47ea22d88f3f72c10e#13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 dependencies = [
  "tracing 0.1.40",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,11 +159,11 @@ debug = "line-tables-only"
 
 [patch.crates-io.maitake]
 git = "https://github.com/hawkw/mycelium"
-rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+rev = "ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 
 [patch.crates-io.mycelium-alloc]
 git = "https://github.com/hawkw/mycelium"
-rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+rev = "ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 # Use the `mycelium-bitfield` crate from the Mycelium monorepo rather than
 # crates.io.
 # NOTE: this patch, unlike the patches for `maitake` and `mycelium-util`, (which
@@ -173,23 +173,23 @@ rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 # having both a Git dep and a crates.io dep seems unfortunate.
 [patch.crates-io.mycelium-bitfield]
 git = "https://github.com/hawkw/mycelium"
-rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+rev = "ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 
 [patch.crates-io.mycelium-util]
 git = "https://github.com/hawkw/mycelium"
-rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+rev = "ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 
 [patch.crates-io.cordyceps]
 git = "https://github.com/hawkw/mycelium"
-rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+rev = "ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 
 [patch.crates-io.hal-core]
 git = "https://github.com/hawkw/mycelium"
-rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+rev = "ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 
 [patch.crates-io.hal-x86_64]
 git = "https://github.com/hawkw/mycelium"
-rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+rev = "ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5"
 
 [patch.crates-io.bbq10kbd]
 git = "https://github.com/hawkw/bbq10kbd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,8 @@ default-members = [
 # this isn't actually a crate
 exclude = ["source/notes"]
 
+### workspace dependencies ###
+
 [workspace.package]
 edition = "2021"
 repository = "https://github.com/tosc-rs/mnemos"
@@ -74,7 +76,13 @@ homepage = "https://mnemos.dev"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
+cordyceps = { version = "0.3", default-features = false }
+hal-core = { version = "0.1.0" }
+maitake = { version = "0.1.0", default-features = false }
 miette = "7.2"
+mycelium-alloc = { version = "0.1.0", features = ["buddy", "bump"] }
+mycelium-bitfield = { version = "0.1.5" }
+mycelium-util = { version = "0.1.0" }
 
 ### profile settings ###
 
@@ -150,13 +158,12 @@ debug = "line-tables-only"
 ### patches ###
 
 [patch.crates-io.maitake]
-git = "https://github.com/hawkw/mycelium.git"
+git = "https://github.com/hawkw/mycelium"
 rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 
-[patch.crates-io.mycelium-util]
-git = "https://github.com/hawkw/mycelium.git"
+[patch.crates-io.mycelium-alloc]
+git = "https://github.com/hawkw/mycelium"
 rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
-
 # Use the `mycelium-bitfield` crate from the Mycelium monorepo rather than
 # crates.io.
 # NOTE: this patch, unlike the patches for `maitake` and `mycelium-util`, (which
@@ -165,23 +172,23 @@ rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 # since it's already in our dependency tree as a transitive dep of `maitake` ---
 # having both a Git dep and a crates.io dep seems unfortunate.
 [patch.crates-io.mycelium-bitfield]
-git = "https://github.com/hawkw/mycelium.git"
+git = "https://github.com/hawkw/mycelium"
+rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
+
+[patch.crates-io.mycelium-util]
+git = "https://github.com/hawkw/mycelium"
 rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 
 [patch.crates-io.cordyceps]
-git = "https://github.com/hawkw/mycelium.git"
+git = "https://github.com/hawkw/mycelium"
 rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 
 [patch.crates-io.hal-core]
-git = "https://github.com/hawkw/mycelium.git"
+git = "https://github.com/hawkw/mycelium"
 rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 
 [patch.crates-io.hal-x86_64]
-git = "https://github.com/hawkw/mycelium.git"
-rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
-
-[patch.crates-io.mycelium-alloc]
-git = "https://github.com/hawkw/mycelium.git"
+git = "https://github.com/hawkw/mycelium"
 rev = "13d0722429ef201f38e4ea47ea22d88f3f72c10e"
 
 [patch.crates-io.bbq10kbd]

--- a/platforms/allwinner-d1/board-configs/lichee-rv.toml
+++ b/platforms/allwinner-d1/board-configs/lichee-rv.toml
@@ -1,6 +1,5 @@
 [kernel]
 max_drivers = 16
-timer_granularity = { secs = 0, nanos = 333 }
 
 [services.spawnulator]
 enabled = true

--- a/platforms/allwinner-d1/d1-core/src/timer.rs
+++ b/platforms/allwinner-d1/d1-core/src/timer.rs
@@ -16,10 +16,12 @@ impl Timer0 {
 
         let _ = self.get_and_clear_interrupt();
 
+        // Start the timer counting down from 0xffff_ffff_ffff_ffff.
+
         // TODO(eliza): if it's zero, handle that lol --- when the IRQ fires
         // we need to increment some higher half counter and then reset the
         // timer to u32::MAX?
-        self.start_counter(0xFFFF_FFFF);
+        self.start_counter(u32::MAX);
 
         Clock::new(core::time::Duration::from_nanos(333), || {
             let timer0 = unsafe {
@@ -27,7 +29,10 @@ impl Timer0 {
                 // concurrently mutating the timer.
                 Self::steal()
             };
-            0xFFFF_FFFF - timer0.current_value() as u64
+            // Since timer 0 is counting *down*, we have to subtract its current
+            // value from the intial value to get an increasing timestamp for
+            // Maitake.
+            (u32::MAX - timer0.current_value()) as u64
         })
         .named("CLOCK_D1_TIMER0")
     }

--- a/platforms/allwinner-d1/d1-core/src/timer.rs
+++ b/platforms/allwinner-d1/d1-core/src/timer.rs
@@ -27,7 +27,7 @@ impl Timer0 {
                 // concurrently mutating the timer.
                 Self::steal()
             };
-            timer0.current_value() as u64
+            0xFFFF_FFFF - timer0.current_value() as u64
         })
         .named("CLOCK_D1_TIMER0")
     }

--- a/platforms/allwinner-d1/d1-core/src/timer.rs
+++ b/platforms/allwinner-d1/d1-core/src/timer.rs
@@ -1,3 +1,5 @@
+use crate::plic::{Plic, Priority};
+use core::sync::atomic::{AtomicU32, Ordering};
 pub use d1_pac::timer::tmr_ctrl::{
     TMR_CLK_PRES_A as TimerPrescaler, TMR_CLK_SRC_A as TimerSource, TMR_MODE_A as TimerMode,
 };
@@ -9,19 +11,27 @@ pub struct Timers {
     pub timer1: Timer1,
 }
 
+static TIMER0_ROLLOVERS: AtomicU32 = AtomicU32::new(0);
+
 impl Timer0 {
-    pub fn into_maitake_clock(mut self) -> Clock {
+    const INITIAL_VALUE: u32 = u32::MAX;
+
+    pub fn into_maitake_clock(mut self, plic: &Plic) -> Clock {
+        use d1_pac::Interrupt;
         self.set_prescaler(TimerPrescaler::P8); // 24M / 8:  3.00M ticks/s
         self.set_mode(TimerMode::PERIODIC);
 
+        // Clear any previous interrupt flag.
         let _ = self.get_and_clear_interrupt();
 
-        // Start the timer counting down from 0xffff_ffff_ffff_ffff.
+        // Register the interrupt handler for when the timer rolls over.
+        unsafe {
+            plic.register(Interrupt::TIMER0, Self::maitake_timer_interrupt);
+            plic.activate(Interrupt::TIMER0, Priority::P1).unwrap();
+        }
 
-        // TODO(eliza): if it's zero, handle that lol --- when the IRQ fires
-        // we need to increment some higher half counter and then reset the
-        // timer to u32::MAX?
-        self.start_counter(u32::MAX);
+        // Start the timer counting down from u32::MAX;.
+        self.reset();
 
         Clock::new(core::time::Duration::from_nanos(333), || {
             let timer0 = unsafe {
@@ -30,11 +40,46 @@ impl Timer0 {
                 Self::steal()
             };
             // Since timer 0 is counting *down*, we have to subtract its current
-            // value from the intial value to get an increasing timestamp for
-            // Maitake.
-            (u32::MAX - timer0.current_value()) as u64
+            // value from the intial value to get an i[ncreasing timestamp for
+            // Maitake. As timer 0 is a 32-bit timer, this forms the lower half
+            // of our 64-bit timestamp.
+            let lo = (Self::INITIAL_VALUE - timer0.current_value()) as u64;
+            // The higher half of the 64-bit timestamp is the current value of
+            // the 32-bit timer rollover counter --- i.e. the number of times
+            // that timer 0 has counted down to 0.
+            let hi = TIMER0_ROLLOVERS.load(Ordering::Relaxed) as u64;
+            // Combine the two halves to form the full 64-bit timestamp.
+            (hi << 32) | lo
         })
         .named("CLOCK_D1_TIMER0")
+    }
+
+    fn reset(&mut self) {
+        self.start_counter(Self::INITIAL_VALUE);
+        // N.B. that we probably don't *have* to reset the IRQ_EN bit every time
+        // it fires, but  let's make sure it's enabled just in case...
+        self.set_interrupt_en(true);
+    }
+
+    /// Handle a TIMER0 interrupt when TIMER0 is used as the maitake timer.
+    fn maitake_timer_interrupt() {
+        let mut timer0 = unsafe {
+            // Safety: we need to do this to be an ISR lol
+            Self::steal()
+        };
+
+        // Clear the interrupt flag
+        let _ = timer0.get_and_clear_interrupt();
+
+        // Increment the rollover counter
+        TIMER0_ROLLOVERS.fetch_add(1, Ordering::Relaxed);
+
+        // Wait for the interrupt to clear to avoid repeat interrupts
+        let timers = unsafe { &*TIMER::PTR };
+        while timers.tmr_irq_sta.read().tmr0_irq_pend().bit_is_set() {}
+
+        // RESET THE CLOCK!
+        timer0.reset();
     }
 
     unsafe fn steal() -> Self {

--- a/platforms/allwinner-d1/src/lib.rs
+++ b/platforms/allwinner-d1/src/lib.rs
@@ -192,7 +192,7 @@ impl D1 {
         kernel_settings: KernelSettings,
         service_settings: KernelServiceSettings,
     ) -> Self {
-        let timer0_clock = timers.timer0.into_maitake_clock();
+        let timer0_clock = timers.timer0.into_maitake_clock(&plic);
         let k = unsafe {
             Box::into_raw(
                 Kernel::new(kernel_settings, timer0_clock).expect("cannot initialize kernel"),

--- a/platforms/allwinner-d1/src/lib.rs
+++ b/platforms/allwinner-d1/src/lib.rs
@@ -163,7 +163,7 @@ pub fn kernel_entry(config: mnemos_config::MnemosConfig<PlatformConfig>) -> ! {
 
 pub struct D1 {
     pub kernel: &'static Kernel,
-    pub timers: Timers,
+    pub timer1: mnemos_d1_core::Timer1,
     pub plic: Plic,
     pub dmac: Dmac,
     _uart: Uart,
@@ -192,8 +192,9 @@ impl D1 {
         kernel_settings: KernelSettings,
         service_settings: KernelServiceSettings,
     ) -> Self {
+        let timer0_clock = timer0_maitake_clock(timers.timer0);
         let k = unsafe {
-            Box::into_raw(Kernel::new(kernel_settings).expect("cannot initialize kernel"))
+            Box::into_raw(Kernel::new(kernel_settings, clock).expect("cannot initialize kernel"))
                 .as_ref()
                 .unwrap()
         };
@@ -240,7 +241,7 @@ impl D1 {
             kernel: k,
             _uart: uart,
             _spim: spim,
-            timers,
+            timer1: timers.timer1,
             plic,
             dmac,
             i2c0_int,
@@ -293,7 +294,7 @@ impl D1 {
     pub fn run(self) -> ! {
         let Self {
             kernel: k,
-            timers,
+            timer1,
             plic,
             dmac: _,
             _uart,
@@ -308,19 +309,9 @@ impl D1 {
         //
         // In the future, we probably want to rework this to use the RTC timer for
         // both purposes, as this will likely play better with sleep power usage.
-        let Timers {
-            mut timer0,
-            mut timer1,
-        } = timers;
 
-        // NOTE: if you change the timer frequency, make sure you update
-        // initialize_kernel() below to correct the kernel timer wheel
-        // granularity setting!
-        timer0.set_prescaler(TimerPrescaler::P8); // 24M / 8:  3.00M ticks/s
         timer1.set_prescaler(TimerPrescaler::P8);
-        timer0.set_mode(TimerMode::PERIODIC);
         timer1.set_mode(TimerMode::SINGLE_COUNTING);
-        let _ = timer0.get_and_clear_interrupt();
         let _ = timer1.get_and_clear_interrupt();
 
         unsafe {
@@ -344,16 +335,13 @@ impl D1 {
             }
         }
 
-        timer0.start_counter(0xFFFF_FFFF);
-
         loop {
             // Tick the scheduler
             let start = timer0.current_value();
             let tick = k.tick();
 
             // Timer is downcounting
-            let elapsed = start.wrapping_sub(timer0.current_value());
-            let turn = k.timer().force_advance_ticks(elapsed.into());
+            let turn = k.timer().turn();
 
             // If there is nothing else scheduled, and we didn't just wake something up,
             // sleep for some amount of time
@@ -385,7 +373,7 @@ impl D1 {
 
                 // Account for time slept
                 let elapsed = wfi_start.wrapping_sub(timer0.current_value());
-                let _turn = k.timer().force_advance_ticks(elapsed.into());
+                let _turn = k.timer().turn();
             }
         }
     }

--- a/platforms/melpomene/Cargo.toml
+++ b/platforms/melpomene/Cargo.toml
@@ -97,7 +97,8 @@ version = "0.4"
 # which is needed to support the Tokio Console while running in the simulator,
 # but is not needed by actual builds of mnemOS running on real hardware.
 [dependencies.maitake]
-version = "0.1.0"
+workspace = true
+default-features = true
 features = ["tracing-01"]
 
 [dependencies.forth3]

--- a/platforms/pomelo/Cargo.toml
+++ b/platforms/pomelo/Cargo.toml
@@ -56,7 +56,8 @@ features = ["use-std"]
 # which is needed to support the Tokio Console while running in the simulator,
 # but is not needed by actual builds of mnemOS running on real hardware.
 [dependencies.maitake]
-version = "0.1.0"
+workspace = true
+default-features = true
 features = ["tracing-01"]
 
 [dependencies.forth3]

--- a/platforms/pomelo/src/main.rs
+++ b/platforms/pomelo/src/main.rs
@@ -71,7 +71,7 @@ async fn kernel_entry() {
         maitake::time::Clock::new(
             // TODO(eliza): timer granularity chosen totally arbitrarily
             // Anatol: the WASM app runs in a callback loop from request_animation_frame, whose
-            // max speed is capped at the display refresh rate -
+            // max speed is typically (:rolleyes:) capped at the display refresh rate -
             // I guess 1ms granularity should therefore be plenty?
             Duration::from_micros(1),
             || {

--- a/platforms/pomelo/src/main.rs
+++ b/platforms/pomelo/src/main.rs
@@ -180,9 +180,9 @@ async fn kernel_entry() {
             cmd.dispatch(kernel);
         }
     });
-    unsafe {
-        init_term(&eternal_cb);
-    }
+
+    init_term(&eternal_cb);
+
     eternal_cb.forget();
 
     let timer = kernel.timer();

--- a/platforms/pomelo/src/main.rs
+++ b/platforms/pomelo/src/main.rs
@@ -70,6 +70,9 @@ async fn kernel_entry() {
     let clock = {
         maitake::time::Clock::new(
             // TODO(eliza): timer granularity chosen totally arbitrarily
+            // Anatol: the WASM app runs in a callback loop from request_animation_frame, whose
+            // max speed is capped at the display refresh rate -
+            // I guess 1ms granularity should therefore be plenty?
             Duration::from_micros(1),
             || {
                 chrono::Utc::now()

--- a/platforms/pomelo/src/main.rs
+++ b/platforms/pomelo/src/main.rs
@@ -71,12 +71,9 @@ async fn kernel_entry() {
         maitake::time::Clock::new(
             // TODO(eliza): timer granularity chosen totally arbitrarily
             Duration::from_micros(1),
-            || {
-                // TODO(anatol) please fix this for me thanks :)
-                unimplemented!("FIGURE OUT HOW TO GET A NORMAL TIMESTAMP OUT OF WASM LOL")
-            },
+            || chrono::Local::now().timestamp_micros().try_into().expect("could not convert i64 timestamp to u64"),
         )
-        .named("CLOCK_THIS_ONE_JUST_FUCKING_PANICS_LOL")
+        .named("chrono-wasm")
     };
     let kernel = unsafe {
         mnemos_alloc::containers::Box::into_raw(Kernel::new(settings, clock).unwrap())

--- a/platforms/x86_64/core/Cargo.toml
+++ b/platforms/x86_64/core/Cargo.toml
@@ -40,18 +40,16 @@ features = ["attributes"]
 default-features = false
 
 [dependencies.hal-core]
-version = "0.1.0"
-default-features = false
+workspace = true
 
 [dependencies.hal-x86_64]
 version = "0.1.0"
 
 [dependencies.mycelium-util]
-version = "0.1.0"
+workspace = true
 
 [dependencies.mycelium-alloc]
-version = "0.1.0"
-features = ["buddy", "bump"]
+workspace = true
 
 [dependencies.futures]
 version = "0.3.21"

--- a/platforms/x86_64/core/src/bin/bootloader/bootinfo.rs
+++ b/platforms/x86_64/core/src/bin/bootloader/bootinfo.rs
@@ -69,12 +69,7 @@ impl BootInfo for BootloaderApiBootInfo {
 
 impl BootloaderApiBootInfo {
     fn vm_offset(&self) -> VAddr {
-        VAddr::from_u64(
-            self.inner
-                .physical_memory_offset
-                .into_option()
-                .expect("haha wtf"),
-        )
+        VAddr::from_u64(self.inner.physical_memory_offset.into_option().unwrap_or(0))
     }
 
     pub(super) fn from_bootloader(inner: &'static mut info::BootInfo) -> Self {

--- a/source/alloc/Cargo.toml
+++ b/source/alloc/Cargo.toml
@@ -18,11 +18,11 @@ categories = [
 ]
 
 [dependencies.cordyceps]
-version = "0.3"
+workspace = true
 default-features = false
 
 [dependencies.maitake]
-version = "0.1"
+workspace = true
 default-features = false
 
 [dependencies.heapless]

--- a/source/kernel/Cargo.toml
+++ b/source/kernel/Cargo.toml
@@ -70,8 +70,7 @@ path = "../trace-proto"
 optional = true
 
 [dependencies.maitake]
-version = "0.1.0"
-default-features = false
+workspace = true
 features = ["alloc"]
 
 [dependencies.mycelium-util]

--- a/source/mstd/Cargo.toml
+++ b/source/mstd/Cargo.toml
@@ -23,12 +23,12 @@ version = "0.3"
 default-features = false
 
 [dependencies.cordyceps]
-version = "0.3"
+workspace = true
 default-features = false
 
 [dependencies.maitake]
-version = "0.1.0"
 default-features = false
+workspace = true
 
 [dependencies.abi]
 package = "mnemos-abi"
@@ -49,4 +49,3 @@ default-features = false
 
 [features]
 panic-handler = []
-

--- a/source/spitebuf/Cargo.toml
+++ b/source/spitebuf/Cargo.toml
@@ -19,5 +19,5 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 
 [dependencies.maitake]
-version = "0.1.0"
+workspace = true
 default-features = false

--- a/tools/x86_64-bootimager/src/qemu.rs
+++ b/tools/x86_64-bootimager/src/qemu.rs
@@ -74,6 +74,8 @@ impl Options {
             "qemu64".to_string(),
             "-smp".to_string(),
             "cores=4".to_string(),
+            // "-d guest_errors,cpu_reset".to_string(),
+            // "-no-reboot".to_string(),
         ]
     }
 
@@ -156,7 +158,7 @@ impl Options {
         let qemu_tag = tag.named("QEMU");
         for line in qemu_stderr.lines() {
             match line {
-                Ok(line) => eprintln!("{qemu_tag} {line:?}"),
+                Ok(line) => eprintln!("{qemu_tag} {line}"),
                 Err(error) => {
                     tracing::warn!(%error, "failed to read from QEMU stderr");
                     break;


### PR DESCRIPTION
This updates our dependencies on Mycelium crates to
hawkw/mycelium@ba56bb4d02f46fb59754b7b88bddc2e8ca99c1f5.

This picks up the new `maitake` timer API, as well as the upstream
change hawkw/mycelium#487 to allow raw access to the IDT in the Mycelium
x86_64 HAL, which we need to do an async UART driver (see #337).

While updating everything to use the new timer API, I also made some
tweaks to our existing timer code, including implementing 32-bit timer
rollover for the D1's TIMER0 (our current timestamp source on that
platform). This was an ancient TODO item since basically forever.

Fixes #337