### PR TITLE
tools: fix `crowtty` cargo alias/just recipe

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-crowtty = "run --bin crowtty --release --"
+crowtty = "run --package crowtty --bin crowtty --release --"
 melpomene = "run --bin melpomene --release --"
 melpo = "melpomene"
 forth3 = "run --bin f3repl --release --"
@@ -23,7 +23,7 @@ runner = "cargo run --package mnemos-x86_64-bootimager -- --kernel-bin"
 # `rust-osdev/bootloader`, where a target crate depends on the kernel binary
 # artifact from the kernel core crate and links it with the bootloader binary in
 # a `build.rs` script.
-# 
+#
 # Artifact dependencies are also used by `manganese` to depend on binary crates
 # as normal Cargo.toml dependencies.
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ default-members = [
     # tools
     # note that this skips `manganese` by default, so that we don't build its
     # dependency features when running `cargo check --all-features` and similar.
+    #
+    # also, crowtty is excluded by default, as it depends on `libudev` on Linux,
+    # and we would like to be able to build documentation without having to
+    # install libudev on CI.
     "tools/libcrowtty",
     "tools/dumbloader",
     "tools/f3repl",

--- a/justfile
+++ b/justfile
@@ -181,7 +181,7 @@ _x86-bootimager cmd *args='':
 
 # run crowtty (a host serial multiplexer, log viewer, and pseudo-keyboard)
 crowtty *FLAGS:
-    {{ _cargo }} run --profile {{ profile }} --bin crowtty -- {{ FLAGS }}
+    {{ _cargo }} run --package crowtty --profile {{ profile }} --bin crowtty -- {{ FLAGS }}
 
 # run the Melpomene simulator
 melpomene *FLAGS:


### PR DESCRIPTION
PR #342 broke the `cargo crowtty` alias and `just crowtty` Just recipe. This is because we moved the `crowtty` binary out of the workspace's `default-packages`, so that CI builds don't require `libuv`. Because `crowtty` is no longer in `default-package`, running it using `cargo run` now  requires passing --pacakge crowtty` as well as `--bin crowtty`, which the aliases don't do.

This commit fixes that by adding `--package crowtty` to the `cargo crowtty` alias and the Just recipe. I also documented why crowtty isn't in `default-packages` in the Cargo.toml.