### PR TITLE
tools: enable fancy miette errors in `crowtty`

### DIFF
--- a/tools/crowtty/Cargo.toml
+++ b/tools/crowtty/Cargo.toml
@@ -46,3 +46,4 @@ features = ["std"]
 
 [dependencies.miette]
 workspace = true
+features = ["fancy"]


### PR DESCRIPTION
At some point (probably when `crowtty` was separated out into its own binary in #342), the `miette` dependency's `"fancy"` feature flag, which makes the debug print format for errors actually look nice and include cause chains, was eaten. This is a bummer, because having cause chains is important in order to understand the error message.

This commit re-enables the `"fancy"` feature flag for `miette` in `crowtty`'s `Cargo.toml'.

Prior to this change, errors looked like this:

```console
eliza@theseus ~/Code/mnemos $ cargo run -p crowtty -- serial /dev/ttyUSB1 --verbose --trace trace
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.39s
     Running `target/debug/crowtty serial /dev/ttyUSB1 --verbose --trace trace`
Error: Diagnostic { message: "failed to connect to /dev/ttyUSB1 (@ 115200)" }
NOTE: If you're looking for the fancy error reports, install miette with the `fancy` feature, or write your own and hook it up with miette::set_hook().

```

...which I think we can all agree is not that useful.

Now, the error looks like this:

```console
eliza@theseus ~/Code/mnemos $ cargo run -p crowtty -- serial /dev/ttyUSB1 --verbose --trace trace
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.22s
     Running `target/debug/crowtty serial /dev/ttyUSB1 --verbose --trace trace`
Error:   × failed to connect to /dev/ttyUSB1 (@ 115200)
  ╰─▶ Device or resource busy

```

This actually explains what went wrong, which seems good to me.