### PR TITLE
fix(d1): make `Plic::mask` actually do that

### DIFF
--- a/platforms/allwinner-d1/d1-core/src/plic.rs
+++ b/platforms/allwinner-d1/d1-core/src/plic.rs
@@ -61,7 +61,7 @@ impl Plic {
     /// Disable an interrupt
     pub fn mask(&self, interrupt: Interrupt) {
         let (mie, irq_en) = self.index_mie(interrupt);
-        mie.modify(|r, w| unsafe { w.bits(r.bits() | irq_en) });
+        mie.modify(|r, w| unsafe { w.bits(r.bits() & !irq_en) });
     }
 
     /// Globally set priority for one interrupt


### PR DESCRIPTION
PR #312 (commit df41decc1bfc2a7069007c333a85b08e89173525) inadvertently broke the `Plic` method to mask an interrupt by copy-pasting the code from `Plic::unmask`.

Previously, `Plic::unmask` would write `MIE[offset]| irq_en` to `MIE[offset]`, setting the `IRQ_EN` bit for that interrupt; while `Plic::mask` would write `MIE[offset] & !irq_en` to `MIE[offset]`, unsetting the `IRQ_EN` bit. But now they both *set* the `IRQ_EN` bit, so masking  an interrupt actually unmasks it. Whoopsie. This seems to have occurred because I'm a LOSER FUCKING IDIOT.

This commit puts it back the way it was supposed to be. Sorry.

Fixes #347